### PR TITLE
Fix shellcheck warnings and errors

### DIFF
--- a/Runner/init_env
+++ b/Runner/init_env
@@ -1,7 +1,11 @@
+#!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # Source this file to setup the test suite environment
-export BASEDIR=$(pwd)
-export TOOLS=$(pwd)/utils
-export SUITES=$(pwd)/suites
+BASEDIR=$(pwd)
+export BASEDIR
+TOOLS=$(pwd)/utils
+export TOOLS
+SUITES=$(pwd)/suites
+export SUITES

--- a/Runner/run-test.sh
+++ b/Runner/run-test.sh
@@ -1,12 +1,13 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 
 
 # Find test case path by name
@@ -16,8 +17,8 @@ find_test_case_by_name() {
     # Get the directory name
     dir_name_in_dir=${1##*/}
 
-    # Check if the directory name matches the user input (ignoring case)
-    if [ "${dir_name_in_dir,,}" = "$test_name" ]; then
+    # Check if the directory name matches the user input
+    if [ "${dir_name_in_dir}" = "$test_name" ]; then
       # Get the absolute path of the directory
       abs_path=$(readlink -f "$1")
       echo "$abs_path"  
@@ -53,7 +54,6 @@ execute_test_case() {
 # Function to run a specific test case by name
 run_specific_test_by_name() {
     test_name="$1"
-    test_name=${test_name,,}
     test_path=$(find_test_case_by_name ".")
     if [ -z "$test_path" ]; then
         log "Test case with name $test_name not found."

--- a/Runner/suites/Kernel/FunctionalArea/baseport/BWMON/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/BWMON/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="BWMON"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "--------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
@@ -41,6 +42,7 @@ log_info "Comparing votes"
 
 
 incremented=true
+# shellcheck disable=SC2046
 for i in $(seq 2 $(echo "$initial_votes" | wc -l)); do
   initial_vote=$(echo "$initial_votes" | sed -n "${i}p")
   final_vote=$(echo "$final_votes" | sed -n "${i}p")

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Buses/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Buses/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="Buses"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/CPUFreq_Validation/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/CPUFreq_Validation/run.sh
@@ -1,9 +1,9 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
-
-. "$(pwd)/init_env"
+. "${PWD}/init_env"
 TESTNAME="CPUFreq_Validation"
 . "$TOOLS/functestlib.sh"
 

--- a/Runner/suites/Kernel/FunctionalArea/baseport/GIC/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/GIC/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="GIC"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/IPA/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/IPA/run.sh
@@ -1,9 +1,10 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="IPA"
 . "$TOOLS/functestlib.sh"
 test_path=$(find_test_case_by_name "$TESTNAME")

--- a/Runner/suites/Kernel/FunctionalArea/baseport/IPCC/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/IPCC/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="IPCC"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "--------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Interrupts/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Interrupts/run.sh
@@ -1,14 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="Interrupts"
 
 #import test functions library
-. $TOOLS/functestlib.sh
-test_path=$(find_test_case_by_name "$TESTNAME")
+. "${TOOLS}"/functestlib.sh
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
 

--- a/Runner/suites/Kernel/FunctionalArea/baseport/MEMLAT/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/MEMLAT/run.sh
@@ -1,12 +1,13 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="MEMLAT"
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 test_bin_path=$(find_test_case_bin_by_name "lat_mem_rd")
 log_info "-----------------------------------------------------------------------------------------"
@@ -37,6 +38,7 @@ wait
 log_info "Comparing votes..."
 
 incremented=true
+# shellcheck disable=SC2046
 for i in $(seq 1 $(echo "$initial_votes" | wc -l)); do
   initial_vote=$(echo "$initial_votes" | sed -n "${i}p")
   final_vote=$(echo "$final_votes" | sed -n "${i}p")

--- a/Runner/suites/Kernel/FunctionalArea/baseport/RMNET/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/RMNET/run.sh
@@ -1,9 +1,10 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="RMNET"
 . "$TOOLS/functestlib.sh"
 test_path=$(find_test_case_by_name "$TESTNAME")

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Reboot_health_check/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Reboot_health_check/run.sh
@@ -1,17 +1,15 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
-TESTNAME="Reboot_health_check"
+. "{PWD}"/init_env
 #import test functions library
-. $TOOLS/functestlib.sh
-test_path=$(find_test_case_by_name "$TESTNAME")
+. "${TOOLS}"/functestlib.sh
 
 # Directory for health check files
 HEALTH_DIR="/var/reboot_health"
-LOG_FILE="$HEALTH_DIR/reboot_test.log"
 RETRY_FILE="$HEALTH_DIR/reboot_retry_count"
 MAX_RETRIES=3
 

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Timer/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Timer/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="Timer"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
@@ -21,7 +22,7 @@ BINARY_PATH="/var/common/bins/timers/posix_timers"
 OUTPUT=$($BINARY_PATH)
 
 # Check if "pass:7" is in the output
-if [[ $OUTPUT == *"pass:7"* ]]; then
+if echo "${OUTPUT}" | grep "pass:7"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
 else

--- a/Runner/suites/Kernel/FunctionalArea/baseport/adsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/adsp_remoteproc/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="adsp_remoteproc"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "--------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/cdsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/cdsp_remoteproc/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="cdsp_remoteproc"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/hotplug/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/hotplug/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="hotplug"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "--------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/iommu/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/iommu/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="iommu"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "--------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/irq/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/irq/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="irq"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/kaslr/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/kaslr/run.sh
@@ -1,12 +1,13 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="kaslr"
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 
 log_info "--------------------------------------------------------------------------"
@@ -19,7 +20,7 @@ value=$(echo $output | awk '{print $1}')
 
 
 
-if [ $value == "0000000000000000" ]; then
+if [ $value = "0000000000000000" ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
 else

--- a/Runner/suites/Kernel/FunctionalArea/baseport/pinctrl/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/pinctrl/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="pinctrl"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/qcrypto/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/qcrypto/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="qcrypto"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
@@ -16,11 +17,11 @@ log_info "Checking if dependency binary is available"
 check_dependencies kcapi-convience
 
 kcapi-convience
+KCAPI_RET=$?
 
-echo $?
+echo "${KCAPI_RET}"
 
-
-if [ $? -eq 0 ]; then
+if [ ${KCAPI_RET} -eq 0 ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
 else

--- a/Runner/suites/Kernel/FunctionalArea/baseport/remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/remoteproc/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="remoteproc"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="rngtest"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/smmu/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/smmu/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="smmu"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/storage/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/storage/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="storage"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/watchdog/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/watchdog/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="watchdog"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "--------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 TESTNAME="wpss_remoteproc"
 
 #import test functions library
-. $TOOLS/functestlib.sh
+. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Multimedia/DSP_AudioPD/run.sh
+++ b/Runner/suites/Multimedia/DSP_AudioPD/run.sh
@@ -13,7 +13,7 @@ log_info "Checking if dependency binary is available"
 check_dependencies adsprpcd
 
 adsprpcd &
-PID = $!
+PID=$!
 
 if [ -z "$PID" ]; then
   echo "Failed to start the binary"
@@ -23,10 +23,10 @@ else
 fi
 
 check_stack_trace() {
-	local pid = $1
-	if cat /proc/$pid/stack 2>/dev/null | grep -q "do_sys_poll"
+	local pid=$1
+	if cat /proc/$pid/stack 2>/dev/null | grep -q "do_sys_poll"; then
 		return 0
-	else 
+	else
 		return 1
 	fi
 }

--- a/Runner/suites/Multimedia/Graphics/run.sh
+++ b/Runner/suites/Multimedia/Graphics/run.sh
@@ -18,7 +18,7 @@ dmesg -c
 cat /dev/dri/card0 &
 OUTPUT=$(dmesg)
 
-if [ $OUTPUT == *"Loaded GMU firmware"* ]; then
+if echo "${OUTPUT}" | grep "Loaded GMU firmware"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME : Test Passed" > $test_path/$TESTNAME.res
 else

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -1,10 +1,12 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # Import test suite definitions
-. $(pwd)/init_env
+. "${PWD}"/init_env
 #import platform
-. $TOOLS/platform.sh
+. "${TOOLS}"/platform.sh
 
 __RUNNER_SUITES_DIR="/var/Runner/suites"
 __RUNNER_UTILS_BIN_DIR="/var/common"
@@ -37,7 +39,7 @@ find_test_case_script_by_name() {
 check_dependencies() {
     local missing=0
     for cmd in "$@"; do
-        if ! command -v "$cmd" &>/dev/null; then
+        if ! command -v "$cmd" > /dev/null 2>&1; then
             log_error "ERROR: Required command '$cmd' not found in PATH."
             missing=1
         fi


### PR DESCRIPTION
This patch fixes all shellcheck warnings and errors in existing shell scripts. Shellcheck should not display any issues when run with the following parameters

    shellcheck -S warning -e SC1091 SC2230 SC3043

Shellcheck version 0.9.0 was used for this patch.