### PR TITLE
Add kvm_check test script and its README documentation

### DIFF
--- a/Runner/suites/Kernel/Baseport/kvm_check/README.md
+++ b/Runner/suites/Kernel/Baseport/kvm_check/README.md
@@ -1,0 +1,50 @@
+# KVM_Check - Validation test
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+This test case validates the presence of the **dev/kvm** device node on the target system. The /dev/kvm interface is essential for enabling hardware-assisted virtualization using KVM (Kernel-based Virtual Machine). This test ensures that the KVM module is properly loaded and available.
+
+## Test Performs :
+1. Verifies required dependencies
+2. Checks for the presence of **/dev/kvm**
+3. Logs the result and writes it to a .res file
+
+## Usage
+Instructions:
+1. **Copy repo to Target Device**: Use `scp` to transfer the scripts from the host to the target device. The scripts should be copied to any directory on the target device.
+2. **Verify Transfer**: Ensure that the repo has been successfully copied to the target device.
+3. **Run Scripts**: Navigate to the directory where these files are copied on the target device and execute the scripts as needed.
+
+Run the kvm_check test using:
+---
+#### Quick Example
+```sh
+git clone <this-repo>
+cd <this-repo>
+scp -r common Runner user@target_device_ip:<Path in device>
+ssh user@target_device_ip
+cd <Path in device>/Runner && ./run-test.sh kvm_check
+```
+---
+
+## Prerequisites
+1. Root access is required to check device nodes.
+---
+
+ ## Result Format
+Test result will be saved in `kvm_check.res` as:  
+
+## Output
+A .res file is generated in the same directory:
+`kvm_check  PASS`  OR   `kvm_check FAIL` 
+
+## Sample Log
+```
+[INFO] 1970-01-01 00:15:40 - -----------------------------------------------------------------------------------------
+[INFO] 1970-01-01 00:15:40 - ------------------- Starting kvm_check Testcase ----------------------------
+[INFO] 1970-01-01 00:15:40 - === Test Initialization ===
+[INFO] 1970-01-01 00:15:40 - Checking for /dev/kvm presence...
+[PASS] 1970-01-01 00:15:40 - /dev/kvm is present
+
+```

--- a/Runner/suites/Kernel/Baseport/kvm_check/run.sh
+++ b/Runner/suites/Kernel/Baseport/kvm_check/run.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+ 
+# Only source if not already loaded (idempotent)
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+# Always source functestlib.sh, using $TOOLS exported by init_env
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+ 
+TESTNAME="kvm_check"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+ 
+log_info "-----------------------------------------------------------------------------------------"
+log_info "------------------- Starting $TESTNAME Testcase ----------------------------"
+log_info "=== Test Initialization ==="
+ 
+log_info "Checking for /dev/kvm presence..."
+ 
+if [ ! -e /dev/kvm ]; then
+    log_fail "/dev/kvm is not present"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+fi
+ 
+log_pass "/dev/kvm is present"
+echo "$TESTNAME PASS" > "$res_file"
+log_info "------------------- Completed $TESTNAME Testcase ----------------------"
+exit 0
+ 


### PR DESCRIPTION
This commit introduces the `kvm_check` test case to validate the presence of /dev/kvm, ensuring KVM support is available on the target device. The test uses standardized helper functions for logging, dependency checks, and result formatting.


Additionally, a detailed README is included, outlining the test's purpose, usage instructions, prerequisites, result format, and sample logs to support integration and execution