### PR TITLE
Add encrypted ext4 and connectivity validation scripts to baseport suite

### DIFF
--- a/Runner/suites/Connectivity/Bluetooth/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/run.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Import test suite definitions
+. $(pwd)/init_env
+TESTNAME="Bluetooth"
+
+#import test functions library
+. $TOOLS/functestlib.sh
+test_path=$(find_test_case_by_name "$TESTNAME")
+log_info "--------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+
+log_info "Starting Bluetooth Test..."
+
+# Check if bluetoothctl is available
+if ! command -v bluetoothctl >/dev/null 2>&1; then
+    log_fail "bluetoothctl not found. Please install bluez."
+    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    exit 1
+fi
+
+# Check if bluetoothd is running
+if ! pgrep bluetoothd >/dev/null; then
+    log_fail "bluetoothd is not running. Please start the Bluetooth daemon."
+    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    exit 1
+fi
+
+# Power off Bluetooth controller
+log_info "Powering off Bluetooth controller..."
+bluetoothctl power off
+
+# Power on Bluetooth controller
+log_info "Powering on Bluetooth controller..."
+output=$(bluetoothctl power on)
+
+# Check for success message
+if echo "$output" | grep -q "Changing power on succeeded"; then
+    log_pass "Bluetooth controller powered on successfully."
+    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+else
+    log_fail "Failed to power on Bluetooth controller."
+    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+fi
+
+log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+

--- a/Runner/suites/Connectivity/Ethernet/run.sh
+++ b/Runner/suites/Connectivity/Ethernet/run.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Import test suite definitions
+source $(pwd)/init_env
+TESTNAME="Ethernet"
+
+#import test functions library
+source $TOOLS/functestlib.sh
+test_path=$(find_test_case_by_name "$TESTNAME")
+log_info "--------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+
+log_info "Starting Ethernet test..."
+
+IFACE="eth0"
+
+# Check interface existence
+if ! ip link show "$IFACE" >/dev/null 2>&1; then
+    log_fail "Ethernet interface $IFACE not found"
+    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    exit 1
+fi
+
+# Check if interface is up, try to bring it up if not
+if ! ip link show "$IFACE" | grep -q "state UP"; then
+    log_warn "Interface $IFACE is down, attempting to bring it up..."
+    ip link set "$IFACE" up
+    sleep 3
+    if ! ip link show "$IFACE" | grep -q "state UP"; then
+        log_fail "Failed to bring up $IFACE"
+        echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+        exit 1
+    fi
+fi
+
+# Ping test
+log_info "Running ping test to 8.8.8.8..."
+if ping -I "$IFACE" -c 4 -W 2 8.8.8.8 >/dev/null 2>&1; then
+    log_pass "Ethernet connectivity verified"
+    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+else
+    log_fail "Ethernet ping failed"
+    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    exit 1
+fi
+
+log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+

--- a/Runner/suites/Connectivity/WIFI/run.sh
+++ b/Runner/suites/Connectivity/WIFI/run.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Import test suite definitions
+. "$(pwd)/init_env"
+TESTNAME="WIFI"
+
+# Import test functions library
+. "$TOOLS/functestlib.sh"
+test_path=$(find_test_case_by_name "$TESTNAME")
+
+log_info "--------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "Starting WiFi Test..."
+
+WLAN="wlan0"
+SSID_CONF="$(dirname "$0")/wifi_test.conf" # should contain: SSID and PASSWORD
+
+if [ ! -f "$SSID_CONF" ]; then
+    log_fail "WiFi config $SSID_CONF not found"
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    exit 1
+fi
+
+. "$SSID_CONF"
+
+log_info "Loaded SSID=$SSID, PASSWORD=$PASSWORD"
+
+if ! command -v nmcli >/dev/null 2>&1; then
+    log_fail "nmcli not found"
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    exit 1
+fi
+
+# Restart NetworkManager if needed
+if ! systemctl is-active NetworkManager >/dev/null 2>&1; then
+    log_warn "NetworkManager not active. Trying to start it..."
+    systemctl start NetworkManager
+    sleep 3
+    if ! systemctl is-active NetworkManager >/dev/null 2>&1; then
+        log_fail "Failed to start NetworkManager"
+        echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+        exit 1
+    fi
+fi
+
+# Connect to WiFi
+log_info "Attempting to connect to SSID: $SSID"
+nmcli_output=$(nmcli dev wifi connect "$SSID" password "$PASSWORD" ifname "$WLAN" 2>&1)
+log_info "nmcli output: $nmcli_output"
+sleep 5
+
+if echo "$nmcli_output" | grep -qi "successfully activated"; then
+    log_pass "Connected to $SSID"
+    echo "$TESTNAME PASS" > "$test_path/$TESTNAME.res"
+else
+    log_fail "Failed to connect to $SSID"
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    exit 1
+fi
+
+
+log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+

--- a/Runner/suites/Kernel/FunctionalArea/baseport/shmbridge/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/shmbridge/run.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# Import test suite definitions
+source "$(pwd)/init_env"
+TESTNAME="shmbridge"
+
+# Import test functions library
+source "$TOOLS/functestlib.sh"
+test_path=$(find_test_case_by_name "$TESTNAME")
+
+log_info "--------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+
+MOUNT_POINT="/mnt/overlay"
+PARTITION="/dev/disk/by-partlabel/xbl_ramdump_a"
+KEY_FILE="$MOUNT_POINT/stdkey"
+TEST_DIR="$MOUNT_POINT/test"
+TEST_FILE="$TEST_DIR/txt"
+
+log_info "Creating mount point at $MOUNT_POINT"
+mkdir -p "$MOUNT_POINT"
+
+log_info "Checking if partition exists"
+if [ ! -e "$PARTITION" ]; then
+    log_fail "Partition $PARTITION not found"
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    exit 1
+fi
+
+log_info "Formatting partition with ext4 and encryption options"
+if ! mount | grep -q "$PARTITION"; then
+    mkfs.ext4 -F -O encrypt,stable_inodes "$PARTITION"
+else
+    log_warn "$PARTITION is already mounted; skipping format"
+fi
+
+log_info "Mounting partition to $MOUNT_POINT with inlinecrypt"
+mount "$PARTITION" -o inlinecrypt "$MOUNT_POINT"
+
+log_info "Generating 64-byte encryption key"
+head -c 64 /dev/urandom > "$KEY_FILE"
+
+log_info "Checking if dependency binary is available"
+check_dependencies fscryptctl
+
+log_info "Adding encryption key using fscryptctl"
+identifier=$(fscryptctl add_key "$MOUNT_POINT" < "$KEY_FILE")
+
+mkdir -p "$TEST_DIR"
+
+log_info "Setting encryption policy on $TEST_DIR"
+fscryptctl set_policy --iv-ino-lblk-64 "$identifier" "$TEST_DIR"
+
+log_info "Verifying encryption policy"
+fscryptctl get_policy "$TEST_DIR"
+
+log_info "Writing test file"
+echo "hello" > "$TEST_FILE"
+sync
+echo 3 > /proc/sys/vm/drop_caches
+
+log_info "Reading test file"
+if cat "$TEST_FILE" | grep -q "hello"; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$test_path/$TESTNAME.res"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    exit 1
+fi
+
+log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+


### PR DESCRIPTION
This pull request introduces two key additions to the baseport functional test suite:

**1. Encrypted ext4 Mount Test (shmbridge)**  
   - Validates encrypted ext4 filesystem setup using `fscryptctl`
   - Includes partition formatting, key generation, encryption policy application, and file I/O verification  
   - Location: `Runner/suites/Kernel/FunctionalArea/baseport/shmbridge/run.sh`

**2. Connectivity Test Scripts**
   - Adds standalone test scripts for Bluetooth, Ethernet, and WiFi validation  
   - Each script performs dependency checks, interface status verification, and connectivity tests  
   - Includes clear logging and result reporting for integration into automated test frameworks

These additions enhance the kernel-level validation coverage for secure storage and basic connectivity.

Signed-off-by: anilyada <anilyada@qti.qualcomm.com>