### PR TITLE
CI: Add ShellCheck linting & script permission enforcement

### DIFF
--- a/.github/workflows/check-executable-permissions.yml
+++ b/.github/workflows/check-executable-permissions.yml
@@ -1,10 +1,14 @@
 name: Enforce Script Executable Permissions
 
 on:
-  pull_request:
+  pull_request_target:
+    branches: [ "main" ]
     paths:
       - '**/run.sh'
       - '**/*.sh'
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   permissions:

--- a/.github/workflows/preflight-checker-workflow.yml
+++ b/.github/workflows/preflight-checker-workflow.yml
@@ -15,7 +15,7 @@ jobs:
     uses: qualcomm-linux/qli-actions/.github/workflows/multi-checker.yml@main
     with:
         repolinter: true # default: true
-        semgrep: false # default: true
+        semgrep: true # default: true
         copyright-license-detector: true # default: true
         pr-check-emails: true # default: true
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,6 +1,11 @@
 name: Shell Lint
 
-on: [pull_request, push]
+on:
+  pull_request_target:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   shellcheck:


### PR DESCRIPTION
This PR introduces two critical CI checks for maintaining shell script quality:
 
ShellCheck Linting: Ensures POSIX-compliant, clean scripts with exclusions for known safe cases. Runs on PRs, pushes to main, and manual dispatch.