### PR TITLE
Updated the qcom-next testplan with DCVS, scheduler tests

### DIFF
--- a/Runner/plans/qcom-next-ci-premerge.yaml
+++ b/Runner/plans/qcom-next-ci-premerge.yaml
@@ -52,4 +52,8 @@ run:
         - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/FunctionalArea/baseport/storage/storage.res || true
         - $PWD/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/wpss_remoteproc.res || true
+        - $PWD/suites/Kernel/FunctionalArea/DCVS/Freq_Scaling/run.sh || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/FunctionalArea/DCVS/Freq_Scaling/Freq_Scaling.res || true
+        - $PWD/suites/Kernel/FunctionalArea/Scheduler/CPU_affinity/run.sh || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/FunctionalArea/Scheduler/CPU_affinity/CPU_affinity.res || true
         - $PWD/utils/result_parse.sh

--- a/Runner/suites/Kernel/FunctionalArea/Scheduler/CPU_affinity/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/Scheduler/CPU_affinity/run.sh
@@ -39,7 +39,7 @@ log_info "-------- Starting $TESTNAME Functional Test --------"
 
 check_dependencies taskset top chrt zcat grep
 
-REQUIRED_CONFIGS="CONFIG_SCHED_DEBUG CONFIG_CGROUP_SCHED CONFIG_SMP"
+REQUIRED_CONFIGS="CONFIG_CGROUP_SCHED CONFIG_SMP"
 for config in $REQUIRED_CONFIGS; do
     if check_kernel_config "$config"; then
         log_pass "$config is enabled"


### PR DESCRIPTION
- Updated the qcom-next testplan with DCVS, scheduler tests
- Updated cpu affinity test to remove the debug  config check which is not required