### PR TITLE
Add WiFi Connectivity Validation with Hybrid nmcli and wpa_supplicant Support

### DIFF
--- a/Runner/suites/Connectivity/WiFi/README_WiFi_Connectivity.md
+++ b/Runner/suites/Connectivity/WiFi/README_WiFi_Connectivity.md
@@ -1,0 +1,72 @@
+# WiFi Connectivity Validation
+
+## 📋 Overview
+
+This test validates WiFi functionality by:
+
+- Connecting to an access point (AP) using either `nmcli` or `wpa_supplicant`.
+- Verifying IP acquisition via DHCP.
+- Checking internet connectivity with a `ping` test.
+- Handling systemd network service status.
+- Supporting flexible SSID/password input via arguments, environment, or file.
+
+## ✅ SSID/PASSWORD Input Priority (Hybrid Approach)
+
+1. **Command-line arguments**:
+   ```sh
+   ./run.sh "MySSID" "MyPassword"
+   ```
+
+2. **Environment variables**:
+   ```sh
+   SSID_ENV=MySSID PASSWORD_ENV=MyPassword ./run.sh
+   ```
+
+3. **Fallback to `ssid_list.txt` file** (if above not set):
+   ```txt
+   MySSID MyPassword
+   ```
+
+## ⚙️ Supported Tools
+
+- Primary: `nmcli`
+- Fallback: `wpa_supplicant`, `udhcpc`, `ifconfig`
+
+Ensure these tools are available in the system before running the test. Missing tools are detected and logged as skipped/failure.
+
+## 🧪 Test Flow
+
+1. **Dependency check** – verifies necessary binaries are present.
+2. **Systemd services check** – attempts to start network services if inactive.
+3. **WiFi connect (nmcli or wpa_supplicant)** – based on tool availability.
+4. **IP assignment check** – validates `ifconfig wlan0` output.
+5. **Internet test** – pings `8.8.8.8` to confirm outbound reachability.
+6. **Result logging** – writes `.res` file and logs all actions.
+
+## 🧾 Output
+
+- `WiFi_Connectivity.res`: Contains `WiFi_Connectivity PASS` or `FAIL`.
+- Logs are printed using `log_info`, `log_pass`, and `log_fail` from `functestlib.sh`.
+
+## 📂 Directory Structure
+
+```
+WiFi/
+├── run.sh
+├── ssid_list.txt (optional)
+├── README.md
+```
+
+## 🌐 Integration (meta-qcom_PreMerge.yaml)
+
+Add this test with SSID parameters as follows:
+
+```yaml
+- name: WiFi_Connectivity
+  path: Runner/suites/Connectivity/WiFi
+  timeout:
+    minutes: 5
+  params:
+    SSID_ENV: "xxxx"
+    PASSWORD_ENV: "xxxx"
+```

--- a/Runner/suites/Connectivity/WiFi/run.sh
+++ b/Runner/suites/Connectivity/WiFi/run.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    . "$INIT_ENV"
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="WiFi"
+res_file="./$TESTNAME.res"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+
+log_info "-------------------------------------------------------------"
+log_info "------------------- Starting $TESTNAME Test -----------------"
+
+# Parse SSID and PASSWORD from args/env/file
+SSID="$1"
+PASSWORD="$2"
+
+if [ -z "$SSID" ] || [ -z "$PASSWORD" ]; then
+    SSID="${SSID:-$SSID_ENV}"
+    PASSWORD="${PASSWORD:-$PASSWORD_ENV}"
+fi
+
+if [ -z "$SSID" ] || [ -z "$PASSWORD" ]; then
+    if [ -f "./ssid_list.txt" ]; then
+        SSID=$(awk 'NR==1 {print $1}' ./ssid_list.txt)
+        PASSWORD=$(awk 'NR==1 {print $2}' ./ssid_list.txt)
+        log_info "Using SSID and password from ssid_list.txt"
+    else
+        log_fail "SSID and password not provided via argument, env, or file."
+        echo "$TESTNAME FAIL" > "$res_file"
+        exit 1
+    fi
+fi
+
+# Define cleanup function
+cleanup() {
+    log_info "Cleaning up WiFi test environment..."
+    pkill -f "wpa_supplicant -i wlan0" 2>/dev/null
+    rm -f /tmp/wpa_supplicant.conf
+    ifconfig wlan0 0.0.0.0 >/dev/null 2>&1
+}
+
+# Check required dependencies
+check_dependencies ifconfig ping
+check_systemd_services systemd-networkd.service || {
+    log_error "Network services check failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+}
+
+# Try nmcli first
+if command -v nmcli >/dev/null 2>&1; then
+    log_info "Trying to connect using nmcli..."
+    nmcli dev wifi connect "$SSID" password "$PASSWORD" 2>&1 | tee nmcli.log && {
+        log_pass "Connected to $SSID using nmcli"
+        IP=$(ifconfig wlan0 | awk '/inet / {print $2}')
+        log_info "IP Address: $IP"
+        if ping -c 3 -W 2 8.8.8.8 >/dev/null 2>&1; then
+            log_pass "Internet connectivity verified via ping"
+            echo "$TESTNAME PASS" > "$res_file"
+            cleanup
+            exit 0
+        else
+            log_fail "Ping test failed after nmcli connection"
+        fi
+    }
+fi
+
+# Fall back to wpa_supplicant + udhcpc
+if command -v wpa_supplicant >/dev/null 2>&1 && command -v udhcpc >/dev/null 2>&1; then
+    log_info "Falling back to wpa_supplicant + udhcpc"
+    WPA_CONF="/tmp/wpa_supplicant.conf"
+    {
+        echo "ctrl_interface=/var/run/wpa_supplicant"
+        echo "network={"
+        echo " ssid=\"$SSID\""
+        echo " key_mgmt=WPA-PSK"
+        echo " pairwise=CCMP TKIP"
+        echo " group=CCMP TKIP"
+        echo " psk=\"$PASSWORD\""
+        echo "}"
+    } > "$WPA_CONF"
+
+    killall wpa_supplicant 2>/dev/null
+    wpa_supplicant -B -i wlan0 -D nl80211 -c "$WPA_CONF" 2>&1 | tee wpa.log
+    sleep 4
+    udhcpc -i wlan0 >/dev/null 2>&1
+    sleep 2
+
+    IP=$(ifconfig wlan0 | awk '/inet / {print $2}')
+    if [ -n "$IP" ]; then
+        log_pass "Got IP via udhcpc: $IP"
+        if ping -c 3 -W 2 8.8.8.8 >/dev/null 2>&1; then
+            log_pass "Internet connectivity verified via ping"
+            echo "$TESTNAME PASS" > "$res_file"
+            cleanup
+            exit 0
+        else
+            log_fail "Ping test failed after wpa_supplicant connection"
+        fi
+    else
+        log_fail "Failed to acquire IP via udhcpc"
+    fi
+else
+    log_error "Neither nmcli nor wpa_supplicant+udhcpc available"
+fi
+
+log_fail "$TESTNAME : Test Failed"
+echo "$TESTNAME FAIL" > "$res_file"
+cleanup
+exit 1

--- a/Runner/suites/Connectivity/WiFi/ssid_list.txt
+++ b/Runner/suites/Connectivity/WiFi/ssid_list.txt
@@ -1,0 +1,2 @@
+#<SSID> <PASSWORD>
+#<SSID_1> <PASSWORD_1>

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -382,3 +382,27 @@ weston_start() {
     fi
 }
 
+# Get systemd service status
+check_systemd_services() {
+    for service in "$@"; do
+        if systemctl is-enabled "$service" >/dev/null 2>&1; then
+            if ! systemctl is-active --quiet "$service"; then
+                log_warn "$service is not running, attempting to start..."
+                systemctl start "$service"
+                sleep 2
+                if systemctl is-active --quiet "$service"; then
+                    log_pass "$service started successfully."
+                else
+                    log_fail "$service failed to start."
+                    return 1
+                fi
+            else
+                log_info "$service is already active."
+            fi
+        else
+            log_warn "$service is not enabled or not found"
+        fi
+    done
+    return 0
+}
+


### PR DESCRIPTION
This patch adds a new hardware validation test for WiFi connectivity under the FunctionalArea suite. Key features include:
 
- Hybrid connection method:
  - Primary: nmcli (NetworkManager CLI)
  - Fallback: wpa_supplicant + udhcpc
- Supports reading SSID/password from:
  - CLI arguments
  - Environment variables
  - Fallback file (ssid_list.txt)
- Validates network IP assignment and performs internet ping test
- Handles systemd-networkd.service check and recovery
- Includes cleanup of background processes (wpa_supplicant) and configuration files
 
This test is useful for CI environments where both NetworkManager and wpa_supplicant setups might exist across devices.

```
@mwasilew @vnarapar @qcom-anilyada 
``` 