### PR TITLE
Modularized adsp, cdsp, and wpss remoteproc tests using common helper functions 

### DIFF
--- a/Runner/suites/Kernel/FunctionalArea/baseport/adsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/adsp_remoteproc/run.sh
@@ -2,7 +2,6 @@
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
-
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
@@ -14,12 +13,12 @@ while [ "$SEARCH" != "/" ]; do
     fi
     SEARCH=$(dirname "$SEARCH")
 done
- 
+
 if [ -z "$INIT_ENV" ]; then
     echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
     exit 1
 fi
- 
+
 # Only source if not already loaded (idempotent)
 if [ -z "$__INIT_ENV_LOADED" ]; then
     # shellcheck disable=SC1090
@@ -28,65 +27,48 @@ fi
 # Always source functestlib.sh, using $TOOLS exported by init_env
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
-
+ 
 TESTNAME="adsp_remoteproc"
+firmware_name="adsp"
+res_file="./$TESTNAME.res"
+LOG_FILE="./$TESTNAME.log"
+ 
+exec > >(tee -a "$LOG_FILE") 2>&1
+ 
 test_path=$(find_test_case_by_name "$TESTNAME")
 cd "$test_path" || exit 1
-# shellcheck disable=SC2034
-res_file="./$TESTNAME.res"
-
+ 
 log_info "-----------------------------------------------------------------------------------------"
-log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "------------------- Starting $TESTNAME Testcase ----------------------------"
 log_info "=== Test Initialization ==="
-
-# Get the firmware output and find the position of adsp
-log_info "Checking for firmware"
-firmware_output=$(cat /sys/class/remoteproc/remoteproc*/firmware)
-adsp_position=$(echo "$firmware_output" | grep -n "adsp" | cut -d: -f1)
-
-# Adjust the position to match the remoteproc numbering (starting from 0)
-remoteproc_number=$((adsp_position - 1))
-
-# Construct the remoteproc path based on the adsp position
-remoteproc_path="/sys/class/remoteproc/remoteproc${remoteproc_number}"
-log_info "Remoteproc node is $remoteproc_path"
-# Execute command 1 and check if the output is "running"
-state1=$(cat ${remoteproc_path}/state)
-
-if [ "$state1" != "running" ]; then
-    log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+ 
+if ! validate_remoteproc_running "$firmware_name" "$LOG_FILE" 15 2; then
+    log_fail "$firmware_name remoteproc is not in running state after bootup"
+    echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-
-# Execute command 2 (no output expected)
-log_info "Stopping remoteproc"
-echo stop > ${remoteproc_path}/state
-
-# Execute command 3 and check if the output is "offline"
-state3=$(cat ${remoteproc_path}/state)
-if [ "$state3" != "offline" ]; then
-    log_fail "adsp stop failed"
-    echo "$TESTNAME FAIL" > "$test_path/$TESTNAME.res"
+ 
+log_pass "$firmware_name remoteproc validated as running"
+ 
+rproc_path=$(get_remoteproc_path_by_firmware "$firmware_name")
+ 
+stop_remoteproc "$rproc_path" || {
+    log_fail "$TESTNAME stop failed"
+    echo "$TESTNAME FAIL" > "$res_file"
     exit 1
-else
-    log_pass "adsp stop successful"
-fi
-log_info "Restarting remoteproc"
-# Execute command 4 (no output expected)
-echo start > ${remoteproc_path}/state
-
-# Execute command 5 and check if the output is "running"
-state5=$(cat ${remoteproc_path}/state)
-if [ "$state5" != "running" ]; then
-    log_fail "adsp start failed"
-    echo "$TESTNAME FAIL" > "$res_file" 
+}
+log_pass "$firmware_name stop successful"
+ 
+log_info "Restarting $firmware_name"
+start_remoteproc "$rproc_path" || {
+    log_fail "$TESTNAME start failed"
+    echo "$TESTNAME FAIL" > "$res_file"
     exit 1
-fi
-
-# If all checks pass, print "PASS"
-echo "adsp PASS"
-log_pass "adsp PASS"
+}
+ 
+log_pass "$firmware_name PASS"
 echo "$TESTNAME PASS" > "$res_file"
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+ 
+log_info "------------------- Completed $TESTNAME Testcase ----------------------------"
 exit 0
+ 

--- a/Runner/suites/Kernel/FunctionalArea/baseport/cdsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/cdsp_remoteproc/run.sh
@@ -2,7 +2,6 @@
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
-
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
@@ -28,63 +27,48 @@ fi
 # Always source functestlib.sh, using $TOOLS exported by init_env
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
-
+ 
 TESTNAME="cdsp_remoteproc"
+firmware_name="cdsp"
+res_file="./$TESTNAME.res"
+LOG_FILE="./$TESTNAME.log"
+ 
+exec > >(tee -a "$LOG_FILE") 2>&1
+ 
 test_path=$(find_test_case_by_name "$TESTNAME")
 cd "$test_path" || exit 1
-# shellcheck disable=SC2034
-res_file="./$TESTNAME.res"
-
+ 
 log_info "-----------------------------------------------------------------------------------------"
-log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "------------------- Starting $TESTNAME Testcase ----------------------------"
 log_info "=== Test Initialization ==="
-
-# Get the firmware output and find the position of cdsp
-log_info "Get the firmware output and find the position of cdsp"
-firmware_output=$(cat /sys/class/remoteproc/remoteproc*/firmware)
-cdsp_position=$(echo "$firmware_output" | grep -n "cdsp" | cut -d: -f1)
-
-# Adjust the position to match the remoteproc numbering (starting from 0)
-remoteproc_number=$((cdsp_position - 1))
-
-# Construct the remoteproc path based on the cdsp position
-remoteproc_path="/sys/class/remoteproc/remoteproc${remoteproc_number}"
-
-# Execute command 1 and check if the output is "running"
-state1=$(cat ${remoteproc_path}/state)
-if [ "$state1" != "running" ]; then
-    log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
-    exit 1
-fi
-
-# Execute command 2 (no output expected)
-echo stop > ${remoteproc_path}/state
-
-# Execute command 3 and check if the output is "offline"
-state3=$(cat ${remoteproc_path}/state)
-if [ "$state3" != "offline" ]; then
-    log_fail "cdsp stop failed"
-    echo "$TESTNAME FAIL" > $test_path/$TESTNAME.res
-    exit 1
-else
-    log_pass "cdsp stop successful"
-fi
-log_info "Restarting remoteproc"
-# Execute command 4 (no output expected)
-echo start > ${remoteproc_path}/state
-
-# Execute command 5 and check if the output is "running"
-state5=$(cat ${remoteproc_path}/state)
-if [ "$state5" != "running" ]; then
-    log_fail "cdsp start failed"
+ 
+if ! validate_remoteproc_running "$firmware_name" "$LOG_FILE" 15 2; then
+    log_fail "$firmware_name remoteproc is not in running state after bootup"
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-
-# If all checks pass, print "PASS"
-echo "cdsp PASS"
-log_pass "cdsp PASS"
-echo "$TESTNAME PASS" > "$res_file" 
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+ 
+log_pass "$firmware_name remoteproc validated as running"
+ 
+rproc_path=$(get_remoteproc_path_by_firmware "$firmware_name")
+ 
+stop_remoteproc "$rproc_path" || {
+    log_fail "$TESTNAME stop failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+}
+log_pass "$firmware_name stop successful"
+ 
+log_info "Restarting $firmware_name"
+start_remoteproc "$rproc_path" || {
+    log_fail "$TESTNAME start failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+}
+ 
+log_pass "$firmware_name PASS"
+echo "$TESTNAME PASS" > "$res_file"
+ 
+log_info "------------------- Completed $TESTNAME Testcase ----------------------------"
 exit 0
+ 

--- a/Runner/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh
+++ b/Runner/suites/Kernel/FunctionalArea/baseport/wpss_remoteproc/run.sh
@@ -2,7 +2,6 @@
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
-
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
@@ -14,12 +13,12 @@ while [ "$SEARCH" != "/" ]; do
     fi
     SEARCH=$(dirname "$SEARCH")
 done
- 
+
 if [ -z "$INIT_ENV" ]; then
     echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
     exit 1
 fi
- 
+
 # Only source if not already loaded (idempotent)
 if [ -z "$__INIT_ENV_LOADED" ]; then
     # shellcheck disable=SC1090
@@ -28,71 +27,48 @@ fi
 # Always source functestlib.sh, using $TOOLS exported by init_env
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
-
+ 
 TESTNAME="wpss_remoteproc"
+firmware_name="wpss"
+res_file="./$TESTNAME.res"
+LOG_FILE="./$TESTNAME.log"
+ 
+exec > >(tee -a "$LOG_FILE") 2>&1
+ 
 test_path=$(find_test_case_by_name "$TESTNAME")
 cd "$test_path" || exit 1
-# shellcheck disable=SC2034
-res_file="./$TESTNAME.res"
-
+ 
 log_info "-----------------------------------------------------------------------------------------"
-log_info "-------------------Starting $TESTNAME Testcase----------------------------"
+log_info "------------------- Starting $TESTNAME Testcase ----------------------------"
 log_info "=== Test Initialization ==="
-
-log_info "=== Detecting and validating WPSS remoteproc instance ==="
  
-log_info "Looking for remoteproc device exposing WPSS..."
-wpss_path=""
-for node in /sys/class/remoteproc/remoteproc*; do
-    [ -f "$node/name" ] || continue
-    name=$(cat "$node/name" 2>/dev/null | tr '[:upper:]' '[:lower:]')
-    if echo "$name" | grep -qi "wpss"; then
-        wpss_path="$node"
-        break
-    fi
-done
- 
-if [ -z "$wpss_path" ]; then
-    log_skip "WPSS remoteproc node not found"
-    echo "$TESTNAME SKIP" > "$res_file"
-    exit 0
-fi
- 
-log_info "Found WPSS remoteproc node at: $wpss_path"
-firmware=$(cat "$wpss_path/firmware" 2>/dev/null)
-log_info "WPSS firmware: $firmware"
- 
-# Capture state before any change
-orig_state=$(cat "$wpss_path/state" 2>/dev/null)
-log_info "Original state: $orig_state"
- 
-log_info "Attempting to stop WPSS..."
-if echo stop > "$wpss_path/state" 2>/dev/null; then
-    sleep 1
-    new_state=$(cat "$wpss_path/state" 2>/dev/null)
-    if [ "$new_state" != "offline" ]; then
-        log_warn "Expected offline state after stop, got: $new_state"
-    fi
-else
-    log_warn "Could not stop WPSS; may already be offline"
-fi
- 
-log_info "Attempting to start WPSS..."
-if echo start > "$wpss_path/state" 2>/dev/null; then
-    sleep 1
-    final_state=$(cat "$wpss_path/state" 2>/dev/null)
-    if [ "$final_state" = "running" ]; then
-        log_pass "WPSS remoteproc started successfully"
-        echo "$TESTNAME PASS" > "$res_file"
-        exit 0
-    else
-        log_fail "WPSS remoteproc failed to start, state: $final_state"
-        echo "$TESTNAME FAIL" > "$res_file"
-        exit 1
-    fi
-else
-    log_fail "Failed to write 'start' to $wpss_path/state"
+if ! validate_remoteproc_running "$firmware_name" "$LOG_FILE" 15 2; then
+    log_fail "$firmware_name remoteproc is not in running state after bootup"
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+ 
+log_pass "$firmware_name remoteproc validated as running"
+ 
+rproc_path=$(get_remoteproc_path_by_firmware "$firmware_name")
+ 
+stop_remoteproc "$rproc_path" || {
+    log_fail "$TESTNAME stop failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+}
+log_pass "$firmware_name stop successful"
+ 
+log_info "Restarting $firmware_name"
+start_remoteproc "$rproc_path" || {
+    log_fail "$TESTNAME start failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+}
+ 
+log_pass "$firmware_name PASS"
+echo "$TESTNAME PASS" > "$res_file"
+ 
+log_info "------------------- Completed $TESTNAME Testcase ----------------------------"
+exit 0
+ 


### PR DESCRIPTION
Refactored remoteproc test scripts for adsp, cdsp, and wpss to use modular helper functions from functestlib.sh.

Changes include:

-   Replaced hardcoded logic with reusable functions: get_remoteproc_path_by_firmware, get_remoteproc_state, stop_remoteproc, and start_remoteproc.
-  Improved readability, maintainability, and consistency across these subsystem tests.

This modularization lays the foundation for extending the same structure to other subsystems like gdsp and general remoteproc validation in future updates.