### PR TITLE
CI: Improve ShellCheck workflow to skip deleted files in PRs

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,9 +25,9 @@ jobs:
         run: |
           echo "Checking only changed shell files in PR..."
           git fetch origin ${{ github.base_ref }}
-          FILES=$(git diff --name-only origin/${{ github.base_ref }} -- '*.sh' | xargs -r -n1 echo | xargs -r realpath --no-symlinks --canonicalize-missing 2>/dev/null || true)
+          FILES=$(git diff --diff-filter=d --name-only origin/${{ github.base_ref }} -- '*.sh')
           if [ -n "$FILES" ]; then
-            echo "$FILES" | tr ' ' '\n' | xargs -r shellcheck -S warning -e SC1091,SC2230,SC3043
+            echo "$FILES" | tr '\n' '\0' | xargs -0 -r shellcheck -S warning -e SC1091,SC2230,SC3043
           else
             echo "No shell files to lint."
           fi


### PR DESCRIPTION
- Updated shellcheck GitHub Actions workflow to exclude deleted .sh files during pull request linting using --diff-filter=d.
- Ensures ShellCheck runs only on existing, modified shell scripts in PRs.
- Retains full linting on push and manual workflow_dispatch events.
- Removed use of 'realpath' to avoid issues with non-existent files.