### PR TITLE
suites: Multimedia/Graphics/KMSCube: fix TESTNAME value

### DIFF
--- a/Runner/suites/Multimedia/Graphics/KMSCube/run.sh
+++ b/Runner/suites/Multimedia/Graphics/KMSCube/run.sh
@@ -27,7 +27,7 @@ fi
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
 
-TESTNAME="kmscube"
+TESTNAME="KMSCube"
 FRAME_COUNT=999
 EXPECTED_FRAMES=$((FRAME_COUNT - 1))
 test_path=$(find_test_case_by_name "$TESTNAME")


### PR DESCRIPTION
Fix value of TESTNAME variable in KMSCube test. The value of the variable in the script didn't match the value in the meta-qcom-premerge test plan.