### PR TITLE
Adding Camera RDI validation using YAVTA Test Scripts

### DIFF
--- a/Runner/suites/Multimedia/Camera/v4l2_camera_RDI_dump/README_Camera.md
+++ b/Runner/suites/Multimedia/Camera/v4l2_camera_RDI_dump/README_Camera.md
@@ -1,0 +1,88 @@
+# Camera RDI dump validation using YAVTA App Test Scripts for Qualcomm Linux based platform (Yocto)
+
+## Overview
+
+Camera scripts automates the Camera RDI dump validation using YAVTA App on the Qualcomm Linux based platform running a Yocto-based Linux system.It utilizes yavta and media-ctl binaries which is publicly available 
+## Features
+
+- Camera RDI dump validation using YAVTA App
+- Compatible with Yocto-based root filesystem
+
+## Prerequisites
+
+Ensure the following components are present in the target Yocto build:
+
+- `yavta and media-ctl` (available in /usr/bin/) 
+- To find the exact /dev/media node for our camss driver
+  ```
+  media-ctl -p -d /dev/media 'y' | grep camss ['y' has to be replaced with media0 or media1 eg: /dev/media0, /dev/media1]
+
+  Output will be # driver   qcom-camss [for probed media]
+  ```
+- To find list avaliable device files
+  ```
+  v4l2-ctl --list-devices
+  ```
+  Output will be # video0 video1 video2 ...
+- /dev/video# linking to RDI port is dynamic not fixed , user need to identify the correct video device file(by trail and error) to use in yavta RDI dump command
+
+  'y' has to be replaced eg: /dev/video0, /dev/video1 depending on RDI port configured..
+  ```
+  yavta -B capture-mplane -c -I -n 5 -f SRGGB10P -s 4056x3040 -F /dev/video'y' --capture=5 --file='frame-#.bin'  
+  ```
+- camera_node_finder function dynamically detects the active media node and the corresponding video node (e.g., /dev/mediaX and /dev/videoY) for the msm_vfe0_rdi0 entity, enabling automated and adaptable camera pipeline configuration.
+  
+## Directory Structure
+
+```bash
+Runner/
+├── suites/
+│   ├── Multimedia/
+│   │   ├── Camera/
+│   │   │   ├── v4l2_camera_RDI_dump
+│   │   │   │   ├── run.sh
+│   │   │   ├── README_Camera.md
+│   │   │   │    
+```
+
+## Usage
+
+1. Copy repo to Target Device: Use scp to transfer the scripts from the host to the target device. The scripts should be copied to any directory on the target device.
+
+2. Verify Transfer: Ensure that the repo have been successfully copied to any directory on the target device.
+
+3. Run Scripts: Navigate to the directory where these files are copied on the target device and execute the scripts as needed.
+
+Run a specific test using:
+---
+Quick Example
+```
+git clone <this-repo>
+cd <this-repo>
+scp -r Runner user@target_device_ip:<Path in device>
+ssh user@target_device_ip 
+cd <Path in device> && chmod +x run.sh && ./run.sh 
+```
+Sample output:
+```
+sh-5.2# cd <Path in device>
+sh-5.2# ./run.sh
+[INFO] 2025-01-09 13:45:22 - -----------------------------------------------------------------------------------------
+[INFO] 2025-01-09 13:45:22 - -------------------Starting v4l2_camera_RDI_dump Testcase----------------------------
+[INFO] 2025-01-09 13:45:22 - === Test Initialization ===
+[INFO] 2025-01-09 13:45:22 - Checking if dependency binary is available
+[INFO] 2025-01-09 13:45:22 - -------------------Camera commands execution start----------------------------
+Device /dev/v4l-subdev0 opened.
+Control 0x009f0903 set to 0, is 0
+Device /dev/v4l-subdev0 opened.
+Control 0x009f0903 set to 9, is 9
+[PASS] 2025-01-09 13:45:23 - v4l2_camera_RDI_dump : Test Passed
+[INFO] 2025-01-09 13:45:23 - -------------------Completed v4l2_camera_RDI_dump Testcase----------------------------
+```
+3. Results will be available in the `Runner/suites/Multimedia/Camera/v4l2_camera_RDI_dump/` directory under each usecase folder.
+
+## Notes
+
+- The script does not take any arguments.
+- It validates the presence of required libraries before executing tests.
+- If any critical tool is missing, the script exits with an error message.

--- a/Runner/suites/Multimedia/Camera/v4l2_camera_RDI_dump/media_topology.conf
+++ b/Runner/suites/Multimedia/Camera/v4l2_camera_RDI_dump/media_topology.conf
@@ -1,0 +1,33 @@
+# media_topology.conf
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Device paths
+MEDIA_DEV="$MEDIA_NODE"
+SUBDEV="/dev/v4l-subdev0"
+VIDEO_DEV="$VIDEO_NODE"
+
+# Format settings
+FORMAT="SRGGB10"
+RESOLUTION="1920x1080"
+FIELD="none"
+
+# Control values
+STREAM_OFF=0
+STREAM_ON=9
+
+# Command templates
+RESET_CMD='media-ctl -d "$MEDIA_DEV" --reset'
+
+FORMAT_TPG='media-ctl -d "$MEDIA_DEV" -V "\"msm_tpg0\":0[fmt:$FORMAT/$RESOLUTION field:$FIELD]"'
+FORMAT_CSID='media-ctl -d "$MEDIA_DEV" -V "\"msm_csid0\":0[fmt:$FORMAT/$RESOLUTION field:$FIELD]"'
+FORMAT_VFE='media-ctl -d "$MEDIA_DEV" -V "\"msm_vfe0_rdi0\":0[fmt:$FORMAT/$RESOLUTION field:$FIELD]"'
+
+LINK_TPG_CSID='media-ctl -d "$MEDIA_DEV" -l "\"msm_tpg0\":1->\"msm_csid0\":0[1]"'
+LINK_CSID_VFE='media-ctl -d "$MEDIA_DEV" -l "\"msm_csid0\":1->\"msm_vfe0_rdi0\":0[1]"'
+
+DISABLE_STREAM='yavta --no-query -w "0x009f0903 $STREAM_OFF" "$SUBDEV"'
+ENABLE_STREAM='yavta --no-query -w "0x009f0903 $STREAM_ON" "$SUBDEV"'
+
+CAPTURE_CMD='yavta -B capture-mplane -n 5 -f "${FORMAT}P" -s "$RESOLUTION" "$VIDEO_DEV" --capture=10 --file="frame-#.bin" >> "${test_path}/Camera_RDI_Test.txt"'
+

--- a/Runner/suites/Multimedia/Camera/v4l2_camera_RDI_dump/run.sh
+++ b/Runner/suites/Multimedia/Camera/v4l2_camera_RDI_dump/run.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# --------- Robustly source init_env and functestlib.sh ----------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    . "$INIT_ENV"
+fi
+. "$TOOLS/functestlib.sh"
+# ---------------------------------------------------------------
+
+TESTNAME="v4l2_camera_RDI_dump"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+
+log_info "-----------------------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
+
+log_info "Checking if dependency binary is available"
+check_dependencies yavta media-ctl
+
+# To find the exact probed media and video nodes for camera
+camera_node_finder
+
+log_info "-------------------Camera commands execution start----------------------------"
+
+# Load configuration
+source "$test_path/media_topology.conf"
+
+
+# Execute commands using variables
+eval $RESET_CMD
+eval $DISABLE_STREAM
+eval $FORMAT_TPG
+eval $FORMAT_CSID
+eval $FORMAT_VFE
+eval $LINK_TPG_CSID
+eval $LINK_CSID_VFE
+eval $ENABLE_STREAM
+ 
+# Removing the previous execution logs 
+rm -rf "${test_path}"/Camera_RDI_Test.txt
+rm -rf "${test_path}"/v4l2_camera_RDI_dump.res
+rm -rf "${test_path}"/*.bin
+ 
+# Start capture using the dynamic video node
+eval $CAPTURE_CMD
+
+if grep -q "Captured 10 frames" "${test_path}/Camera_RDI_Test.txt"; then
+    log_pass "$TESTNAME : Test Passed"
+	echo "$TESTNAME PASS" > "$test_path/$TESTNAME.res"
+else
+    log_fail "$TESTNAME : Test Failed"
+	echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+fi
+
+log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -391,3 +391,45 @@ weston_start() {
     fi
 }
 
+#Function to find the probed media and video node for camera
+camera_node_finder() {
+    # Step 1: Find the media node with qcom-camss driver
+    for media in /dev/media*; do
+        if media-ctl -p -d "$media" 2>/dev/null | grep -q "driver[[:space:]]*qcom-camss"; then
+            MEDIA_NODE="$media"
+            break
+        fi
+    done
+
+    if [ -z "$MEDIA_NODE" ]; then
+        echo "No media device with qcom-camss driver found."
+        exit 1
+    fi
+
+    export MEDIA_NODE
+
+    # Step 2: Get the entity number for msm_vfe0_video0
+    ENTITY_LINE=$(media-ctl -p -d "$MEDIA_NODE" 2>/dev/null | grep -E 'entity [0-9]+: msm_vfe0_video0')
+    ENTITY_NUM=$(echo "$ENTITY_LINE" | grep -oP 'entity \K[0-9]+')
+
+    if [ -z "$ENTITY_NUM" ]; then
+        echo "Could not find entity for msm_vfe0_video0."
+        exit 1
+    fi
+
+    # Step 3: Extract the device node name from that entity
+    VIDEO_NODE=$(media-ctl -p -d "$MEDIA_NODE" 2>/dev/null | \
+        awk -v entity="entity $ENTITY_NUM:" '
+        $0 ~ entity { found=1; next }
+        found && /device node name/ {
+            print $NF
+            exit
+        }')
+
+    if [ -n "$VIDEO_NODE" ]; then
+        export VIDEO_NODE
+    else
+        echo "Could not find video node for msm_vfe0_video0."
+        exit 1
+    fi
+}


### PR DESCRIPTION
- Introduced automated test scripts for validating camera RDI dumps using YAVTA and media-ctl
- Compatible with Qualcomm Yocto-based Linux systems
- Includes run.sh for test execution and README_Camera.md for usage instructions :x