### PR TITLE
ci(zstd): use official GitHub release actions instead of softprops

### DIFF
--- a/.github/workflows/zstd.yml
+++ b/.github/workflows/zstd.yml
@@ -2,16 +2,13 @@ name: Zstd Archive Release
 
 on:
   push:
-    # Match semver tags like v1.2.3
     tags:
       - 'v*.*.*'
-  # Allow manual runs from the Actions UI
   workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,30 +21,41 @@ jobs:
       - name: Extract version info
         id: version
         run: |
-          # If triggered by a tag push, GITHUB_REF is refs/tags/vX.Y.Z
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
-          SHORT_TAG="${TAG_NAME#v}" # strip leading "v"
-          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-          echo "short_tag=$SHORT_TAG" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF#refs/tags/}"
+          SHORT="${TAG#v}"
+          echo "tag_name=$TAG" >> $GITHUB_OUTPUT
+          echo "short_tag=$SHORT" >> $GITHUB_OUTPUT
 
       - name: Create .tar.zst archives
         run: |
-          # full-tag archive (vX.Y.Z.tar.zst)
-          git archive --format=tar \
-            --prefix=test-definitions/ \
-            "${{ steps.version.outputs.tag_name }}" \
-          | zstd -o "$GITHUB_WORKSPACE/${{ steps.version.outputs.tag_name }}.tar.zst"
+          git archive --format=tar --prefix=test-definitions/ "${{ steps.version.outputs.tag_name }}" \
+            | zstd -o "$GITHUB_WORKSPACE/${{ steps.version.outputs.tag_name }}.tar.zst"
+          git archive --format=tar --prefix=test-definitions/ "${{ steps.version.outputs.tag_name }}" \
+            | zstd -o "$GITHUB_WORKSPACE/${{ steps.version.outputs.short_tag }}.tar.zst"
 
-          # short-tag archive (X.Y.Z.tar.zst)
-          git archive --format=tar \
-            --prefix=test-definitions/ \
-            "${{ steps.version.outputs.tag_name }}" \
-          | zstd -o "$GITHUB_WORKSPACE/${{ steps.version.outputs.short_tag }}.tar.zst"
-
-      - name: Upload .tar.zst archives to GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
         with:
-          # Pick up both .tar.zst files at the workspace root
-          files: '*.tar.zst'
+          tag_name: ${{ steps.version.outputs.tag_name }}
+          release_name: Release ${{ steps.version.outputs.tag_name }}
+          draft: false
+          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload full-tag .tar.zst
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/${{ steps.version.outputs.tag_name }}.tar.zst
+          asset_name: ${{ steps.version.outputs.tag_name }}.tar.zst
+          asset_content_type: application/zstd
+
+      - name: Upload short-tag .tar.zst
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/${{ steps.version.outputs.short_tag }}.tar.zst
+          asset_name: ${{ steps.version.outputs.short_tag }}.tar.zst
+          asset_content_type: application/zstd


### PR DESCRIPTION
Switch from softprops/action-gh-release to the built-in actions/create-release and actions/upload-release-asset so that our workflow complies with the org’s allowed actions policy. 
Both .tar.zst artifacts are now created and uploaded using only GitHub-verified actions.