### PR TITLE
ci: fix ShellCheck workflow to run correctly on PRs and main

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,7 +1,7 @@
 name: Shell Lint
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
   push:
     branches: [ "main" ]
@@ -10,10 +10,30 @@ on:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Install ShellCheck 0.9.0-1
-        run: sudo apt-get install -y shellcheck=0.9.0-1
-      - name: Run ShellCheck with exclusions
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Install ShellCheck from apt
         run: |
-          find . -name '*.sh' -print0 | xargs -0 shellcheck -S warning -e SC1091,SC2230,SC3043
+          sudo apt-get update
+          sudo apt-get install -y shellcheck=0.9.0-1
+
+      - name: Run ShellCheck on changed .sh files in PR
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Checking only changed shell files in PR..."
+          git fetch origin ${{ github.base_ref }}
+          FILES=$(git diff --name-only origin/${{ github.base_ref }} -- '*.sh' | xargs -r -n1 echo | xargs -r realpath --no-symlinks --canonicalize-missing 2>/dev/null || true)
+          if [ -n "$FILES" ]; then
+            echo "$FILES" | tr ' ' '\n' | xargs -r shellcheck -S warning -e SC1091,SC2230,SC3043
+          else
+            echo "No shell files to lint."
+          fi
+
+      - name: Run ShellCheck on all .sh files (main or manual trigger)
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "Linting all shell files in repository..."
+          find . -type f -name '*.sh' -print0 | xargs -0 -r shellcheck -S warning -e SC1091,SC2230,SC3043


### PR DESCRIPTION
- Updated  to properly differentiate between PRs and direct pushes to
- On pull_request: only runs ShellCheck on changed  files to avoid false positives from main
- On push to main and manual dispatch: runs ShellCheck on all  files in the repository
- Ensures accurate and relevant linting results on both CI and developer PRs
- Fixes issue where shellcheck errors from main were incorrectly reported on unrelated PRs