### PR TITLE
Add stm_cpu trace test script  and README documentation

### DIFF
--- a/Runner/suites/Kernel/Baseport/stm_cpu/README.md
+++ b/Runner/suites/Kernel/Baseport/stm_cpu/README.md
@@ -1,0 +1,64 @@
+# STM CPU Trace  Validation test
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+This test case validates the System Trace Macrocell (STM) functionality on the target device by configuring the STM source, enabling tracing, and capturing trace data. It ensures that the STM infrastructure is correctly initialized and capable of generating trace output.
+
+## Test Performs :
+1. Verifies presence of required kernel configurations
+2. Mounts **configfs** and **debugfs**
+3. Loads STM-related kernel modules
+4. configures STM policy directories
+5. Enables ETF sink and STM source
+6. Captures and validates trace output
+
+## Usage
+Instructions:
+1. **Copy repo to Target Device**: Use `scp` to transfer the scripts from the host to the target device. The scripts should be copied to any directory on the target device.
+2. **Verify Transfer**: Ensure that the repo has been successfully copied to the target device.
+3. **Run Scripts**: Navigate to the directory where these files are copied on the target device and execute the scripts as needed.
+
+Run the etm_trace  test using:
+---
+
+#### Quick Example
+```sh
+git clone <this-repo>
+cd <this-repo>
+scp -r common Runner user@target_device_ip:<Path in device>
+ssh user@target_device_ip
+cd <Path in device>/Runner && ./run-test.sh stm_cpu
+```
+---
+
+## Prerequisites
+1. Required kernel configs must be enabled:    
+   CONFIG_STM_PROTO_BASIC   
+   CONFIG_STM_PROTO_SYS_T    
+   CONFIG_STM_DUMMY    
+   CONFIG_STM_SOURCE_CONSOLE    
+   CONFIG_STM_SOURCE_HEARTBEAT
+2. Root access is required to mount filesystems and load kernel modules.
+3. init_env and functestlib.sh must be present and correctly configured.
+---
+
+ ## Result Format
+Test result will be saved in `stm_cpu.res` as:  
+
+## Output
+A .res file is generated in the same directory:
+`stm_cpu PASS`  OR   `stm_cpu FAIL`   OR `stm_cpu SKIP`
+
+## Skip Criteria
+1. If the required kernel configuration is missing, the result will be:
+2. `stm_cpu SKIP`
+
+## Sample Log
+```
+[INFO] 1970-01-01 00:44:35 - -----------------------------------------------------------------------------------------
+[INFO] 1970-01-01 00:44:35 - -------------------Starting stm_cpu Testcase----------------------------
+[INFO] 1970-01-01 00:44:35 - === Test Initialization ===
+[FAIL] 1970-01-01 00:44:35 - Kernel config CONFIG_STM_PROTO_BASIC is missing or not enabled
+[SKIP] 1970-01-01 00:44:35 - stm_cpu : Required kernel configs missing
+```

--- a/Runner/suites/Kernel/Baseport/stm_cpu/run.sh
+++ b/Runner/suites/Kernel/Baseport/stm_cpu/run.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+ 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+ 
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+ 
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+ 
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+ 
+TESTNAME="stm_cpu"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+ 
+log_info "-----------------------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
+ 
+# Step 1: Check required kernel configs individually
+CONFIGS="CONFIG_STM_PROTO_BASIC CONFIG_STM_PROTO_SYS_T CONFIG_STM_DUMMY CONFIG_STM_SOURCE_CONSOLE CONFIG_STM_SOURCE_HEARTBEAT"
+for cfg in $CONFIGS; do
+    log_info "Checking if $cfg is enabled"
+    if ! check_kernel_config "$cfg" >/dev/null; then
+        log_fail "$cfg is not enabled"
+        echo "$TESTNAME FAIL" > "$res_file"
+        exit 1
+    fi
+done
+ 
+# Step 2: Mount configfs if not mounted
+if ! mountpoint -q /sys/kernel/config 2>/dev/null && [ -z "$(ls /sys/kernel/config 2>/dev/null)" ]; then
+    mount -t configfs configfs /sys/kernel/config || {
+        log_skip "$TESTNAME : Failed to mount configfs"
+        echo "$TESTNAME SKIP" > "$res_file"
+        exit 0
+    }
+fi
+ 
+# Step 3: Create STM policy directories
+mkdir -p /sys/kernel/config/stp-policy/stm0_basic.policy/default || {
+    log_skip "$TESTNAME : Failed to create STM policy directories"
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+}
+ 
+# Step 4: Enable ETF sink only if not already enabled
+if [ "$(cat /sys/bus/coresight/devices/tmc_etf0/enable_sink)" != "1" ]; then
+    echo 1 > /sys/bus/coresight/devices/tmc_etf0/enable_sink || {
+        log_skip "$TESTNAME : Failed to enable ETF sink"
+        echo "$TESTNAME SKIP" > "$res_file"
+        exit 0
+    }
+fi
+ 
+# Step 5: Load STM modules
+for mod in stm_heartbeat stm_console stm_ftrace; do
+    mod_path=$(find_kernel_module "$mod")
+    load_kernel_module "$mod_path" || {
+        log_skip "$TESTNAME : Failed to load module $mod"
+        echo "$TESTNAME SKIP" > "$res_file"
+        exit 0
+    }
+done
+ 
+# Step 6: Link STM source to ftrace
+echo stm0 > /sys/class/stm_source/ftrace/stm_source_link
+ 
+# Step 7: Mount debugfs if not mounted
+if ! mountpoint -q /sys/kernel/debug 2>/dev/null && [ -z "$(ls /sys/kernel/debug 2>/dev/null)" ]; then
+    mount -t debugfs nodev /sys/kernel/debug || {
+        log_skip "$TESTNAME : Failed to mount debugfs"
+        echo "$TESTNAME SKIP" > "$res_file"
+        exit 0
+    }
+fi
+ 
+# Step 8: Enable tracing
+echo 1 > /sys/kernel/debug/tracing/tracing_on
+echo 1 > /sys/kernel/debug/tracing/events/sched/sched_switch/enable
+echo 1 > /sys/bus/coresight/devices/stm0/enable_source
+ 
+# Step 9: Capture trace output
+trace_output="/tmp/qdss_etf_stm.bin"
+rm -f "$trace_output"
+ 
+if [ ! -e /dev/tmc_etf0 ]; then
+    log_skip "$TESTNAME : Trace device /dev/tmc_etf0 not found"
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+ 
+cat /dev/tmc_etf0 > "$trace_output"
+ 
+# Step 10: Validate trace output is not empty
+if [ -s "$trace_output" ]; then
+    log_pass "$TESTNAME : Trace captured successfully"
+    echo "$TESTNAME PASS" > "$res_file"
+    rm -f "$trace_output"
+    log_info "------------------- Completed $TESTNAME Testcase ----------------------------"
+    exit 0
+else
+    log_fail "$TESTNAME : Trace output is empty"
+    echo "$TESTNAME FAIL" > "$res_file"
+    rm -f "$trace_output"
+    log_info "------------------- Completed $TESTNAME Testcase ----------------------------"
+    exit 1
+fi
+ 


### PR DESCRIPTION
This commit introduces the stm_cpu test script designed to validate the System Trace Macrocell (STM) functionality on the target platform. The script performs a series of steps including:

- Verifying required kernel configurations for STM support
- Mounting configfs and debugfs if not already mounted
- Creating STM policy directories and enabling ETF sink
- Loading STM-related kernel modules (stm_heartbeat, stm_console, stm_ftrace)
- Linking STM source to ftrace and enabling tracing
- Capturing trace output and validating its presence

The script generates a result file (`stm_cpu.res`) indicating PASS, FAIL, or SKIP based on the outcome of the test.

Additionally, a detailed README.md is added, covering:
- Test overview and objectives
- Usage instructions and prerequisites
- Result format and sample logs

This test ensures that the STM infrastructure is correctly configured and functional for trace capture on supported platforms.
