### PR TITLE
This PR disables the Semgrep static analysis step from the CI workflow.

### DIFF
--- a/.github/workflows/preflight-checker-workflow.yml
+++ b/.github/workflows/preflight-checker-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     uses: qualcomm-linux/qli-actions/.github/workflows/multi-checker.yml@main
     with:
         repolinter: true # default: true
-        semgrep: true # default: true
+        semgrep: false # default: true
         copyright-license-detector: true # default: true
         pr-check-emails: true # default: true
 


### PR DESCRIPTION
### Summary
 
This PR disables the Semgrep static analysis step from the CI workflow.
 
### Reason
 
- Current Semgrep rules are generating false positives or noise not relevant to the current codebase.