### PR TITLE
Add explicit permissions section to GitHub Actions workflows

### DIFF
--- a/.github/workflows/preflight-checker-workflow.yml
+++ b/.github/workflows/preflight-checker-workflow.yml
@@ -6,6 +6,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+ contents: read
+ security-events: write
+
 jobs:
   checker:
     uses: qualcomm-linux/qli-actions/.github/workflows/multi-checker.yml@main


### PR DESCRIPTION
This PR updates the GitHub Actions workflows under `.github/workflows/` to include an explicit `permissions` block. This change improves security posture and follows GitHub's best practices, especially when using reusable workflows or third-party actions.

Specifically:
- Sets minimal required permissions for actions
- Prevents workflows from running with unnecessarily elevated privileges
- Prepares for compatibility with future GitHub enforcement policies