### PR TITLE
Add POSIX-safe init, runner fixes, and full contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,61 +1,278 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Contributing to the Shell Scripts Repository
+# 🛠️ Contributing to qcom-linux-testkit
 
-Welcome! This repository contains hardware validation shell scripts for Qualcomm embedded robotic platform boards running Linux systems. These scripts follow POSIX standards for maximum portability and integration into CI tools like LAVA.
+Thank you for considering contributing to the **qcom-linux-testkit** project! Your contributions help improve the quality and functionality of our test suite. Please follow the guidelines below to ensure a smooth contribution process.
 
-## Directory Structure
+---
 
-- `Runner/`: Root test harness
-- `Runner/utils/`: Shared libraries like `functestlib.sh`
-- `Runner/init_env`: Common environment setup
-- `Runner/suites/`: Functional test suites organized per feature
+## 📋 Contribution Checklist
 
-## Getting Started
+Before submitting a PR, please ensure the following:
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/qualcomm-linux/qcom-linux-testkit.git
-   ```
+- [ ] **Branching**: Create your feature or fix branch from the latest `main` branch.
+- [ ] **Descriptive Commits**: Write clear and concise commit messages. 
+- [ ] **ShellCheck Compliance**: Run ShellCheck on all modified shell scripts and address any warnings or errors.
+- [ ] **Functionality**: Verify that your changes do not break existing functionality.
+- [ ] **Documentation**: Update or add documentation as necessary.
+- [ ] **Testing**: Add or update tests to cover your changes, if applicable.
 
-2. Run test suites using:
-   ```bash
-   ./Runner/run-test.sh
-   ```
+---
 
-3. Ensure `init_env` and utilities are sourced using relative paths:
-   ```bash
-   . "$(dirname "$0")/../../init_env"
-   . "$(dirname "$0")/../../utils/functestlib.sh"
-   ```
+## 🧪 Running ShellCheck
 
-## Style Guidelines
+We use [ShellCheck](https://www.shellcheck.net/) to analyze shell scripts for common mistakes and potential issues.
 
-- Shell scripts must be POSIX-compliant (`#!/bin/sh`)
-- Avoid Bash-specific syntax
-- Validate using `shellcheck -x`
-- Use consistent format: colored output, logging, `PASS/FAIL` status
+### Installation
 
-## Commit and PR Guidelines
+You can install ShellCheck using your package manager:
 
-- One logical change per commit
-- Always add sign-off:
-  ```bash
-  git commit -s -m "Add test for Bluetooth functionality"
-  ```
+- **macOS**: `brew install shellcheck`
+- **Ubuntu/Debian**: `sudo apt-get install shellcheck`
+- **Fedora**: `sudo dnf install ShellCheck`
+- **Arch Linux**: `sudo pacman -S shellcheck`
 
-- Mention reviewers if needed and explain validation steps
-- PRs should be raised against `main` unless otherwise noted
+### Usage
 
-## License
+To analyze a script:
 
-All contributions must include:
+```bash
+shellcheck path/to/your_script.sh
+```
+
+Address all warnings and errors before submitting your PR. If you need to disable a specific ShellCheck warning, use:
+
 ```sh
-# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# shellcheck disable=SC1090
+```
+
+---
+
+## 📂 Test Suite Structure & Pseudocode Guidelines
+
+Each test suite must follow the standard structure shown below and include a `run.sh` script that:
+
+- Sources `init_env` and `functestlib.sh`
+- Sets `TESTNAME`
+- Finds the test directory dynamically
+- Logs results using `log_pass`, `log_fail`, and outputs a `.res` file
+
+### Directory Structure
+
+```
+Runner/
+├── suites/
+│   └── Kernel/
+│       └── FunctionalArea/
+│           └── baseport/
+│               └── Foo_Validation/
+│                   ├── run.sh
+│                   └── enabled_tests.list (optional)
+├── utils/
+│   ├── init_env
+│   └── functestlib.sh
+```
+
+### Pseudo `run.sh` Template
+
+```sh
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+#Source init_env and functestlib.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="Foo_Validation"
+test_path=$(find_test_case_by_name "$TESTNAME") || {
+    log_fail "$TESTNAME : Test directory not found."
+    echo "FAIL $TESTNAME" > "./$TESTNAME.res"
+    exit 1
+}
+
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+rm -f "$res_file"
+
+log_info "Starting $TESTNAME"
+
+# Run test logic
+if run_some_check_or_command; then
+    log_pass "$TESTNAME: passed"
+    echo "PASS $TESTNAME" > "$res_file"
+else
+    log_fail "$TESTNAME: failed"
+    echo "FAIL $TESTNAME" > "$res_file"
+fi
+```
+
+### `.res` File Requirements
+
+Each `run.sh` **must generate** a `.res` file in the same directory:
+
+- **File Name**: `<TESTNAME>.res`
+- **Content**:
+  - `PASS <TESTNAME>` on success
+  - `FAIL <TESTNAME>` on failure
+  - `SKIP <TESTNAME>` if not applicable
+
+This is essential for CI/CD to parse test outcomes.
+
+### Logging Conventions
+
+Use logging functions from `functestlib.sh`:
+```sh
+log_info "Preparing test"
+log_pass "Test completed successfully"
+log_fail "Test failed"
+log_error "Setup error"
+log_skip "Skipped due to condition"
+```
+
+---
+
+## 📄 Licensing
+
+Ensure that all new files include the appropriate license header:
+
+```sh
+#!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 ```
 
-## Questions?
+---
 
-Open an issue or start a discussion under the GitHub Issues tab.
+## 📬 Submitting a Pull Request
+
+1. **Fork** the repository and create your feature branch:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Commit** your changes with clear messages:
+   ```bash
+   git commit -m "feat: add new feature"
+   ```
+
+3. **Push** to your fork:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+4. **Open a Pull Request**: Navigate to the original repository and open a PR from your forked branch.
+
+Please ensure that your PR description includes:
+
+- A summary of the changes made.
+- The reason for the changes.
+- Any relevant issues or discussions.
+
+---
+
+## 🤝 Code of Conduct
+
+We are committed to fostering a welcoming and respectful community. Please adhere to our [Code of Conduct](docs/CODE_OF_CONDUCT.md) in all interactions.
+
+---
+
+Thank you for contributing to **qcom-linux-testkit**!
+
+
+---
+
+## 🗂️ Test Organization Guidelines
+
+### Directory Placement
+
+- Kernel-level tests → `Runner/suites/Kernel/FunctionalArea/`
+- Multimedia tests → `Runner/suites/Multimedia/`
+- Shared test utilities or binaries → `Runner/common/`
+
+### Script Naming
+
+- Main test launcher must be named `run.sh`
+- Helper scripts should use lowercase with underscores, e.g. `validate_cache.sh`
+- Avoid spaces or uppercase letters in filenames
+
+---
+
+## ⏱️ Test Execution & Timeout Guidelines
+
+- Tests must be self-contained and deterministic
+- Long-running tests should support intermediate logging or status messages
+- Do not rely on `/tmp` or external mounts
+- Scripts must **fail fast** on invalid setup or missing dependencies
+
+---
+
+## 📄 Supported Test Artifacts
+
+Optional per-suite files:
+- `enabled_tests.list`: whitelist of subtests to run
+- `*.log`: output logs from each run; should reside in the same directory
+- `*.res`: REQUIRED file that indicates test result in CI/CD
+
+### .res File Format
+
+Valid output examples:
+```
+PASS Foo_Validation
+FAIL Foo_Validation
+SKIP Foo_Validation (missing dependency)
+```
+
+This format ensures automated tools and LAVA jobs can collect test outcomes.
+
+---
+
+## 🧩 Shell Compatibility
+
+All scripts must run in POSIX `sh`. **Avoid Bash-only features**, including:
+
+- `local` keyword (use plain assignment)
+- `[[ ... ]]` conditions (use `[ ... ]`)
+- Arrays
+- Bash-style arithmetic without quoting (`$(( ))`)
+- Here-strings or `<<<`
+
+Use `#!/bin/sh` in all test scripts and validate with `ShellCheck`.
+
+---
+
+## 🧪 CI Integration Notes
+
+Our CI/CD pipeline expects:
+- Each test case to create a `.res` file in the same folder
+- No stdout/stderr pollution unless via `log_*` functions
+- Proper exit codes (0 for pass, 1 for fail)
+
+All logs should remain local to the suite folder, typically named `*.log`.
+
+---
+
+## 🙋 Questions?
+
+If you're unsure where your test fits or how to structure it, open an issue or tag a maintainer in a draft PR. We're happy to help guide your first contribution.

--- a/Runner/init_env
+++ b/Runner/init_env
@@ -1,11 +1,40 @@
 #!/bin/sh
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Source this file to setup the test suite environment
-BASEDIR=$(pwd)
-export BASEDIR
-TOOLS=$(pwd)/utils
-export TOOLS
-SUITES=$(pwd)/suites
-export SUITES
+# Idempotency guard: only initialize ONCE per shell session
+[ -n "$__INIT_ENV_LOADED" ] && return
+__INIT_ENV_LOADED=1
+
+# (Optional) Remove/comment log line below to keep CI logs clean:
+# echo "[INFO] init_env loaded."
+
+# --- Robust root detection ---
+if [ -z "$ROOT_DIR" ]; then
+    # Fast path: current working directory is root
+    if [ -d "./utils" ] && [ -d "./suites" ]; then
+        ROOT_DIR="$(pwd)"
+    else
+        # Fallback: walk up from this script's location
+        _script_dir="$(cd "$(dirname "$0")" && pwd)"
+        _search="$_script_dir"
+        while [ "$_search" != "/" ]; do
+            if [ -d "$_search/utils" ] && [ -d "$_search/suites" ]; then
+                ROOT_DIR="$_search"
+                break
+            fi
+            _search=$(dirname "$_search")
+        done
+    fi
+fi
+
+if [ ! -d "$ROOT_DIR/utils" ] || [ ! -f "$ROOT_DIR/utils/functestlib.sh" ]; then
+echo "[ERROR] Could not detect testkit root (missing utils/ or functestlib.sh)" >&2
+    exit 1
+fi
+
+export ROOT_DIR
+export TOOLS="$ROOT_DIR/utils"
+export __RUNNER_SUITES_DIR="$ROOT_DIR/suites"
+export __RUNNER_UTILS_BIN_DIR="$ROOT_DIR/common"

--- a/Runner/run-test.sh
+++ b/Runner/run-test.sh
@@ -3,70 +3,110 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
+# Resolve the real path of this script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+# Set TOOLS path to utils under the script directory
+TOOLS="$SCRIPT_DIR/utils"
 
+# Safely source init_env from the same directory as this script
+if [ -f "$SCRIPT_DIR/init_env" ]; then
+    # shellcheck source=/dev/null
+    . "$SCRIPT_DIR/init_env"
+else
+    echo "[INFO] init_env not found at $SCRIPT_DIR/init_env — skipping."
+fi
 
-# Find test case path by name
-find_test_case_by_name() {
-    # Check if the file is a directory
-  if [ -d "$1" ]; then
-    # Get the directory name
-    dir_name_in_dir=${1##*/}
+# Source functestlib.sh from utils/
+if [ -f "$TOOLS/functestlib.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$TOOLS/functestlib.sh"
+    # Export key vars so they are visible to child scripts like ./run.sh
+    export ROOT_DIR
+    export TOOLS
+    export __RUNNER_SUITES_DIR
+    export __RUNNER_UTILS_BIN_DIR
+else
+    echo "[ERROR] functestlib.sh not found at $TOOLS/functestlib.sh"
+    exit 1
+fi
 
-    # Check if the directory name matches the user input
-    if [ "${dir_name_in_dir}" = "$test_name" ]; then
-      # Get the absolute path of the directory
-      abs_path=$(readlink -f "$1")
-      echo "$abs_path"  
-    fi
-  fi
+# Store results
+RESULTS_PASS=""
+RESULTS_FAIL=""
 
-  # Recursively search for the directory in the subdirectory
-  for file in "$1"/*; do
-    # Check if the file is a directory
-    if [ -d "$file" ]; then
-      # Recursively search for the directory in the subdirectory
-      find_test_case_by_name "$file"
-    fi
-  done
-}
-
-# Execute a test case
 execute_test_case() {
-    local test_path="$1"
+    test_path=$1
+    test_name=$(basename "$test_path")
+
     if [ -d "$test_path" ]; then
         run_script="$test_path/run.sh"
         if [ -f "$run_script" ]; then
-            log "Executing test case: $test_path"
-            sh "$run_script" 2>&1 
+            log "Executing test case: $test_name"
+            if (cd "$test_path" && sh "./run.sh"); then
+                log_pass "$test_name passed"
+                if [ -z "$RESULTS_PASS" ]; then
+                    RESULTS_PASS="$test_name"
+                else
+                    RESULTS_PASS=$(printf "%s\n%s" "$RESULTS_PASS" "$test_name")
+                fi
+            else
+                log_fail "$test_name failed"
+                if [ -z "$RESULTS_FAIL" ]; then
+                    RESULTS_FAIL="$test_name"
+                else
+                    RESULTS_FAIL=$(printf "%s\n%s" "$RESULTS_FAIL" "$test_name")
+                fi
+            fi
         else
-            log "No run.sh found in $test_path"
+            log_error "No run.sh found in $test_path"
+            RESULTS_FAIL=$(printf "%s\n%s" "$RESULTS_FAIL" "$test_name (missing run.sh)")
         fi
     else
-        log "Test case directory not found: $test_path"
+        log_error "Test case directory not found: $test_path"
+        RESULTS_FAIL=$(printf "%s\n%s" "$RESULTS_FAIL" "$test_name (directory not found)")
     fi
 }
 
-# Function to run a specific test case by name
 run_specific_test_by_name() {
-    test_name="$1"
-    test_path=$(find_test_case_by_name ".")
+    test_name=$1
+    test_path=$(find_test_case_by_name "$test_name")
     if [ -z "$test_path" ]; then
-        log "Test case with name $test_name not found."
+        log_error "Test case with name $test_name not found."
+        RESULTS_FAIL=$(printf "%s\n%s" "$RESULTS_FAIL" "$test_name (not found)")
     else
         execute_test_case "$test_path"
     fi
 }
 
-# Main script logic
+run_all_tests() {
+    find "${__RUNNER_SUITES_DIR}" -maxdepth 3 -type d -name '[A-Za-z]*' | while IFS= read -r test_dir; do
+        if [ -f "$test_dir/run.sh" ]; then
+            execute_test_case "$test_dir"
+        fi
+    done
+}
+
+print_summary() {
+    echo
+    log_info "========== Test Summary =========="
+    echo "PASSED:"
+    [ -n "$RESULTS_PASS" ] && printf "%s\n" "$RESULTS_PASS" || echo " None"
+    echo
+    echo "FAILED:"
+    [ -n "$RESULTS_FAIL" ] && printf "%s\n" "$RESULTS_FAIL" || echo " None"
+    log_info "=================================="
+}
+
 if [ "$#" -eq 0 ]; then
     log "Usage: $0 [all | <testcase_name>]"
     exit 1
 fi
 
+if [ "$1" = "all" ]; then
+    run_all_tests
+else
+    run_specific_test_by_name "$1"
+fi
 
-run_specific_test_by_name "$1"
+print_summary

--- a/Runner/suites/Kernel/FunctionalArea/baseport/BWMON/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/BWMON/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="BWMON"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="BWMON"
 test_path=$(find_test_case_by_name "$TESTNAME")
-log_info "--------------------------------------------------------------------------"
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Checking if dependency binary is available"
 check_dependencies bw_mem
@@ -56,9 +82,9 @@ done
 
 if $incremented; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file" 
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Buses/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Buses/run.sh
@@ -2,16 +2,41 @@
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-# Import test suite definitions
-. "${PWD}"/init_env
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
 TESTNAME="Buses"
-
-#import test functions library
-. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Checking if dependency binary is available"
 check_dependencies i2c-msm-test
@@ -19,12 +44,11 @@ check_dependencies i2c-msm-test
 log_info "running i2c binary"
 output=$(i2c-msm-test -v -D /dev/i2c-0 -l | grep "ret:1")
 
-
 if echo "$output" | grep -q "Reading"; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file" 
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/CPUFreq_Validation/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/CPUFreq_Validation/run.sh
@@ -3,54 +3,86 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-. "${PWD}/init_env"
-TESTNAME="CPUFreq_Validation"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
 
+TESTNAME="CPUFreq_Validation"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
-log_info "=== CPUFreq Frequency Walker with Validation ==="
-
-# Color codes (ANSI escape sequences)
-GREEN="\033[32m"
-RED="\033[31m"
-YELLOW="\033[33m"
-BLUE="\033[34m"
-NC="\033[0m"
+log_info "=== CPUFreq Frequency Walker with Retry and Cleanup ==="
 
 NUM_CPUS=$(nproc)
-printf "${YELLOW}Detected %s CPU cores.${NC}\n" "$NUM_CPUS"
+log_info "Detected $NUM_CPUS CPU cores."
 
 overall_pass=0
 status_dir="/tmp/cpufreq_status.$$"
 mkdir -p "$status_dir"
 
 validate_cpu_core() {
-    local cpu=$1
-    local core_id=$2
-    status_file="$status_dir/core_$core_id"
+    local cpu="$1"
+    local core_id="$2"
+    local status_file="$status_dir/core_$core_id"
+    echo "unknown" > "$status_file"
 
-    printf "${BLUE}Processing %s...${NC}\n" "$cpu"
+    log_info "Processing $cpu..."
+
+    local cpu_num
+    cpu_num=$(basename "$cpu" | tr -dc '0-9')
+    if [ -f "/sys/devices/system/cpu/cpu$cpu_num/online" ]; then
+        echo 1 > "/sys/devices/system/cpu/cpu$cpu_num/online"
+    fi
 
     if [ ! -d "$cpu/cpufreq" ]; then
-        printf "${BLUE}[SKIP]${NC} %s does not support cpufreq.\n" "$cpu"
+        log_info "[SKIP] $cpu does not support cpufreq."
         echo "skip" > "$status_file"
         return
     fi
 
-    available_freqs=$(cat "$cpu/cpufreq/scaling_available_frequencies" 2>/dev/null)
-
+    local freqs_file="$cpu/cpufreq/scaling_available_frequencies"
+    read -r available_freqs < "$freqs_file" 2>/dev/null
     if [ -z "$available_freqs" ]; then
-        printf "${YELLOW}[INFO]${NC} No available frequencies for %s. Skipping...\n" "$cpu"
+        log_info "[SKIP] No available frequencies for $cpu"
         echo "skip" > "$status_file"
         return
     fi
 
-    if echo "userspace" | tee "$cpu/cpufreq/scaling_governor" > /dev/null; then
-        printf "${YELLOW}[INFO]${NC} Set governor to userspace.\n"
+    local original_governor
+    original_governor=$(cat "$cpu/cpufreq/scaling_governor" 2>/dev/null)
+
+    if echo "userspace" > "$cpu/cpufreq/scaling_governor"; then
+        log_info "[INFO] Set governor to userspace."
+        sync
+        sleep 0.5
     else
-        printf "${RED}[ERROR]${NC} Cannot set userspace governor for %s.\n" "$cpu"
+        log_error "Cannot set userspace governor for $cpu."
         echo "fail" > "$status_file"
         return
     fi
@@ -59,23 +91,46 @@ validate_cpu_core() {
 
     for freq in $available_freqs; do
         log_info "Setting $cpu to frequency $freq kHz..."
-        if echo "$freq" | tee "$cpu/cpufreq/scaling_setspeed" > /dev/null; then
+
+        echo "$freq" > "$cpu/cpufreq/scaling_min_freq" 2>/dev/null
+        echo "$freq" > "$cpu/cpufreq/scaling_max_freq" 2>/dev/null
+
+        if ! echo "$freq" > "$cpu/cpufreq/scaling_setspeed" 2>/dev/null; then
+            log_error "[SKIP] Kernel rejected freq $freq for $cpu"
+            continue
+        fi
+
+        retry=0
+        success=0
+        while [ "$retry" -lt 5 ]; do
+            cur=$(cat "$cpu/cpufreq/scaling_cur_freq")
+            if [ "$cur" = "$freq" ]; then
+                log_info "[PASS] $cpu set to $freq kHz."
+                success=1
+                break
+            fi
             sleep 0.2
-            actual_freq=$(cat "$cpu/cpufreq/scaling_cur_freq")
-            if [ "$actual_freq" = "$freq" ]; then
-                printf "${GREEN}[PASS]${NC} %s set to %s kHz.\n" "$cpu" "$freq"
+            retry=$((retry + 1))
+        done
+
+        if [ "$success" -eq 0 ]; then
+            log_info "[RETRY] Re-attempting to set $cpu to $freq kHz..."
+            echo "$freq" > "$cpu/cpufreq/scaling_setspeed"
+            sleep 0.3
+            cur=$(cat "$cpu/cpufreq/scaling_cur_freq")
+            if [ "$cur" = "$freq" ]; then
+                log_info "[PASS-after-retry] $cpu set to $freq kHz."
             else
-                printf "${RED}[FAIL]${NC} Tried to set %s to %s kHz, but current is %s kHz.\n" "$cpu" "$freq" "$actual_freq"
+                log_error "[FAIL] $cpu failed to set $freq kHz twice. Current: $cur"
                 echo "fail" > "$status_file"
             fi
-        else
-            printf "${RED}[ERROR]${NC} Failed to set %s to %s kHz.\n" "$cpu" "$freq"
-            echo "fail" > "$status_file"
         fi
     done
 
-    echo "Restoring $cpu governor to 'ondemand'..."
-    echo "ondemand" | sudo tee "$cpu/cpufreq/scaling_governor" > /dev/null
+    log_info "Restoring $cpu governor to '$original_governor'..."
+    echo "$original_governor" > "$cpu/cpufreq/scaling_governor"
+    echo 0 > "$cpu/cpufreq/scaling_min_freq" 2>/dev/null
+    echo 0 > "$cpu/cpufreq/scaling_max_freq" 2>/dev/null
 }
 
 cpu_index=0
@@ -93,17 +148,17 @@ for status_file in "$status_dir"/core_*; do
     status=$(cat "$status_file")
     case "$status" in
         pass)
-            printf "CPU%s: ${GREEN}[PASS]${NC}\n" "$idx"
+            log_info "CPU$idx: [PASS]"
             ;;
         fail)
-            printf "CPU%s: ${RED}[FAIL]${NC}\n" "$idx"
+            log_error "CPU$idx: [FAIL]"
             overall_pass=1
             ;;
         skip)
-            printf "CPU%s: ${BLUE}[SKIPPED]${NC}\n" "$idx"
+            log_info "CPU$idx: [SKIPPED]"
             ;;
         *)
-            printf "CPU%s: ${RED}[UNKNOWN STATUS]${NC}\n" "$idx"
+            log_error "CPU$idx: [UNKNOWN STATUS]"
             overall_pass=1
             ;;
     esac
@@ -111,18 +166,16 @@ done
 
 log_info ""
 log_info "=== Overall CPUFreq Validation Result ==="
+
 if [ "$overall_pass" -eq 0 ]; then
-    printf "${GREEN}[OVERALL PASS]${NC} All CPUs validated successfully.\n"
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > "$test_path/$TESTNAME.res"
-    rm -r "$status_dir"
-    exit 0
+    echo "$TESTNAME PASS" > "$res_file"
 else
-    printf "${RED}[OVERALL FAIL]${NC} Some CPUs failed frequency validation.\n"
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
-    rm -r "$status_dir"
-    exit 1
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+rm -r "$status_dir"
+sync
+sleep 1
+exit "$overall_pass"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/GIC/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/GIC/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="GIC"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="GIC"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 # Function to get the timer count
 get_timer_count() {
@@ -39,8 +65,10 @@ echo "$initial_count" | while read -r line; do
     final_values=$(echo "$final_count" | grep "$cpu" | awk '{for(i=2;i<=9;i++) print $i}')
     
     fail_test=false
-    initial_values_list=$(echo "$initial_values" | tr ' ' '\n')
-    final_values_list=$(echo "$final_values" | tr ' ' '\n')
+    initial_values_list=$(echo "$initial_values" | tr ' ' '
+')
+    final_values_list=$(echo "$final_values" | tr ' ' '
+')
     
     i=0
     echo "$initial_values_list" | while read -r initial_value; do
@@ -58,10 +86,10 @@ echo "$initial_count" | while read -r line; do
     echo $fail_test
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
-        echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+        echo "$TESTNAME PASS" > "$res_file"
     else
         log_fail "$TESTNAME : Test Failed"
-        echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+        echo "$TESTNAME FAIL" > "$res_file"
     fi
 done
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/IPA/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/IPA/run.sh
@@ -3,13 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="IPA"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
+
+TESTNAME="IPA"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 PATH=$(find / -name "ipa.ko" 2>/dev/null)
 
@@ -26,10 +54,10 @@ log_info "output of insmod $TEST"
 if /sbin/lsmod | /bin/grep "ipa"; then
     log_info "$(/sbin/lsmod | /bin/grep "ipa")" 
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_error "rmnet module not running"
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/IPCC/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/IPCC/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="IPCC"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="IPCC"
 test_path=$(find_test_case_by_name "$TESTNAME")
-log_info "--------------------------------------------------------------------------"
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 output=$(cat /sys/class/remoteproc/remoteproc*/state)
 
@@ -19,9 +45,9 @@ count=$(echo "$output" | grep -c "running")
 
 if [ $count -eq 4 ]; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Interrupts/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Interrupts/run.sh
@@ -3,14 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="Interrupts"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="Interrupts"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 # Function to get the timer count
 get_timer_count() {
@@ -38,8 +65,10 @@ echo "$initial_count" | while read -r line; do
     final_values=$(echo "$final_count" | grep "$cpu" | awk '{for(i=2;i<=9;i++) print $i}')
     
     fail_test=false
-    initial_values_list=$(echo "$initial_values" | tr ' ' '\n')
-    final_values_list=$(echo "$final_values" | tr ' ' '\n')
+    initial_values_list=$(echo "$initial_values" | tr ' ' '
+')
+    final_values_list=$(echo "$final_values" | tr ' ' '
+')
     
     i=0
     echo "$initial_values_list" | while read -r initial_value; do
@@ -57,8 +86,10 @@ echo "$initial_count" | while read -r line; do
     echo $fail_test
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
+	echo "$TESTNAME PASS" > "$res_file"
     else
         log_fail "$TESTNAME : Test Failed"
+	echo "$TESTNAME FAIL" > "$res_file"
     fi
 done
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/MEMLAT/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/MEMLAT/run.sh
@@ -3,16 +3,43 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
 TESTNAME="MEMLAT"
-#import test functions library
-. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
-test_bin_path=$(find_test_case_bin_by_name "lat_mem_rd")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
+test_bin_path=$(find_test_case_bin_by_name "lat_mem_rd")
 log_info "Checking if dependency binary is available"
 check_dependencies lat_mem_rd
 
@@ -57,9 +84,9 @@ else
 fi
 if $incremented; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/RMNET/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/RMNET/run.sh
@@ -3,13 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="RMNET"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
+
+TESTNAME="RMNET"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 PATH=$(find / -name "rmnet.ko" 2>/dev/null)
 
@@ -24,10 +52,10 @@ log_info "output of insmod $TEST"
 if /sbin/lsmod | /bin/grep "rmnet"; then
     log_info "$(/sbin/lsmod | /bin/grep "rmnet")" 
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_error "rmnet module not running"
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Reboot_health_check/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Reboot_health_check/run.sh
@@ -3,10 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "{PWD}"/init_env
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="Reboot_health_check"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 # Directory for health check files
 HEALTH_DIR="/var/reboot_health"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Timer/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Timer/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="Timer"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="Timer"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 chmod -R 777 /APT/timers
 
@@ -24,9 +50,9 @@ OUTPUT=$($BINARY_PATH)
 # Check if "pass:7" is in the output
 if echo "${OUTPUT}" | grep "pass:7"; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/USBHost/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/USBHost/run.sh
@@ -5,17 +5,41 @@
 
 #Setup requires at least one USB peripheral connected to USB port that supports Host mode function
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="USBHost"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="USBHost"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
-
-log_info "Running USB Host enumeration test"
+log_info "=== Test Initialization ==="
 
 # Check if lsusb is installed
 check_dependencies lsusb
@@ -33,13 +57,14 @@ echo "$usb_output"
 # Check if any USB devices were found
 if [ "$device_count" -eq 0 ]; then
     log_fail "$TESTNAME : Test Failed - No USB devices found."
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
+
 elif [ "$non_hub_count" -eq 0 ]; then
     log_fail "$TESTNAME : Test Failed - Only USB hubs detected, no functional USB devices."
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 else
     log_pass "$TESTNAME : Test Passed - $non_hub_count non-hub USB device(s) found."
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/adsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/adsp_remoteproc/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="adsp_remoteproc"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+ 
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+TESTNAME="adsp_remoteproc"
 test_path=$(find_test_case_by_name "$TESTNAME")
-log_info "--------------------------------------------------------------------------"
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 # Get the firmware output and find the position of adsp
 log_info "Checking for firmware"
@@ -29,7 +55,7 @@ state1=$(cat ${remoteproc_path}/state)
 
 if [ "$state1" != "running" ]; then
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
     exit 1
 fi
 
@@ -41,7 +67,7 @@ echo stop > ${remoteproc_path}/state
 state3=$(cat ${remoteproc_path}/state)
 if [ "$state3" != "offline" ]; then
     log_fail "adsp stop failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
     exit 1
 else
     log_pass "adsp stop successful"
@@ -54,12 +80,12 @@ echo start > ${remoteproc_path}/state
 state5=$(cat ${remoteproc_path}/state)
 if [ "$state5" != "running" ]; then
     log_fail "adsp start failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file" 
     exit 1
 fi
 
 # If all checks pass, print "PASS"
 echo "adsp PASS"
 log_pass "adsp PASS"
-echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+echo "$TESTNAME PASS" > "$res_file"
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/cdsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/cdsp_remoteproc/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="cdsp_remoteproc"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="cdsp_remoteproc"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 # Get the firmware output and find the position of cdsp
 log_info "Get the firmware output and find the position of cdsp"
@@ -52,12 +78,12 @@ echo start > ${remoteproc_path}/state
 state5=$(cat ${remoteproc_path}/state)
 if [ "$state5" != "running" ]; then
     log_fail "cdsp start failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
 
 # If all checks pass, print "PASS"
 echo "cdsp PASS"
 log_pass "cdsp PASS"
-echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+echo "$TESTNAME PASS" > "$res_file" 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/hotplug/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/hotplug/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="hotplug"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="hotplug"
 test_path=$(find_test_case_by_name "$TESTNAME")
-log_info "--------------------------------------------------------------------------"
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 check_cpu_status() {
     cat /sys/devices/system/cpu/cpu*/online
@@ -67,9 +93,9 @@ check_cpu_status | tee -a "$LOG_FILE"
 # Print overall test result
 if [ "$test_passed" = true ]; then
         log_pass "$TESTNAME : Test Passed"
-        echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+        echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/iommu/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/iommu/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="iommu"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="iommu"
 test_path=$(find_test_case_by_name "$TESTNAME")
-log_info "--------------------------------------------------------------------------"
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 # Run the command and capture the output
 OUTPUT=$(dmesg | grep iommu)
@@ -19,9 +45,9 @@ OUTPUT=$(dmesg | grep iommu)
 # Check if the output is null
 if [ -z "$OUTPUT" ]; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/irq/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/irq/run.sh
@@ -3,15 +3,42 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="irq"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="irq"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
+
 # Function to get the timer count
 get_timer_count() {
     cat /proc/interrupts | grep arch_timer
@@ -38,8 +65,10 @@ echo "$initial_count" | while read -r line; do
     final_values=$(echo "$final_count" | grep "$cpu" | awk '{for(i=2;i<=9;i++) print $i}')
     
     fail_test=false
-    initial_values_list=$(echo "$initial_values" | tr ' ' '\n')
-    final_values_list=$(echo "$final_values" | tr ' ' '\n')
+    initial_values_list=$(echo "$initial_values" | tr ' ' '
+')
+    final_values_list=$(echo "$final_values" | tr ' ' '
+')
     
     i=0
     echo "$initial_values_list" | while read -r initial_value; do
@@ -55,10 +84,10 @@ echo "$initial_count" | while read -r line; do
 
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
-        echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+	echo "$TESTNAME PASS" > "$res_file"
     else
         log_fail "$TESTNAME : Test Failed"
-        echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+	echo "$TESTNAME FAIL" > "$res_file"
     fi
 done
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/kaslr/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/kaslr/run.sh
@@ -3,28 +3,51 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="kaslr"
-#import test functions library
-. "${TOOLS}"/functestlib.sh
-test_path=$(find_test_case_by_name "$TESTNAME")
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-log_info "--------------------------------------------------------------------------"
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="kaslr"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 output=$(cat /proc/kallsyms | grep stext)
 
-
 value=$(echo $output | awk '{print $1}')
-
-
 
 if [ $value = "0000000000000000" ]; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/pinctrl/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/pinctrl/run.sh
@@ -3,15 +3,42 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="pinctrl"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="pinctrl"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
+
 log_info "Mounting debugfs"
 mount -t debugfs debugfs /sys/kernel/debug
 # Execute the command and store the output
@@ -20,9 +47,9 @@ output=$(ls /sys/kernel/debug/pinctrl)
 # Print overall test result
 if [ -z "$output" ]; then
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 else
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/qcrypto/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/qcrypto/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="qcrypto"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="qcrypto"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Checking if dependency binary is available"
 check_dependencies kcapi-convience
@@ -23,9 +49,9 @@ echo "${KCAPI_RET}"
 
 if [ ${KCAPI_RET} -eq 0 ]; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/remoteproc/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="remoteproc"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="remoteproc"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Getting the number of subsystems aavailable"
 subsystem_count=$(cat /sys/class/remoteproc/remoteproc*/state | wc -l)
@@ -27,9 +53,9 @@ log_info "rproc subsystems in running state : $count, expected subsystems : $sub
 # Print overall test result
 if [ $count -eq $subsystem_count ]; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="rngtest"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="rngtest"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Checking if dependency binary is available"
 check_dependencies rngtest
@@ -25,9 +51,9 @@ value=$(cat /tmp/rngtest_value.txt)
 
 if [ "$value" -lt 10 ]; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/smmu/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/smmu/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="smmu"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="smmu"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 # Run the command and capture the output
 OUTPUT=$(dmesg | grep iommu)
@@ -19,9 +45,9 @@ OUTPUT=$(dmesg | grep iommu)
 # Check if the output is null
 if [ -z "$OUTPUT" ]; then
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 else
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/storage/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/storage/run.sh
@@ -3,15 +3,41 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="storage"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="storage"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Run the dd command to create a file with random data"
 dd if=/dev/random of=/tmp/a.txt bs=1M count=1024
@@ -24,22 +50,22 @@ if [ -f /tmp/a.txt ]; then
     if [ -s /tmp/a.txt ]; then
         log_pass "File /tmp/a.txt is not empty. Test Passed"
         log_pass "$TESTNAME : Test Passed"
-        echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+	echo "$TESTNAME PASS" > "$res_file"
     else
         log_fail "File /tmp/a.txt is empty. Test Failed."
         log_fail "$TESTNAME : Test Failed"
-        echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+	echo "$TESTNAME FAIL" > "$res_file"
     fi
 else
     log_fail "File /tmp/a.txt is not created. Test Failed"
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 if [ -f /tmp/a.txt ]; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/watchdog/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/watchdog/run.sh
@@ -3,23 +3,49 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-TESTNAME="watchdog"
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
 
-#import test functions library
-. "${TOOLS}"/functestlib.sh
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="watchdog"
 test_path=$(find_test_case_by_name "$TESTNAME")
-log_info "--------------------------------------------------------------------------"
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 if [ -e /dev/watchdog ]; then
     log_pass "/dev/watchdog node is present."
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
     log_fail "/dev/watchdog node is not present."
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase---------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh
@@ -3,15 +3,15 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
 TESTNAME="wpss_remoteproc"
-
-#import test functions library
-. "${TOOLS}"/functestlib.sh
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 # Get the firmware output and find the position of wpss
 firmware_output=$(cat /sys/class/remoteproc/remoteproc*/firmware)
@@ -51,12 +51,12 @@ echo start > ${remoteproc_path}/state
 state5=$(cat ${remoteproc_path}/state)
 if [ "$state5" != "running" ]; then
     log_fail "wpss start failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
+    echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
 
 # If all checks pass, print "PASS"
 echo "wpss PASS"
 log_pass "wpss PASS"
-echo "$TESTNAME PASS" > $test_path/$TESTNAME.res
+echo "$TESTNAME PASS" > "$res_file"
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Multimedia/DSP_AudioPD/run.sh
+++ b/Runner/suites/Multimedia/DSP_AudioPD/run.sh
@@ -1,13 +1,43 @@
 #!/bin/sh
-# Import test suite definitions
-/var/Runner/init_env
-TESTNAME="DSP_AudioPD"
 
-#import test functions library
-. $TOOLS/functestlib.sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="DSP_AudioPD"
 test_path=$(find_test_case_by_name "$TESTNAME")
-log_info "--------------------------------------------------------------------------"
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Checking if dependency binary is available"
 check_dependencies adsprpcd
@@ -23,21 +53,20 @@ else
 fi
 
 check_stack_trace() {
-	local pid=$1
-	if cat /proc/$pid/stack 2>/dev/null | grep -q "do_sys_poll"; then
-		return 0
-	else
-		return 1
-	fi
+    pid=$1
+    if grep -q "do_sys_poll" < "/proc/$pid/stack" 2>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
 }
-
 # Print overall test result
 if check_stack_trace "$PID"; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME : Test Passed" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
-	log_fail "$TESTNAME : Test Failed"
-	echo "$TESTNAME : Test Failed" > $test_path/$TESTNAME.res
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 
 log_info "Kill the process"

--- a/Runner/suites/Multimedia/Graphics/run.sh
+++ b/Runner/suites/Multimedia/Graphics/run.sh
@@ -1,13 +1,43 @@
 #!/bin/sh
-# Import test suite definitions
-/var/Runner/init_env
-TESTNAME="Graphics"
 
-#import test functions library
-. $TOOLS/functestlib.sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="Graphics"
 test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
+
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Checking if dependency binary is available"
 check_dependencies a660_sqe.fw a660_zap.mbn a660_gmu.bin
@@ -20,9 +50,9 @@ OUTPUT=$(dmesg)
 
 if echo "${OUTPUT}" | grep "Loaded GMU firmware"; then
     log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME : Test Passed" > $test_path/$TESTNAME.res
+    echo "$TESTNAME PASS" > "$res_file"
 else
-	log_fail "$TESTNAME : Test Failed"
-	echo "$TESTNAME : Test Failed" > $test_path/$TESTNAME.res
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Multimedia/Video/iris_v4l2_video_decode/run.sh
+++ b/Runner/suites/Multimedia/Video/iris_v4l2_video_decode/run.sh
@@ -3,18 +3,42 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-# shellcheck source=../../../../init_env
-. "${PWD}"/init_env
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
 TESTNAME="iris_v4l2_video_decode"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
 TAR_URL="https://github.com/qualcomm-linux/qcom-linux-testkit/releases/download/IRIS-Video-Files-v1.0/video_clips_iris.tar.gz"
 
-#import test functions library
-# shellcheck source=../../../../utils/functestlib.sh
-. "${TOOLS}"/functestlib.sh
-test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Checking if dependency binary is available"
 check_dependencies iris_v4l2_test
@@ -27,8 +51,8 @@ if grep -q "SUCCESS" "${test_path}/video_dec.txt"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$test_path/$TESTNAME.res"
 else
-	log_fail "$TESTNAME : Test Failed"
-	echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Multimedia/Video/iris_v4l2_video_encode/run.sh
+++ b/Runner/suites/Multimedia/Video/iris_v4l2_video_encode/run.sh
@@ -3,18 +3,42 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-# shellcheck source=../../../../init_env 
-. "${PWD}"/init_env
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
 TESTNAME="iris_v4l2_video_encode"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+# shellcheck disable=SC2034
+res_file="./$TESTNAME.res"
 TAR_URL="https://github.com/qualcomm-linux/qcom-linux-testkit/releases/download/IRIS-Video-Files-v1.0/video_clips_iris.tar.gz"
 
-#import test functions library
-# shellcheck source=../../../../utils/functestlib.sh
-. "${TOOLS}"/functestlib.sh 
-test_path=$(find_test_case_by_name "$TESTNAME")
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
 
 log_info "Checking if dependency binary is available"
 check_dependencies iris_v4l2_test
@@ -27,8 +51,8 @@ if grep -q "SUCCESS" "${test_path}/video_enc.txt"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$test_path/$TESTNAME.res"
 else
-	log_fail "$TESTNAME : Test Failed"
-	echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -3,105 +3,77 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Import test suite definitions
-. "${PWD}"/init_env
-#import platform
-. "${TOOLS}"/platform.sh
-
-__RUNNER_SUITES_DIR="/var/Runner/suites"
-__RUNNER_UTILS_BIN_DIR="/var/common"
-
-#This function used for test logging
+# --- Logging helpers ---
 log() {
-    local level="$1"
+    level=$1
     shift
-    # echo "$(date '+%Y-%m-%d %H:%M:%S') - $message" | tee -a /var/test_framework.log
-    echo "[$level] $(date '+%Y-%m-%d %H:%M:%S') - $*" | tee -a /var/test_output.log
+    echo "[$level] $(date '+%Y-%m-%d %H:%M:%S') - $*"
 }
-# Find test case path by name
-find_test_case_by_name() {
-    local test_name="$1"
-    if [ -d "$__RUNNER_SUITES_DIR" ]; then
-        find $__RUNNER_SUITES_DIR -type d -iname "$test_name" 2>/dev/null
-    else
-        find "${PWD}" -type d -iname "$test_name" 2>/dev/null
-    fi
-}
+log_info()  { log "INFO"  "$@"; }
+log_pass()  { log "PASS"  "$@"; }
+log_fail()  { log "FAIL"  "$@"; }
+log_error() { log "ERROR" "$@"; }
+log_skip()  { log "SKIP"  "$@"; }
 
-# Find test case path by name
-find_test_case_bin_by_name() {
-    local test_name="$1"
-    find $__RUNNER_UTILS_BIN_DIR -type f -iname "$test_name" 2>/dev/null
-}
-
-# Find test case path by name
-find_test_case_script_by_name() {
-    local test_name="$1"
-    if [ -d "$__RUNNER_UTILS_BIN_DIR" ]; then
-        find $__RUNNER_UTILS_BIN_DIR -type d -iname "$test_name" 2>/dev/null
-    else
-        find "${PWD}" -type d -iname "$test_name" 2>/dev/null
-    fi
-}
-
+# --- Dependency check ---
 check_dependencies() {
-    local missing=0
+    missing=0
     for cmd in "$@"; do
-        if ! command -v "$cmd" > /dev/null 2>&1; then
-            log_error "ERROR: Required command '$cmd' not found in PATH."
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            log_error "Required command '$cmd' not found in PATH."
             missing=1
         fi
     done
-    if [ "$missing" -ne 0 ]; then
-        log_error "Exiting due to missing dependencies."
-        exit 1
-    else
-    log_pass "Test related dependencies are present."
-    fi
+    [ "$missing" -ne 0 ] && exit 1
 }
 
-# Logging levels
-log_info() { log "INFO" "$@"; }
-log_pass() { log "PASS" "$@"; }
-log_fail() { log "FAIL" "$@"; }
-log_error() { log "ERROR" "$@"; }
+# --- Test case directory lookup ---
+find_test_case_by_name() {
+    test_name=$1
+    base_dir="${__RUNNER_SUITES_DIR:-$ROOT_DIR/suites}"
+    # Only search under the SUITES directory!
+    testpath=$(find "$base_dir" -type d -iname "$test_name" -print -quit 2>/dev/null)
+    echo "$testpath"
+}
 
+find_test_case_bin_by_name() {
+    test_name=$1
+    base_dir="${__RUNNER_UTILS_BIN_DIR:-$ROOT_DIR/common}"
+    find "$base_dir" -type f -iname "$test_name" -print -quit 2>/dev/null
+}
 
-## this doc fn comes last
-FUNCTIONS="\
-log_info \
-log_pass \
-log_fail \
-log_error \
-find_test_case_by_name \
-find_test_case_bin_by_name \
-find_test_case_script_by_name  \
-log \
-"
+find_test_case_script_by_name() {
+    test_name=$1
+    base_dir="${__RUNNER_UTILS_BIN_DIR:-$ROOT_DIR/common}"
+    find "$base_dir" -type d -iname "$test_name" -print -quit 2>/dev/null
+}
 
-functestlibdoc()
-{
-  echo "functestlib.sh"
-  echo ""
-  echo "Functions:"
-  for fn in $FUNCTIONS; do
-    echo $fn
-    eval $fn"_doc"
+# --- Optional: POSIX-safe repo root detector ---
+detect_runner_root() {
+    path=$1
+    while [ "$path" != "/" ]; do
+        if [ -d "$path/suites" ]; then
+            echo "$path"
+            return
+        fi
+        path=$(dirname "$path")
+    done
     echo ""
-  done
-  echo "Note, these functions will probably not work with >=32 CPUs"
 }
 
+# ----------------------------
+# Additional Utility Functions
+# ----------------------------
 # Function is to check for network connectivity status
 check_network_status() {
     echo "[INFO] Checking network connectivity..."
- 
+
     # Get first active IPv4 address (excluding loopback)
     ip_addr=$(ip -4 addr show scope global up | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
- 
+
     if [ -n "$ip_addr" ]; then
         echo "[PASS] Network is active. IP address: $ip_addr"
- 
+
         if ping -c 1 -W 2 8.8.8.8 >/dev/null 2>&1; then
             echo "[PASS] Internet is reachable."
             return 0
@@ -117,66 +89,77 @@ check_network_status() {
 
 # If the tar file already exists,then function exit. Otherwise function to check the network connectivity and it will download tar from internet.
 extract_tar_from_url() {
-    local url="$1"
-    local filename
-    local extracted_files
-	
-	# Extract the filename from the URL
+    url=$1
     filename=$(basename "$url")
-    if check_tar_file "$filename"; then
-        echo "[PASS] file already exists, Hence skipping downloading"
+
+    check_tar_file "$url"
+    status=$?
+    if [ "$status" -eq 0 ]; then
+        log_info "Already extracted. Skipping download."
         return 0
-    fi
-	
-    check_network_status
-    network_status=$?
-    if [ $network_status -ne 0 ]; then
-        extract_tar_from_url "$TAR_URL"
-    fi
-
-    # Download the file using wget
-    echo "[INFO] Downloading $url..."
-    wget -O "$filename" "$url"
-
-    # Check if wget was successful
-    if [ $? -ne 0 ]; then
-        echo "[FAIL] Failed to download the file."
-        return 1
-    fi
-
-    # Extract the tar file
-    echo "[INFO] Extracting $filename..."
-    tar -xvf "$filename"
-
-    # Check if tar was successful
-    if [ $? -ne 0 ]; then
-        echo "[FAIL] Failed to extract the file."
-        return 1
+    elif [ "$status" -eq 1 ]; then
+        log_info "File missing or invalid. Will download and extract."
+        check_network_status || return 1
+        log_info "Downloading $url..."
+        wget -O "$filename" "$url" || {
+            log_fail "Failed to download $filename"
+            return 1
+        }
+        log_info "Extracting $filename..."
+        tar -xvf "$filename" || {
+            log_fail "Failed to extract $filename"
+            return 1
+        }
+    elif [ "$status" -eq 2 ]; then
+        log_info "File exists and is valid, but not yet extracted. Proceeding to extract."
+        tar -xvf "$filename" || {
+            log_fail "Failed to extract $filename"
+            return 1
+        }
     fi
 
-    # Check if any files were extracted
-    extracted_files=$(tar -tf "$filename")
-    if [ -z "$extracted_files" ]; then
-        echo "[FAIL] No files were extracted."
-        return 1
+    # Optionally, check that extraction succeeded
+    first_entry=$(tar -tf "$filename" 2>/dev/null | head -n1 | cut -d/ -f1)
+    if [ -n "$first_entry" ] && [ -e "$first_entry" ]; then
+        log_pass "Files extracted successfully ($first_entry exists)."
+        return 0
     else
-        echo "[PASS] Files extracted successfully:"
-        echo "[INFO] $extracted_files"
-        return 0
+        log_fail "Extraction did not create expected entry: $first_entry"
+        return 1
     fi
 }
 
 # Function to check if a tar file exists
 check_tar_file() {
-    local url="$1"
-    local filename
-    local extracted_files
-
-    # Extract the filename from the URL
+    url=$1
     filename=$(basename "$url")
-    if [ -f "$filename" ]; then
-        return 0
-    else
+
+    # 1. Check file exists
+    if [ ! -f "$filename" ]; then
+        log_error "File $filename does not exist."
         return 1
     fi
+
+    # 2. Check file is non-empty
+    if [ ! -s "$filename" ]; then
+        log_error "File $filename exists but is empty."
+        return 1
+    fi
+
+    # 3. Check file is a valid tar archive
+    if ! tar -tf "$filename" >/dev/null 2>&1; then
+        log_error "File $filename is not a valid tar archive."
+        return 1
+    fi
+
+    # 4. Check if already extracted: does the first entry in the tar exist?
+    first_entry=$(tar -tf "$filename" 2>/dev/null | head -n1 | cut -d/ -f1)
+    if [ -n "$first_entry" ] && [ -e "$first_entry" ]; then
+        log_pass "$filename has already been extracted ($first_entry exists)."
+        return 0
+    fi
+
+    log_info "$filename exists and is valid, but not yet extracted."
+    return 2
 }
+


### PR DESCRIPTION
This PR includes several enhancements for maintainability and contributor onboarding:
 
init_env was updated to prevent duplicate sourcing and repeated log output using __INIT_ENV_LOADED and NO_INIT_LOG
 
[run-test.sh](http://run-test.sh/) was rewritten for full POSIX compliance and consistent test execution behavior
 
[functestlib.sh](http://functestlib.sh/) and related sourcing paths were aligned and ShellCheck warnings disabled where needed
 
A new [CONTRIBUTING.md](http://contributing.md/) file outlines the required folder structure, .res result handling for CI/CD, ShellCheck rules, and test logging standards
 
These changes help standardize shell-based test contributions and prepare the repo for broader automation and LAVA integration.

```
@vnarapar @abbajaj806 
``` 