### PR TITLE
Add zstd archive to tagged releases

### DIFF
--- a/.github/workflows/zstd.yml
+++ b/.github/workflows/zstd.yml
@@ -1,0 +1,37 @@
+name: Zstd Archive Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'  # Matching tags like v1.1.0
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install zstd
+        run: sudo apt-get update && sudo apt-get install -y zstd
+
+      - name: Extract version info
+        id: version
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Create .tar.zst archives using git archive
+        run: |
+          git archive --format=tar --prefix=test-definitions/ ${{ steps.version.outputs.tag_name }} \
+            | zstd -o ../${{ steps.version.outputs.tag_name }}.tar.zst
+      - name: Upload .tar.zst archives to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag_name }}
+          name: Release ${{ steps.version.outputs.tag_name }}
+          files: |
+            ../${{ steps.version.outputs.tag_name }}.tar.zst
+            ../${{ steps.version.outputs.short_tag }}.tar.zst
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
zstd archive helps with running tests on space constrained systems. It's already supported in LAVA and tuxlava (template renderer). This patch will make it possible to use qcom-linux-testkit in tuxlava.