### PR TITLE
CI: Fix shell script executable permission check in GitHub Actions

### DIFF
--- a/.github/workflows/check-executable-permissions.yml
+++ b/.github/workflows/check-executable-permissions.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Detect missing executable permissions on shell scripts
         run: |
           # Find all .sh and run.sh scripts without +x
-          BAD=$(find . -type f -name 'run.sh' -o -name '*.sh' ! -perm -u=x)
+          BAD=$(find . -type f \( -name "*.sh" -o -name "run.sh" \) ! -perm -u=x)
           if [ -n "$BAD" ]; then
             echo "::error file=run.sh,line=1::❌ Some shell scripts are missing executable permissions. This can break CI and LAVA. Please fix before merging."
             echo "::error file=run.sh,line=2::To fix, run: find . -name '*.sh' -o -name 'run.sh' | xargs chmod +x && git add . && git commit -m 'Fix: restore executable bits on scripts' && git push"


### PR DESCRIPTION
### Summary
 
This PR fixes the shell script executable permissions check in the CI workflow. The previous find command incorrectly matched all files, resulting in false error reports.
 
### Changes
- Updated the find command in the GitHub Actions workflow to properly group name patterns and ensure only shell scripts missing user-execute permission are flagged.
- No functional changes to the repo content, only the CI detection logic is corrected.
 
### Impact
 
This change will:
- Prevent false CI failures due to incorrect file matching.
- Ensure only actual permission issues are flagged in PR checks.
 
No script files were modified. This is a workflow fix for CI reliability.