### PR TITLE
Improve rngtest CI reliability with output-based validation and success ratio logging

### DIFF
--- a/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/rngtest/run.sh
@@ -36,15 +36,18 @@ log_info "----------------------------------------------------------------------
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
 log_info "=== Test Initialization ==="
 
-log_info "Checking if dependency binary is available"
+# Verifying the availability of the dependency binary
 check_dependencies rngtest dd
 
 TMP_BIN="/tmp/rngtest_input.bin"
 TMP_OUT="/tmp/rngtest_output.txt"
 ENTROPY_MB=10
-RNG_SOURCE="/dev/urandom" # Use /dev/random if you want slow but highest entropy
+COUNT=1000
+PASS_THRESHOLD=997
+RNG_SOURCE="/dev/urandom"
+[ -e /dev/hwrng ] && RNG_SOURCE="/dev/hwrng"
 
-log_info "Generating ${ENTROPY_MB}MB entropy input from $RNG_SOURCE using dd..."
+log_info "Generating ${ENTROPY_MB}MB entropy input from $RNG_SOURCE"
 if ! dd if="$RNG_SOURCE" of="$TMP_BIN" bs=1M count="$ENTROPY_MB" status=none 2>/dev/null; then
     log_fail "$TESTNAME : Failed to read random data from $RNG_SOURCE"
     echo "$TESTNAME FAIL" > "$res_file"
@@ -52,44 +55,32 @@ if ! dd if="$RNG_SOURCE" of="$TMP_BIN" bs=1M count="$ENTROPY_MB" status=none 2>/
     exit 1
 fi
 
-log_info "Running rngtest -c 1000 < $TMP_BIN"
-if ! rngtest -c 1000 < "$TMP_BIN" > "$TMP_OUT" 2>&1; then
-    log_fail "$TESTNAME : rngtest execution failed"
-    echo "$TESTNAME FAIL" > "$res_file"
-    rm -f "$TMP_BIN" "$TMP_OUT"
-    exit 1
-fi
+log_info "Running rngtest -c $COUNT < $TMP_BIN"
+rngtest -c "$COUNT" < "$TMP_BIN" > "$TMP_OUT" 2>&1
 
-# Check for entropy errors or source drained
-if grep -q "entropy source drained" "$TMP_OUT"; then
-    log_fail "rngtest: entropy source drained, input too small"
-    echo "$TESTNAME FAIL" > "$res_file"
-    rm -f "$TMP_BIN" "$TMP_OUT"
-    exit 1
-fi
-
-# Parse FIPS 140-2 successes (robust to output variations)
+# Try to extract success count regardless of return code
 successes=$(awk '/FIPS 140-2 successes:/ {print $NF}' "$TMP_OUT" | head -n1)
 
 if [ -z "$successes" ] || ! echo "$successes" | grep -Eq '^[0-9]+$'; then
-    log_fail "rngtest did not return a valid integer for successes; got: '$successes'"
+    log_fail "rngtest: Could not parse valid success count from output"
     echo "$TESTNAME FAIL" > "$res_file"
+    cat "$TMP_OUT"
     rm -f "$TMP_BIN" "$TMP_OUT"
     exit 1
 fi
 
-log_info "rngtest: FIPS 140-2 successes = $successes"
-# You can tune this threshold as needed (10 means <1% fail allowed)
-if [ "$successes" -ge 10 ]; then
-    log_pass "$TESTNAME : Test Passed ($successes FIPS 140-2 successes)"
+log_info "FIPS 140-2 successes: $successes / $COUNT"
+percent=$(awk "BEGIN {printf \"%.2f\", ($successes/$COUNT)*100}")
+log_info "Success ratio: $percent%"
+
+if [ "$successes" -ge "$PASS_THRESHOLD" ]; then
+    log_pass "$TESTNAME : Test Passed ($successes ≥ $PASS_THRESHOLD successes)"
     echo "$TESTNAME PASS" > "$res_file"
     rm -f "$TMP_BIN" "$TMP_OUT"
     exit 0
 else
-    log_fail "$TESTNAME : Test Failed ($successes FIPS 140-2 successes)"
+    log_fail "$TESTNAME : Test Failed ($successes < $PASS_THRESHOLD successes)"
     echo "$TESTNAME FAIL" > "$res_file"
     rm -f "$TMP_BIN" "$TMP_OUT"
     exit 1
 fi
-
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"


### PR DESCRIPTION
This update improves the robustness and CI compatibility of the rngtest functional test by:
 

- Removing dependency on the rngtest return code, which may be unreliable even for acceptable success ratios.
- Parsing and validating based on FIPS 140-2 success count extracted from output.
- Allowing minor failure tolerance by accepting tests with ≥ 997 out of 1000 successes.
- Logging exact success/failure ratio for better visibility, even on failure.
- Cleaning up unused variable (RNGTEST_RC) to resolve ShellCheck SC2034 warning.
- Preserving overall format and logging style in line with qcom-linux-testkit test structure.