### PR TITLE
Add gdsp_remoteproc test script and README for Lemans platform

### DIFF
--- a/Runner/suites/Kernel/Baseport/gdsp_remoteproc/README.md
+++ b/Runner/suites/Kernel/Baseport/gdsp_remoteproc/README.md
@@ -1,0 +1,69 @@
+# gdsp_remoteproc Test
+
+© Qualcomm Technologies, Inc. and/or its subsidiaries.  
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+
+This test case validates the functionality of the **GPDSP (General Purpose DSP)** firmware loading and control on the **Lemans** platform. It specifically targets:
+
+- `gpdsp0`
+- `gpdsp1`
+
+The script ensures that each GPDSP remote processor:
+- Is currently running
+- Can be stopped successfully
+- Can be restarted and returns to the running state
+
+This is essential for verifying the stability and control of DSP subsystems on Qualcomm-based platforms.
+
+## Usage
+
+### Instructions
+
+1. **Transfer the Script**: Use `scp` or any file transfer method to copy the script to the Lemans target device.
+2. **Navigate to the Script Directory**: SSH into the device and go to the directory where the script is located.
+3. **Run the Script**:
+   ```sh
+   ./run.sh
+   ```
+   ---
+   #### Quick Example
+```
+git clone <this-repo>
+cd <this-repo>
+scp -r common Runner user@target_device_ip:<Path in device>
+ssh user@target_device_ip
+cd <Path in device>/Runner && ./run-test.sh gdsp_remoteproc
+```
+---
+## Prerequisites
+1. The device must expose `/sys/class/remoteproc/remoteproc*/firmware and /state` interfaces.
+2. Root access may be required to write to remoteproc state files.
+3. The firmware names must include gpdsp0 and gpdsp1.
+ ---
+ ## Result Format
+Test result will be saved in `gdsp_remoteproc.res` as:  
+## Output
+A .res file is generated in the same directory:
+
+`gdsp_remoteproc PASS`  OR   `gdsp_remoteproc FAIL`
+
+## Sample Log
+```
+Output
+[INFO] 1970-01-01 00:52:35 - -----------------------------------------------------------------------------------------
+[INFO] 1970-01-01 00:52:35 - -------------------Starting gdsp_remoteproc Testcase----------------------------
+[INFO] 1970-01-01 00:52:35 - === Test Initialization ===
+[INFO] 1970-01-01 00:52:35 - Processing gpdsp0
+[PASS] 1970-01-01 00:52:35 - gpdsp0 remoteproc validated as running
+[PASS] 1970-01-01 00:52:35 - gpdsp0 stop successful
+[INFO] 1970-01-01 00:52:35 - Restarting gpdsp0
+[PASS] 1970-01-01 00:52:35 - gpdsp0 PASS
+[INFO] 1970-01-01 00:52:35 - Processing gpdsp1
+[PASS] 1970-01-01 00:52:35 - gpdsp1 remoteproc validated as running
+[PASS] 1970-01-01 00:52:35 - gpdsp1 stop successful
+[INFO] 1970-01-01 00:52:35 - Restarting gpdsp1
+[PASS] 1970-01-01 00:52:35 - gpdsp1 PASS
+[INFO] 1970-01-01 00:52:35 - -------------------Completed gdsp_remoteproc Testcase----------------------------
+```

--- a/Runner/suites/Kernel/Baseport/gdsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/Baseport/gdsp_remoteproc/run.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+ 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+ 
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+ 
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+ 
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+ 
+TESTNAME="gdsp_remoteproc"
+res_file="./$TESTNAME.res"
+LOG_FILE="./$TESTNAME.log"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+ 
+log_info "-----------------------------------------------------------------------------------------" 
+log_info "------------------- Starting $TESTNAME Testcase ----------------------------" 
+log_info "=== Test Initialization ===" 
+ 
+overall_result="PASS"
+ 
+handle_failure() {
+     name="$1"
+     msg="$2"
+     res_file="$3"
+     log="$4"
+    log_fail "$msg" "$log"
+    echo "$name FAIL" > "$res_file"
+    overall_result="FAIL"
+}
+ 
+for gdsp_firmware in gpdsp0 gpdsp1; do
+    log_info "Processing $gdsp_firmware" 
+    indiv_res_file="./$gdsp_firmware.res"
+ 
+    if ! validate_remoteproc_running "$gdsp_firmware" "$LOG_FILE" 15 2; then
+        handle_failure "$gdsp_firmware" "$gdsp_firmware remoteproc validation failed" "$indiv_res_file" "$LOG_FILE"
+        continue
+    fi
+ 
+    log_pass "$gdsp_firmware remoteproc validated as running" 
+ 
+    rproc_path=$(get_remoteproc_path_by_firmware "$gdsp_firmware")
+    if [ -z "$rproc_path" ]; then
+        handle_failure "$gdsp_firmware" "Remoteproc path not found for $gdsp_firmware" "$indiv_res_file" "$LOG_FILE"
+        continue
+    fi
+ 
+    log_info "Stopping $gdsp_firmware at $rproc_path" 
+    if ! stop_remoteproc "$rproc_path"; then
+        handle_failure "$gdsp_firmware" "$gdsp_firmware stop failed" "$indiv_res_file" "$LOG_FILE"
+        continue
+    fi
+    log_pass "$gdsp_firmware stop successful" 
+ 
+    log_info "Restarting $gdsp_firmware at $rproc_path" 
+    if ! start_remoteproc "$rproc_path"; then
+        handle_failure "$gdsp_firmware" "$gdsp_firmware start failed" "$indiv_res_file" "$LOG_FILE"
+        continue
+    fi
+ 
+    log_pass "$gdsp_firmware PASS" 
+    echo "$gdsp_firmware PASS" > "$indiv_res_file"
+done
+ 
+log_info "$TESTNAME $overall_result" 
+echo "$TESTNAME $overall_result" > "$res_file"
+log_info "------------------- Completed $TESTNAME Testcase ----------------------------" 
+ 
+if [ "$overall_result" = "FAIL" ]; then
+    exit 1
+else
+    exit 0
+fi
+ 


### PR DESCRIPTION
This PR introduces a new test script gdsp_remoteproc.sh designed to validate the remoteproc functionality of gpdsp0 and gpdsp1 on the LeMans platform. It also includes a detailed README.md to document the test's purpose, usage, and expected output.

What's Included
1.gdsp_remoteproc.sh: Shell script that Identifies the correct remoteproc entries for gpdsp0 and gpdsp1
2.Verifies initial running state
3.Performs stop and restart operations
4.Confirms successful return to the running state
5. Logs results in a standardized format
6. README.md

Target Platform
LeMans

Notes
This test is specific to LeMans and may require adaptation for other platforms.
Root access is required to control remoteproc state.