### PR TITLE
Fix to get the overall result in LAVA

### DIFF
--- a/Runner/plans/meta-ar-ci-premerge.yaml
+++ b/Runner/plans/meta-ar-ci-premerge.yaml
@@ -18,4 +18,5 @@ run:
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback.res || true  
         - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord.res || true
+        - $PWD/utils/result_parse.sh
 

--- a/Runner/plans/meta-qcom_PreMerge.yaml
+++ b/Runner/plans/meta-qcom_PreMerge.yaml
@@ -56,3 +56,4 @@ run:
         - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/FunctionalArea/baseport/watchdog/watchdog.res || true
         - $PWD/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/wpss_remoteproc.res || true
+        - $PWD/utils/result_parse.sh

--- a/Runner/plans/qcom-next-ci-premerge.yaml
+++ b/Runner/plans/qcom-next-ci-premerge.yaml
@@ -56,3 +56,4 @@ run:
         - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/FunctionalArea/baseport/watchdog/watchdog.res || true
         - $PWD/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/wpss_remoteproc.res || true
+        - $PWD/utils/result_parse.sh

--- a/Runner/utils/result_parse.sh
+++ b/Runner/utils/result_parse.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+echo "Current working directory is $PWD"
+
+find . -type f -name "*.res" 2>/dev/null | while IFS= read res_file; do
+    echo "$res_file"
+    if [ -f "$res_file" ]; then
+        while IFS= read line; do
+            # Skip empty lines
+            [ -z "$line" ] && continue
+            
+            # Split line into words
+            set -- $line
+            tc_name=$1
+            result=$2
+            # Report each test case result to LAVA
+            if [ -n "$tc_name" ] && [ -n "$result" ]; then
+                if [ "$result" = "FAIL" ]; then 
+                    exit 1
+                fi
+            else
+                echo "Warning: Skipping malformed line: $line"
+            fi
+        done < "$res_file"
+    fi
+done


### PR DESCRIPTION
This commit is to update the overall pass/fail status of the LAVA job based on the test results

Added result_parse.sh