### PR TITLE
virtio_infra: Add dynamic QEMU test script and README documentation

### DIFF
--- a/Runner/suites/Kernel/Baseport/virtio_infra_test/README.md
+++ b/Runner/suites/Kernel/Baseport/virtio_infra_test/README.md
@@ -1,0 +1,70 @@
+# virtio_infra_test Test
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+This test case validates the virtio infrastructure by launching a QEMU-based virtual machine using KVM acceleration. It ensures that the virtual machine boots successfully and that the login prompt is detected, confirming that the virtio and KVM setup is functional
+
+## Test Performs :
+1. Dynamically locates required directories:  
+     init_env for environment setup  
+     `myqemu` for QEMU binaries and libraries  
+     volatile for kernel image and root filesystem  
+2. Creates a temporary input file to simulate Enter key press  
+3. Launches `QEMU` with `KVM` using the discovered binaries and images
+4. Monitors the serial log for:  
+     Login prompt  
+     `KVM` usage confirmation  
+5. Writes test result to a .res file
+
+## Usage
+Instructions:
+1. **Prepare Directories:**  
+   Place QEMU binaries and libraries under a directory named myqemu  
+   Place the kernel image (`Image`) and root filesystem (`*.ext4`) anywhere on the target device. These files will be discovered dynamically by the script.  
+   Ensure both directories are accessible from the script's location (they will be discovered dynamically)  
+2. **Copy repo to Target Device**: Use `scp` to transfer the scripts from the host to the target device. The scripts should be copied to any directory on the target device.
+3. **Verify Transfer**: Ensure that the repo has been successfully copied to the target device.
+4. **Run Scripts**: Navigate to the directory where these files are copied on the target device and execute the scripts as needed.
+
+Run the etm_trace  test using:
+---
+
+#### Quick Example
+```sh
+git clone <this-repo>
+cd <this-repo>
+scp -r common Runner user@target_device_ip:<Path in device>
+ssh user@target_device_ip
+cd <Path in device>/Runner && ./run-test.sh virtio_infra_test
+```
+---
+
+## Prerequisites
+1. Required directories must exist:  
+  myqemu containing `QEMU b`inaries and libraries  
+  volatile containing Image and .ext4 root filesystem
+2. The target device must boot with **KVM as the hypervisor** enabled
+3. Root access is required to run` QEMU` with` KVM`
+---
+
+ ## Result Format
+Test result will be saved in `virtio_infra_test.res` as:  
+
+## Output
+A .res file is generated in the same directory:
+`virtio_infra_test PASS`  OR   `virtio_infra_test FAIL` 
+
+## Sample Log
+```
+[INFO] 1970-01-01 01:34:09 - -----------------------------------------------------------------------------------------
+[INFO] 1970-01-01 01:34:09 - -------------------Starting virtio_infra_test Testcase----------------------------
+[INFO] 1970-01-01 01:34:09 - === Test Initialization ===
+[INFO] 1970-01-01 01:34:09 - Creating temporary input file for QEMU...
+[INFO] 1970-01-01 01:34:09 - Launching QEMU with KVM...
+[INFO] 1970-01-01 01:34:09 - Waiting for VM to boot (checking logs)...
+[PASS] 1970-01-01 01:34:17 - Login prompt detected
+[PASS] 1970-01-01 01:34:17 - KVM usage confirmed in boot logs
+[INFO] 1970-01-01 01:34:17 - -------------------Completed virtio_infra_test Testcase----------------------------
+--
+```

--- a/Runner/suites/Kernel/Baseport/virtio_infra_test/run.sh
+++ b/Runner/suites/Kernel/Baseport/virtio_infra_test/run.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+ 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+ 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+QEMU_DIR=""
+IMG_FILE=""
+FS_FILE=""
+ 
+# Locate and source init_env
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+[ -z "$INIT_ENV" ] && echo "[ERROR] Could not find init_env" >&2 && exit 1
+ 
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+ 
+# Source functestlib
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+ 
+# Find QEMU binaries
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    [ -d "$SEARCH/myqemu" ] && QEMU_DIR="$SEARCH/myqemu" && break
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+[ -z "$QEMU_DIR" ] && echo "[ERROR] Could not find myqemu directory" >&2 && exit 1
+chmod -R 777 "$QEMU_DIR"
+ 
+# Find kernel image and ext4 filesystem
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    [ -z "$IMG_FILE" ] && [ -f "$SEARCH/Image" ] && IMG_FILE="$SEARCH/Image"
+    [ -z "$FS_FILE" ] && FS_FILE=$(find "$SEARCH" -maxdepth 1 -name "*.ext4" | head -n 1)
+    [ -n "$IMG_FILE" ] && [ -n "$FS_FILE" ] && break
+    SEARCH=$(dirname "$SEARCH")
+done
+ 
+[ -z "$IMG_FILE" ] && echo "[ERROR] Kernel Image not found" >&2 && exit 1
+[ -z "$FS_FILE" ] && echo "[ERROR] Rootfs .ext4 file not found" >&2 && exit 1
+ 
+TESTNAME="virtio_infra_test"
+res_file="./$TESTNAME.res"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+ 
+serial_log="$PWD/virtio_serial.log"
+input_file="$PWD/qemu_input.txt"
+ 
+log_info "-----------------------------------------------------------------------------------------"
+log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "=== Test Initialization ==="
+ 
+rm -f "$res_file" "$serial_log" "$input_file"
+ 
+log_info "Creating temporary input file for QEMU..."
+echo -e "\n\n" > "$input_file"
+ 
+log_info "Launching QEMU with KVM..."
+cd "$QEMU_DIR" || exit 1
+export LD_LIBRARY_PATH="$QEMU_DIR"
+ 
+./qemu-system-aarch64 \
+    -M virt -m 2G \
+    -drive file="$FS_FILE",if=virtio,format=raw,bus=1,unit=0 \
+    -kernel "$IMG_FILE" \
+    -cpu host --enable-kvm -smp 4 -nographic -append 'root=/dev/vda' \
+    < "$input_file" > "$serial_log" 2>&1 &
+ 
+QEMU_PID=$!
+echo "$QEMU_PID" > "$SCRIPT_DIR/qemu.pid"
+ 
+log_info "Waiting for VM to boot (checking logs)..."
+ 
+timeout=90
+found_login=0
+found_kvm=0
+ 
+for i in $(seq 1 "$timeout"); do
+    grep -q "login:" "$serial_log" && found_login=1
+    grep -qi "kvm" "$serial_log" && found_kvm=1
+    [ $found_login -eq 1 ] && break
+    sleep 1
+done
+ 
+# Check KVM
+if [ $found_kvm -eq 1 ]; then
+    log_pass "KVM usage confirmed in boot logs"
+else
+    log_warn "KVM not explicitly found in logs — fallback may have occurred"
+    echo "$TESTNAME FAIL" > "$res_file"
+    kill "$QEMU_PID" >/dev/null 2>&1
+    rm -f "$input_file" "$SCRIPT_DIR/qemu.pid"
+    log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+    exit 1
+fi
+ 
+# Check login
+if [ $found_login -eq 1 ]; then
+    log_pass "Login prompt detected"
+else
+    log_fail "Login prompt not detected"
+    echo "$TESTNAME FAIL" > "$res_file"
+    kill "$QEMU_PID" >/dev/null 2>&1
+    rm -f "$input_file" "$SCRIPT_DIR/qemu.pid"
+    log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+    exit 1
+fi
+ 
+echo "$TESTNAME PASS" > "$res_file"
+kill "$QEMU_PID" >/dev/null 2>&1
+rm -f "$input_file" "$SCRIPT_DIR/qemu.pid"
+log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+exit 0
+ 


### PR DESCRIPTION
- Introduced a portable `run.sh` script to validate virtio infrastructure using QEMU and KVM.
- The script dynamically locates required directories: `init_env`, `myqemu`, and `volatile`.
- Automatically simulates login prompt detection via serial log monitoring.
- Handles permission issues and ensures QEMU dependencies are resolved.
- Generates a `.res` file with PASS/FAIL status.
- Added a detailed README.md explaining test purpose, usage, prerequisites, and sample logs.