### PR TITLE
Removed checks for Modem PIL subsystem

### DIFF
--- a/Runner/suites/Kernel/FunctionalArea/baseport/remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/remoteproc/run.sh
@@ -40,7 +40,17 @@ log_info "-------------------Starting $TESTNAME Testcase------------------------
 log_info "=== Test Initialization ==="
 
 log_info "Getting the number of subsystems aavailable"
-subsystem_count=$(cat /sys/class/remoteproc/remoteproc*/state | wc -l)
+
+available_rprocs=$(cat /sys/class/remoteproc/remoteproc*/firmware)
+
+# Check if any line contains "modem"
+echo "$available_rprocs" | grep -q "modem"
+if [ $? -eq 0 ]; then
+    subsystem_count=$(echo "$available_rprocs" | grep -v "modem" | wc -l)
+else
+    # "modem" not found, count all lines
+    subsystem_count=$(echo "$available_rprocs" | wc -l)
+fi
 
 # Execute the command and get the output
 log_info "Checking if all the remoteprocs are in running state"


### PR DESCRIPTION
This commit fixes the issue with remoteproc test by removing the checks for modem as it is not supported for QCS6490