### PR TITLE
Added Connectivity Testcases [Ethernet and Bluetooth] and one Kernel Testcase [shmbridge] 

### DIFF
--- a/Runner/suites/Connectivity/Bluetooth/README.md
+++ b/Runner/suites/Connectivity/Bluetooth/README.md
@@ -1,0 +1,59 @@
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Bluetooth Validation Test
+
+## Overview
+
+This test case validates the basic functionality of the Bluetooth controller on the device. It checks for:
+
+- Presence of `bluetoothctl`
+- Running status of `bluetoothd`
+- Power state toggling of the Bluetooth controller
+
+## Usage
+
+Instructions:
+
+1. Copy repo to Target Device: Use scp to transfer the scripts from the host to the target device. The scripts should be copied to any directory on the target device.
+2. Verify Transfer: Ensure that the repo have been successfully copied to any directory on the target device.
+3. Run Scripts: Navigate to the directory where these files are copied on the target device and execute the scripts as needed.
+
+Run a Connectivity Bluetooth test using:
+---
+#### Quick Example
+```
+git clone <this-repo>
+cd <this-repo>
+scp -r common Runner user@target_device_ip:<Path in device>
+ssh user@target_device_ip
+cd <Path in device>/Runner && ./run-test.sh Bluetooth
+```
+
+## Prerequisites
+- bluez package must be installed (provides bluetoothctl)
+- bluetoothd daemon must be running
+- Root access may be required for complete validation
+
+## Result Format
+
+Test result will be saved in Bluetooth.res as:  
+#### Pass Criteria  
+- bluetoothctl is available
+- bluetoothd is running
+- Power on command returns success
+- Bluetooth controller powered on successfully. – if all validations pass  
+<!-- -->
+#### Fail Criteria  
+- bluetoothctl not found
+- bluetoothd not running
+- Power on command fails
+- Failed to power on Bluetooth controller. – if any check fails
+
+
+## Output
+A .res file is generated in the same directory:
+
+`PASS Bluetooth`  OR   `FAIL Bluetooth`
+
+

--- a/Runner/suites/Connectivity/Bluetooth/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/run.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+ 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+ 
+# Source init_env and functestlib.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+ 
+# shellcheck disable=SC1090
+. "$INIT_ENV"
+ 
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+ 
+TESTNAME="Bluetooth"
+test_path=$(find_test_case_by_name "$TESTNAME") || {
+    log_fail "$TESTNAME : Test directory not found."
+    echo "$TESTNAME FAIL" > "./$TESTNAME.res"
+    exit 1
+}
+ 
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+rm -f "$res_file"
+ 
+log_info "-----------------------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "Checking dependency: bluetoothctl"
+check_dependencies bluetoothctl
+ 
+log_info "Checking if bluetoothd is running..."
+MAX_RETRIES=3
+RETRY_DELAY=5
+retry=0
+ 
+while [ "$retry" -lt "$MAX_RETRIES" ]; do
+    if pgrep bluetoothd >/dev/null 2>&1; then
+        log_info "bluetoothd is running"
+        break
+    fi
+    log_warn "bluetoothd not running, retrying in ${RETRY_DELAY}s..."
+    sleep "$RETRY_DELAY"
+    retry=$((retry + 1))
+done
+ 
+if [ "$retry" -eq "$MAX_RETRIES" ]; then
+    log_fail "Bluetooth daemon not detected after ${MAX_RETRIES} attempts."
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+fi
+ 
+log_info "Powering off Bluetooth controller..."
+poweroff_output=$(bluetoothctl power off 2>&1)
+if echo "$poweroff_output" | grep -q "Changing power off succeeded"; then
+    log_pass "Bluetooth powered off successfully"
+else
+    log_warn "Power off result: $poweroff_output"
+    log_fail "Bluetooth power off failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+fi
+ 
+log_info "Powering on Bluetooth controller..."
+poweron_output=$(bluetoothctl power on 2>&1)
+if echo "$poweron_output" | grep -q "Changing power on succeeded"; then
+    log_pass "Bluetooth powered on successfully"
+    echo "$TESTNAME PASS" > "$res_file"
+    exit 0
+else
+    log_warn "Power on result: $poweron_output"
+    log_fail "Bluetooth power on failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+fi
+

--- a/Runner/suites/Connectivity/Ethernet/README.md
+++ b/Runner/suites/Connectivity/Ethernet/README.md
@@ -1,0 +1,57 @@
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Ethernet Validation Test
+
+## Overview
+
+This test case validates the basic functionality of the Ethernet interface (`eth0`) on the device. It checks for:
+
+- Interface presence
+- Interface status (UP/DOWN)
+- Basic connectivity via ping to `8.8.8.8`
+
+## Usage
+
+Instructions:
+
+1. Copy repo to Target Device: Use scp to transfer the scripts from the host to the target device. The scripts should be copied to any directory on the target device.
+2. Verify Transfer: Ensure that the repo have been successfully copied to any directory on the target device.
+3. Run Scripts: Navigate to the directory where these files are copied on the target device and execute the scripts as needed.
+
+Run a Connectivity Ethernet test using:
+---
+#### Quick Example
+```
+git clone <this-repo>
+cd <this-repo>
+scp -r common Runner user@target_device_ip:<Path in device>
+ssh user@target_device_ip
+cd <Path in device>/Runner && ./run-test.sh Ethernet
+```
+
+## Prerequisites
+
+- `ip` and `ping` must be available
+- Root access may be required for complete validation
+
+## Result Format
+Test result will be saved in `Ethernet.res` as:  
+#### Pass Criteria  
+- Ethernet interface eth0 is detected
+- Interface is successfully brought up (if down)
+- Ping to 8.8.8.8 succeeds
+- `Ethernet connectivity verified` – if all validations pass  
+<!-- -->
+#### Fail Criteria  
+- Interface eth0 is not found
+- Interface cannot be brought up
+- Ping test fails
+- `Ethernet ping failed` – if any check fails
+
+
+## Output
+A .res file is generated in the same directory:
+
+`PASS Ethernet`  OR   `FAIL Ethernet`
+

--- a/Runner/suites/Connectivity/Ethernet/run.sh
+++ b/Runner/suites/Connectivity/Ethernet/run.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+ 
+#Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#SPDX-License-Identifier: BSD-3-Clause-Clear
+ 
+# Source init_env and functestlib.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+ 
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+ 
+# shellcheck disable=SC1090
+. "$INIT_ENV"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+ 
+TESTNAME="Ethernet"
+test_path=$(find_test_case_by_name "$TESTNAME") || {
+    log_fail "$TESTNAME : Test directory not found."
+    echo "FAIL $TESTNAME" > "./$TESTNAME.res"
+    exit 1
+}
+ 
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+rm -f "$res_file"
+ 
+log_info "--------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+ 
+check_dependencies ip ping
+ 
+IFACE="eth0"
+RETRIES=3
+SLEEP_SEC=3
+ 
+# Check interface existence
+if ! ip link show "$IFACE" >/dev/null 2>&1; then
+    log_fail "Ethernet interface $IFACE not found"
+    echo "FAIL $TESTNAME" > "$res_file"
+    exit 1
+fi
+ 
+# Bring up interface with retries
+log_info "Ensuring $IFACE is UP..."
+i=0
+while [ $i -lt $RETRIES ]; do
+    ip link set "$IFACE" up
+    sleep "$SLEEP_SEC"
+    if ip link show "$IFACE" | grep -q "state UP"; then
+        log_info "$IFACE is UP"
+        break
+    fi
+    log_warn "$IFACE is still DOWN (attempt $((i + 1))/$RETRIES)..."
+    i=$((i + 1))
+done
+ 
+if [ $i -eq $RETRIES ]; then
+    log_fail "Failed to bring up $IFACE after $RETRIES attempts"
+    echo "FAIL $TESTNAME" > "$res_file"
+    exit 1
+fi
+ 
+# Ping test with retries
+log_info "Running ping test to 8.8.8.8 via $IFACE..."
+i=0
+while [ $i -lt $RETRIES ]; do
+    if ping -I "$IFACE" -c 4 -W 2 8.8.8.8 >/dev/null 2>&1; then
+        log_pass "Ethernet connectivity verified via ping"
+        echo "PASS $TESTNAME" > "$res_file"
+        exit 0
+    fi
+    log_warn "Ping failed (attempt $((i + 1))/$RETRIES)... retrying"
+    sleep "$SLEEP_SEC"
+    i=$((i + 1))
+done
+ 
+log_fail "Ping test failed after $RETRIES attempts"
+echo "FAIL $TESTNAME" > "$res_file"
+exit 1

--- a/Runner/suites/Kernel/FunctionalArea/baseport/shmbridge/README.md
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/shmbridge/README.md
@@ -1,0 +1,59 @@
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# shmbridge Validation Test
+
+## Overview
+
+This test case validates the encryption and access functionality of the `shmbridge` partition by:
+
+- Formatting the partition with ext4 and encryption options
+- Mounting it with `inlinecrypt`
+- Adding an encryption key using `fscryptctl`
+- Setting and verifying an encryption policy
+- Writing and reading a test file to confirm data integrity
+
+## Usage
+
+Instructions:
+
+1. Copy repo to Target Device: Use scp to transfer the scripts from the host to the target device. The scripts should be copied to any directory on the target device.
+2. Verify Transfer: Ensure that the repo have been successfully copied to any directory on the target device.
+3. Run Scripts: Navigate to the directory where these files are copied on the target device and execute the scripts as needed.
+
+Run a Kernel Baseport shmbridge test using:
+---
+#### Quick Example
+```
+git clone <this-repo>
+cd <this-repo>
+scp -r common Runner user@target_device_ip:<Path in device>
+ssh user@target_device_ip
+cd <Path in device>/Runner && ./run-test.sh shmbridge
+```
+
+## Prerequisites
+- `fscryptctl`, `mkfs.ext4` and `mount` must be available
+- Root access is required
+- Partition /dev/disk/by-partlabel/xbl_ramdump_a must exist and be accessible
+
+## Result Format
+
+Test result will be saved in shmbridge.res as:  
+#### Pass Criteria
+- Partition is found and formatted
+- Encryption key is added and policy is set
+- Test file is written and read successfully
+- `Test Passed` – if all validations succeed
+<!-- -->
+#### Fail Criteria
+- Partition not found
+- Encryption setup fails
+- Test file cannot be read or content mismatch
+- `Test Failed` – if any check fails
+
+## Output
+A .res file is generated in the same directory:
+
+`PASS shmbridge`  OR   `FAIL shmbridge`
+

--- a/Runner/suites/Kernel/FunctionalArea/baseport/shmbridge/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/shmbridge/run.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+ 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+ 
+# Locate and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+ 
+# shellcheck disable=SC1090
+. "$INIT_ENV"
+ 
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+ 
+TESTNAME="shmbridge"
+test_path=$(find_test_case_by_name "$TESTNAME") || {
+    log_fail "$TESTNAME : Test directory not found."
+    echo "$TESTNAME FAIL" > "./$TESTNAME.res"
+    exit 1
+}
+ 
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+rm -f "$res_file"
+ 
+log_info "--------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+ 
+check_dependencies fscryptctl mkfs.ext4 mount dd grep cat
+ 
+MOUNT_POINT="/mnt/overlay"
+PARTITION="/dev/disk/by-partlabel/xbl_ramdump_a"
+KEY_FILE="$MOUNT_POINT/stdkey"
+TEST_DIR="$MOUNT_POINT/test"
+TEST_FILE="$TEST_DIR/txt"
+ 
+log_info "Creating mount point at $MOUNT_POINT"
+mkdir -p "$MOUNT_POINT"
+ 
+if [ ! -e "$PARTITION" ]; then
+    log_fail "Partition $PARTITION not found"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+fi
+ 
+if ! mount | grep -q "$PARTITION"; then
+    log_info "Formatting $PARTITION with ext4 (encrypt, stable_inodes)"
+    mkfs.ext4 -F -O encrypt,stable_inodes "$PARTITION"
+else
+    log_warn "$PARTITION already mounted, skipping format"
+fi
+ 
+log_info "Mounting $PARTITION to $MOUNT_POINT with inlinecrypt"
+if ! mount "$PARTITION" -o inlinecrypt "$MOUNT_POINT"; then
+    log_fail "Failed to mount $PARTITION"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+fi
+ 
+log_info "Generating 64-byte encryption key"
+dd if=/dev/urandom bs=1 count=64 of="$KEY_FILE" status=none
+ 
+log_info "Adding encryption key with fscryptctl"
+identifier=$(fscryptctl add_key "$MOUNT_POINT" < "$KEY_FILE") || {
+    log_fail "Failed to add key to $MOUNT_POINT"
+    echo "$TESTNAME FAIL" > "$res_file"
+    umount "$MOUNT_POINT"
+    exit 1
+}
+ 
+mkdir -p "$TEST_DIR"
+log_info "Applying encryption policy to $TEST_DIR"
+fscryptctl set_policy --iv-ino-lblk-64 "$identifier" "$TEST_DIR" || {
+    log_fail "Failed to set policy on $TEST_DIR"
+    echo "$TESTNAME FAIL" > "$res_file"
+    umount "$MOUNT_POINT"
+    exit 1
+}
+ 
+log_info "Verifying encryption policy"
+fscryptctl get_policy "$TEST_DIR"
+ 
+log_info "Writing and reading test file"
+echo "hello" > "$TEST_FILE"
+sync
+echo 3 > /proc/sys/vm/drop_caches
+ 
+if grep -q "hello" "$TEST_FILE"; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed to verify data"
+    echo "$TESTNAME FAIL" > "$res_file"
+    umount "$MOUNT_POINT"
+    exit 1
+fi
+ 
+umount "$MOUNT_POINT"
+log_info "Unmounted $MOUNT_POINT and cleaned up."
+ 
+log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+exit 0
+


### PR DESCRIPTION
This pull request includes testcases and respective README.md file from two key suites Connectivity and Kernel, further details are given below:

**1. Encrypted ext4 Mount Test (shmbridge)**  
   - Validates encrypted ext4 filesystem setup using `fscryptctl`
   - Includes partition formatting, key generation, encryption policy application, and file I/O verification  
   - Location: `Runner/suites/Kernel/FunctionalArea/baseport/shmbridge/run.sh`

**2. Connectivity Test Scripts**
   - Adds standalone test scripts for Bluetooth and Ethernet
   - Each script performs dependency checks, interface status verification, and connectivity tests  
   - Includes clear logging and result reporting for integration into automated test frameworks

These additions enhance the kernel-level validation coverage for secure storage and basic connectivity.

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>