### PR TITLE
Add PCIe test script with capability checks and result logging

### DIFF
--- a/Runner/suites/Kernel/FunctionalArea/baseport/PCIe/README.md
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/PCIe/README.md
@@ -1,0 +1,48 @@
+# PCIe Validation Test
+© Qualcomm Technologies, Inc. and/or its subsidiaries.  
+SPDX-License-Identifier: BSD-3-Clause-Clear
+## Overview
+This test case validates the PCIe interface on the target device by checking for the presence of key PCIe attributes using the `lspci -vvv` command. It ensures that the PCIe subsystem is correctly enumerated and functional
+### The test checks for:
+- Presence of **Device Tree Node**
+- Availability of **PCIe Capabilities**
+- Binding of a **Kernel Driver**
+
+These checks help confirm that the PCIe root port is properly initialized and ready for use 
+## Usage
+### Instructions:
+1. **Copy the test suite to the target device** using `scp` or any preferred method.
+2. **Navigate to the test directory** on the target device.
+3. **Run the test script** using the test runner or directly.
+---
+### Quick Example
+```bash
+git clone <this-repo>
+cd <this-repo>
+scp -r common Runner user@target_device_ip:<path-on-device>
+ssh user@target_device_ip
+cd <path-on-device>/Runner && ./run-test.sh PCIe
+```
+---
+### Prerequisites
+1. `lspci` must be available on the target device 
+2. PCIe interface must be exposed and initialized
+3. Root access may be required depending on system configuration
+---
+## Result Format
+Test result will be saved in `PCIe.res` as:  
+## Output
+A .res file is generated in the same directory:
+`PCIe PASS`  OR   `PCIe FAIL`
+## Sample Log
+```
+[INFO] 1980-01-06 00:43:54 - -----------------------------------------------------------------------------------------
+[INFO] 1980-01-06 00:43:54 - -------------------Starting PCIe Testcase----------------------------
+[INFO] 1980-01-06 00:43:54 - === Test Initialization ===
+[INFO] 1980-01-06 00:43:54 - Checking if required tools are available
+[INFO] 1980-01-06 00:43:54 - Running PCIe
+[INFO] 1980-01-06 00:43:54 - DT node is present
+[INFO] 1980-01-06 00:43:54 - Yes, 'Capabilities:' is found
+[INFO] 1980-01-06 00:43:54 - Driver is loaded
+[PASS] 1980-01-06 00:43:54 - PCIe : Test Passed
+```

--- a/Runner/suites/Kernel/FunctionalArea/baseport/PCIe/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/PCIe/run.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="PCIe"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
+log_info "Checking if required tools are available"
+
+check_dependencies "lspci"
+log_info "Running PCIe "
+lspci_output=$(lspci -vvv)
+
+missing=""
+
+if echo "$lspci_output" | grep -q "Device tree node:"; then
+    log_info "DT node is present"
+else
+    log_warn "DT node is not present"
+    missing=1
+fi
+
+if echo "$lspci_output" | grep -q "Capabilities:"; then
+    log_info "Yes, 'Capabilities:' is found"
+else
+    log_warn "No, 'Capabilities:' is missing"
+    missing=1
+fi
+
+if echo "$lspci_output" | grep -q "Kernel driver in use:"; then
+    log_info "Driver is loaded"
+else
+    log_warn "Driver is not loaded"
+    missing=1
+fi
+
+if [ -z "$missing" ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+    exit 0
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+fi
+
+log_info "-------------------Completed $TESTNAME Testcase----------------------------"


### PR DESCRIPTION
This patch introduces a new PCIe test script that validates the presence of key PCIe attributes using `lspci -vvv`. It checks for:

- Device tree node
- Capabilities
- Kernel driver in use

The script logs detailed info and warnings for each check and writes a simple PASS/FAIL result to a .res file. It follows the existing test framework structure and uses functestlib logging utilities.