### PR TITLE
Fix remaining shellcheck warnings

### DIFF
--- a/Runner/suites/Kernel/FunctionalArea/baseport/Reboot_health_check/setup_systemd.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Reboot_health_check/setup_systemd.sh
@@ -1,7 +1,8 @@
+#!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#!/bin/sh
 # Import test suite definitions
 set -x
 chmod 777 -R /var/common/*
@@ -25,15 +26,15 @@ NC="\033[0m" # No Color
 
 # Function to log
 log_info() {
-    echo -e "${YELLOW}[INFO]${NC} $1"
+    echo "${YELLOW}[INFO]${NC} $1"
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
+    echo "${GREEN}[SUCCESS]${NC} $1"
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
+    echo "${RED}[ERROR]${NC} $1"
 }
 
 # Verify app binary exists

--- a/Runner/suites/Kernel/FunctionalArea/baseport/USBHost/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/USBHost/run.sh
@@ -32,14 +32,14 @@ echo "$usb_output"
 
 # Check if any USB devices were found
 if [ "$device_count" -eq 0 ]; then
-    log_fail "$TESTNAME : Test Failed - No USB devices found."
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    log_fail "$TESTNAME : Test Failed - No USB devices found."
+    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
 elif [ "$non_hub_count" -eq 0 ]; then
-    log_fail "$TESTNAME : Test Failed - Only USB hubs detected, no functional USB devices."
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    log_fail "$TESTNAME : Test Failed - Only USB hubs detected, no functional USB devices."
+    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
 else
-    log_pass "$TESTNAME : Test Passed - $non_hub_count non-hub USB device(s) found."
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    log_pass "$TESTNAME : Test Passed - $non_hub_count non-hub USB device(s) found."
+    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/utils/platform.sh
+++ b/Runner/utils/platform.sh
@@ -1,3 +1,6 @@
+# shellcheck disable=SC2148
+# Intentionally not defining shell.
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
@@ -5,9 +8,11 @@
 ANDROID_PATH=/system/build.prop
 if [ -f $ANDROID_PATH ]; then
     ANDROID=1
+    # shellcheck disable=SC2209,SC2034
     SHELL_CMD=sh
 else
     ANDROID=0
+    # shellcheck disable=SC2209,SC2034
     SHELL_CMD=bash
 fi
 


### PR DESCRIPTION
Fix warnings and errors in remaining files. Where errors are unavoidable add suitable exceptions, like in the platform.sh script.