### PR TITLE
Add Probe_Failure_Check test to detect driver probe issues in dmesg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
 # Linux Feature Validation Framework
 
 ## Overview

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Probe_Failure_Check/Probe_Failure_Check_README.md
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Probe_Failure_Check/Probe_Failure_Check_README.md
@@ -1,0 +1,58 @@
+# Probe Failure Check Test
+
+This directory contains the **Probe_Failure_Check** test suite for the Qualcomm Linux Testkit. This test verifies that no device driver probe errors occurred during the most recent system boot.
+
+## Test Overview
+
+- **Test Name:** Probe_Failure_Check
+- **Purpose:** Scan the kernel log for any "probe failed", "failed to probe", or "probe error" messages, indicating a driver failed to initialize.
+- **Results:**
+  - On success: a result file `Probe_Failure_Check.res` is written with `Probe_Failure_Check PASS`.
+  - On failure: a `probe_failures.log` file is created containing the matching log entries, and `Probe_Failure_Check.res` is written with `Probe_Failure_Check FAIL`.
+
+## Files
+
+- **run.sh**: The main test script. Execute to perform the check.
+- **probe_failures.log**: (Generated on failure) Contains all discovered probe failure messages.
+- **Probe_Failure_Check.res**: Test result file with PASS or FAIL.
+
+## Usage
+
+1. Ensure the testkit environment is set up and the board has booted.
+2. From this directory, make sure the script is executable:
+   ```sh
+   chmod +x run.sh
+   ```
+3. Run the test:
+   ```sh
+   ./run.sh
+   ```
+4. Check the result:
+   - If the test passes, look for `Probe_Failure_Check.res` containing `PASS`.
+   - If the test fails, examine `probe_failures.log` for details.
+
+## Integration
+
+This test integrates with the top-level runner in `Runner/run-test.sh` and can be invoked as:
+
+```sh
+cd Runner
+./run-test.sh Probe_Failure_Check
+```
+
+The `.res` file will be parsed by CI/LAVA to determine overall test status.
+
+## Dependencies
+
+- **shell**: POSIX compliant (`/bin/sh`)
+- **journalctl** (optional): for collecting kernel logs. Falls back to `dmesg` or `/var/log/kern.log` if unavailable.
+- **grep**: for pattern matching.
+
+## Shellcheck Compliance
+
+The script is tested with `shellcheck` and disables SC2039 and SC1091 where sourcing dynamic paths.
+
+## License
+
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Probe_Failure_Check/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Probe_Failure_Check/run.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly source init_env and functestlib.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="Probe_Failure_Check"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+
+res_file="./$TESTNAME.res"
+log_file="./probe_failures.log"
+
+log_info "-----------------------------------------------------------------------------------------"
+log_info "------------------- Starting $TESTNAME Testcase ----------------------------"
+
+rm -f "$res_file" "$log_file"
+{
+    echo "Probe Failure Report - $(date)"
+    echo "--------------------------------------------------"
+} > "$log_file"
+
+if get_kernel_log 2>/dev/null | \
+   grep -iE '([[:alnum:]_.-]+:)?[[:space:]]*(probe failed|failed to probe|probe error)' \
+   >> "$log_file"; then
+    log_error "Probe failures detected; see $log_file"
+    log_fail "$TESTNAME : Probe failures found"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+else
+    rm -f "$log_file"
+    log_pass "$TESTNAME : No probe failures found"
+    echo "$TESTNAME PASS" > "$res_file"
+    exit 0
+fi

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -16,6 +16,20 @@ log_error() { log "ERROR" "$@"; }
 log_skip()  { log "SKIP"  "$@"; }
 log_warn()  { log "WARN"  "$@"; }
 
+# --- Kernel Log Collection ---
+get_kernel_log() {
+    if command -v journalctl >/dev/null 2>&1; then
+        journalctl -k -b
+    elif command -v dmesg >/dev/null 2>&1; then
+        dmesg
+    elif [ -f /var/log/kern.log ]; then
+        cat /var/log/kern.log
+    else
+        log_warn "No kernel log source found"
+        return 1
+    fi
+}
+
 # --- Dependency check ---
 check_dependencies() {
     missing=0


### PR DESCRIPTION
This patch introduces a new test case `Probe_Failure_Check` under the Kernel FunctionalArea suite. The script scans kernel logs (`journalctl` or `dmesg`) for signs of probe failures including:
 
- "probe failed"
- "failed to probe"
- "probe error"
 
Key Features:
- Compatible with both `journalctl` and `dmesg`-based systems
- Logs detailed output to `probe_failures.log`
- Structured to align with `[functestlib.sh](http://functestlib.sh/)` logging and result reporting
- Designed to run standalone or integrated in CI
 
This helps catch driver initialization issues that may otherwise go unnoticed in boot logs.

```
@vnarapar 
``` 