### PR TITLE
Add exit codes for run.sh scripts

### DIFF
--- a/Runner/suites/Kernel/FunctionalArea/DCVS/Freq_Scaling/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/DCVS/Freq_Scaling/run.sh
@@ -86,9 +86,11 @@ kill $LOAD_PID
 if [ "$CURRENT_FREQ" -gt "$MIN_FREQ" ]; then
     log_pass "DCVS scaling appears functional. Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "DCVS did not scale as expected. Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 
 log_info "----------- Completed $TESTNAME Test ------------"

--- a/Runner/suites/Kernel/FunctionalArea/Scheduler/CPU_affinity/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/Scheduler/CPU_affinity/run.sh
@@ -83,9 +83,11 @@ log_info "Scheduling Policy: $SCHED_POLICY"
 if echo "$SCHED_POLICY" | grep -q "SCHED_OTHER"; then
     log_pass "Default scheduling policy detected. Test passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "Unexpected scheduling policy. Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 
 kill $TASK_PID

--- a/Runner/suites/Kernel/FunctionalArea/baseport/BWMON/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/BWMON/run.sh
@@ -83,8 +83,10 @@ done
 if $incremented; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file" 
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Buses/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Buses/run.sh
@@ -47,8 +47,10 @@ output=$(i2c-msm-test -v -D /dev/i2c-0 -l | grep "ret:1")
 if echo "$output" | grep -q "Reading"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > "$res_file" 
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1 
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/CPUFreq_Validation/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/CPUFreq_Validation/run.sh
@@ -109,9 +109,11 @@ log_info "=== Final Result ==="
 if [ "$overall_pass" -eq 0 ]; then
     log_pass "$TESTNAME: All policies passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME: One or more policies failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 
 rm -rf "$status_dir"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/GIC/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/GIC/run.sh
@@ -87,9 +87,11 @@ echo "$initial_count" | while read -r line; do
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
         echo "$TESTNAME PASS" > "$res_file"
+        exit 0
     else
         log_fail "$TESTNAME : Test Failed"
         echo "$TESTNAME FAIL" > "$res_file"
+        exit 1
     fi
 done
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/IPA/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/IPA/run.sh
@@ -55,10 +55,12 @@ if is_module_loaded "ipa"; then
     log_info "ipa module is loaded"
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_error "ipa module not listed in lsmod"
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 
 log_info "=== Cleanup ==="

--- a/Runner/suites/Kernel/FunctionalArea/baseport/IPCC/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/IPCC/run.sh
@@ -46,8 +46,10 @@ count=$(echo "$output" | grep -c "running")
 if [ $count -eq 4 ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Interrupts/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Interrupts/run.sh
@@ -87,9 +87,11 @@ echo "$initial_count" | while read -r line; do
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
 	echo "$TESTNAME PASS" > "$res_file"
+    exit 0
     else
         log_fail "$TESTNAME : Test Failed"
 	echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
     fi
 done
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/MEMLAT/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/MEMLAT/run.sh
@@ -85,8 +85,10 @@ fi
 if $incremented; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/RMNET/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/RMNET/run.sh
@@ -55,10 +55,12 @@ if is_module_loaded "rmnet"; then
     log_info "rmnet module is loaded"
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_error "rmnet module not listed in lsmod"
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 
 log_info "=== Cleanup ==="

--- a/Runner/suites/Kernel/FunctionalArea/baseport/Timer/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/Timer/run.sh
@@ -51,8 +51,10 @@ OUTPUT=$($BINARY_PATH)
 if echo "${OUTPUT}" | grep "pass:7"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/USBHost/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/USBHost/run.sh
@@ -62,9 +62,11 @@ if [ "$device_count" -eq 0 ]; then
 elif [ "$non_hub_count" -eq 0 ]; then
     log_fail "$TESTNAME : Test Failed - Only USB hubs detected, no functional USB devices."
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 else
     log_pass "$TESTNAME : Test Passed - $non_hub_count non-hub USB device(s) found."
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/adsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/adsp_remoteproc/run.sh
@@ -89,3 +89,4 @@ echo "adsp PASS"
 log_pass "adsp PASS"
 echo "$TESTNAME PASS" > "$res_file"
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+exit 0

--- a/Runner/suites/Kernel/FunctionalArea/baseport/cdsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/cdsp_remoteproc/run.sh
@@ -87,3 +87,4 @@ echo "cdsp PASS"
 log_pass "cdsp PASS"
 echo "$TESTNAME PASS" > "$res_file" 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+exit 0

--- a/Runner/suites/Kernel/FunctionalArea/baseport/hotplug/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/hotplug/run.sh
@@ -94,8 +94,10 @@ check_cpu_status | tee -a "$LOG_FILE"
 if [ "$test_passed" = true ]; then
         log_pass "$TESTNAME : Test Passed"
         echo "$TESTNAME PASS" > "$res_file"
+        exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/iommu/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/iommu/run.sh
@@ -78,9 +78,11 @@ check_runtime_behavior || pass=false
 if $pass; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/irq/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/irq/run.sh
@@ -85,9 +85,11 @@ echo "$initial_count" | while read -r line; do
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
 	echo "$TESTNAME PASS" > "$res_file"
+    exit 0
     else
         log_fail "$TESTNAME : Test Failed"
 	echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
     fi
 done
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/kaslr/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/kaslr/run.sh
@@ -46,8 +46,10 @@ value=$(echo $output | awk '{print $1}')
 if [ $value != "0000000000000000" ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/pinctrl/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/pinctrl/run.sh
@@ -48,8 +48,10 @@ output=$(ls /sys/kernel/debug/pinctrl)
 if [ -z "$output" ]; then
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 else
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/qcrypto/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/qcrypto/run.sh
@@ -50,8 +50,10 @@ echo "${KCAPI_RET}"
 if [ ${KCAPI_RET} -eq 0 ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 1
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 0
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/remoteproc/run.sh
@@ -64,8 +64,10 @@ log_info "rproc subsystems in running state : $count, expected subsystems : $sub
 if [ $count -eq $subsystem_count ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh
@@ -52,8 +52,10 @@ value=$(cat /tmp/rngtest_value.txt)
 if [ "$value" -lt 10 ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/smmu/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/smmu/run.sh
@@ -46,8 +46,10 @@ OUTPUT=$(dmesg | grep iommu)
 if [ -z "$OUTPUT" ]; then
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 else
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/storage/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/storage/run.sh
@@ -64,8 +64,10 @@ fi
 if [ -f /tmp/a.txt ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/watchdog/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/watchdog/run.sh
@@ -43,9 +43,11 @@ if [ -e /dev/watchdog ]; then
     log_pass "/dev/watchdog node is present."
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "/dev/watchdog node is not present."
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 log_info "-------------------Completed $TESTNAME Testcase---------------------------"

--- a/Runner/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh
@@ -84,6 +84,7 @@ if echo start > "$wpss_path/state" 2>/dev/null; then
     if [ "$final_state" = "running" ]; then
         log_pass "WPSS remoteproc started successfully"
         echo "$TESTNAME PASS" > "$res_file"
+        exit 0
     else
         log_fail "WPSS remoteproc failed to start, state: $final_state"
         echo "$TESTNAME FAIL" > "$res_file"

--- a/Runner/suites/Multimedia/Audio/AudioPlayback/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/run.sh
@@ -81,10 +81,12 @@ if [ "$ret" -eq 0 ] || [ "$ret" -eq 124 ] ; then
     log_pass "Playback completed or timed out (ret=$ret) as expected."
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$RESULT_FILE"
+    exit 0
 else
     log_fail "$TESTBINARY playback exited with error code $ret"
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$RESULT_FILE"
+    exit 1
 fi
 
 log_info "See $LOGDIR/playback_stdout.log, dmesg_before/after.log, syslog_before/after.log for debug details"

--- a/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
@@ -64,10 +64,12 @@ if ([ "$ret" -eq 0 ] || [ "$ret" -eq 124 ]) && [ -s "$RECORD_FILE" ]; then
     log_pass "Recording completed or timed out (ret=$ret) as expected and output file exists."
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$RESULT_FILE"
+    exit 0
 else
     log_fail "parec failed (status $ret) or recorded file missing/empty"
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$RESULT_FILE"
+    exit 1
 fi
 
 log_info "See $LOGDIR/parec_stdout.log, dmesg_before/after.log, syslog_before/after.log for debug details"

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
@@ -69,9 +69,11 @@ echo $output
 if echo "$output" | grep -q "All tests completed successfully"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME : PASS" > "$RESULT_FILE"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME : FAIL" > "$RESULT_FILE"
+    exit 1
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Multimedia/DSP_AudioPD/run.sh
+++ b/Runner/suites/Multimedia/DSP_AudioPD/run.sh
@@ -64,9 +64,11 @@ check_stack_trace() {
 if check_stack_trace "$PID"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
 fi
 
 log_info "Kill the process"

--- a/Runner/suites/Multimedia/Graphics/KMSCube/run.sh
+++ b/Runner/suites/Multimedia/Graphics/KMSCube/run.sh
@@ -59,10 +59,12 @@ if kmscube --count="$FRAME_COUNT" > "$LOG_FILE" 2>&1; then
     else
         log_fail "$TESTNAME : Expected output not found (Rendered $EXPECTED_FRAMES frames)"
         echo "$TESTNAME FAIL" > "$RES_FILE"
+        exit 1
     fi
 else
     log_fail "$TESTNAME : Execution failed (non-zero exit code)"
     echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 1
 fi
 
 if [ "$weston_was_running" -eq 1 ]; then

--- a/Runner/suites/Multimedia/Graphics/weston-simple-egl/run.sh
+++ b/Runner/suites/Multimedia/Graphics/weston-simple-egl/run.sh
@@ -69,9 +69,11 @@ count=$(grep -i -o "5 seconds" "$LOG_FILE" | wc -l)
 if [ "$count" -ge 5 ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$RES_FILE"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 1
 fi
 
 log_info "------------------- Completed $TESTNAME Testcase ------------------------"

--- a/Runner/suites/Multimedia/Video/iris_v4l2_video_decode/run.sh
+++ b/Runner/suites/Multimedia/Video/iris_v4l2_video_decode/run.sh
@@ -50,9 +50,11 @@ iris_v4l2_test --config "${test_path}/h264Decoder.json" --loglevel 15 >> "${test
 if grep -q "SUCCESS" "${test_path}/video_dec.txt"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$test_path/$TESTNAME.res"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    exit 1
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Multimedia/Video/iris_v4l2_video_encode/run.sh
+++ b/Runner/suites/Multimedia/Video/iris_v4l2_video_encode/run.sh
@@ -50,9 +50,11 @@ iris_v4l2_test --config "${test_path}/h264Encoder.json" --loglevel 15 >> "${test
 if grep -q "SUCCESS" "${test_path}/video_enc.txt"; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$test_path/$TESTNAME.res"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed"
     echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+    exit 1
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"


### PR DESCRIPTION
This change adds `exit 0` for success and `exit 1` for failure in the run.sh scripts