### PR TITLE
Fix ShellCheck workflow to correctly scope PR and main branch analysis

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,7 +1,7 @@
 name: Shell Lint
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
   push:
     branches: [ "main" ]
@@ -10,10 +10,30 @@ on:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Install ShellCheck 0.9.0-1
-        run: sudo apt-get install -y shellcheck=0.9.0-1
-      - name: Run ShellCheck with exclusions
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Install ShellCheck from apt
         run: |
-          find . -name '*.sh' -print0 | xargs -0 shellcheck -S warning -e SC1091,SC2230,SC3043
+          sudo apt-get update
+          sudo apt-get install -y shellcheck=0.9.0-1
+
+      - name: Run ShellCheck on changed .sh files in PR
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Checking only changed shell files in PR..."
+          git fetch origin ${{ github.base_ref }}
+          FILES=$(git diff --name-only origin/${{ github.base_ref }} -- '*.sh' | xargs -r -n1 echo | xargs -r realpath --no-symlinks --canonicalize-missing 2>/dev/null || true)
+          if [ -n "$FILES" ]; then
+            echo "$FILES" | tr ' ' '\n' | xargs -r shellcheck -S warning -e SC1091,SC2230,SC3043
+          else
+            echo "No shell files to lint."
+          fi
+
+      - name: Run ShellCheck on all .sh files (main or manual trigger)
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "Linting all shell files in repository..."
+          find . -type f -name '*.sh' -print0 | xargs -0 -r shellcheck -S warning -e SC1091,SC2230,SC3043


### PR DESCRIPTION
### Summary
This PR addresses an issue where the ShellCheck workflow was incorrectly reporting errors on PRs due to lint violations present on the `main` branch.
 
### Fixes Included
- Adjusted `.github/workflows/shell-lint.yml` to:
  - Run ShellCheck only on changed `.sh` files during pull requests.
  - Run on all `.sh` files during `push` to `main` or manual dispatch.
- Prevents unrelated errors from `main` from appearing in pull request checks.
- Ensures reliable ShellCheck validation across CI triggers.
 
### Benefits
- Accurate linting feedback scoped only to relevant changes.
- Cleaner CI results for contributors and reviewers.
- Consistent behavior for main branch validation and developer PRs.