### PR TITLE
IPA & RMNET tests: robust module handling, /dev node checks, dmesg scan, ShellCheck fixes

### DIFF
--- a/Runner/suites/Kernel/Baseport/IPA/run.sh
+++ b/Runner/suites/Kernel/Baseport/IPA/run.sh
@@ -2,6 +2,9 @@
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Test for IPA driver: skip if CONFIG_QCOM_IPA not enabled, then
+# builtin vs module, verify /dev/ipa, functional sysfs & dmesg checks.
 
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -30,40 +33,72 @@ fi
 TESTNAME="IPA"
 test_path=$(find_test_case_by_name "$TESTNAME")
 cd "$test_path" || exit 1
-res_file="./$TESTNAME.res"
+RES_FILE="./$TESTNAME.res"
 
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
 log_info "=== Test Initialization ==="
 
-IPA_MODULE_PATH=$(find_kernel_module "ipa")
-
-if [ -z "$IPA_MODULE_PATH" ]; then
-    log_error "ipa.ko module not found in filesystem."
-    echo "$TESTNAME FAIL" > "$res_file"
+fail() {
+    log_fail "$1"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    release_test_lock
     exit 1
-fi
+}
 
-log_info "Found ipa.ko at: $IPA_MODULE_PATH"
+acquire_test_lock "$TESTNAME"
 
-if ! load_kernel_module "$IPA_MODULE_PATH"; then
-    echo "$TESTNAME FAIL" > "$res_file"
-    exit 1
-fi
-
-if is_module_loaded "ipa"; then
-    log_info "ipa module is loaded"
-    log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > "$res_file"
+# Kernel config gate
+if ! check_kernel_config "CONFIG_QCOM_IPA"; then
+    log_skip "$TESTNAME SKIP - CONFIG_QCOM_IPA not enabled"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    release_test_lock
     exit 0
-else
-    log_error "ipa module not listed in lsmod"
-    log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > "$res_file"
-    exit 1
 fi
 
-log_info "=== Cleanup ==="
-unload_kernel_module "ipa" true
+MODNAME="ipa"
+PRE_LOADED=0
+
+# Ensure module is loaded
+if is_module_loaded "$MODNAME"; then
+    PRE_LOADED=1
+    log_info "Module $MODNAME already loaded"
+else
+    MODPATH=$(find_kernel_module "$MODNAME")
+    [ -n "$MODPATH" ] || fail "$MODNAME.ko not found in filesystem"
+    load_kernel_module "$MODPATH" || fail "Failed to load $MODNAME"
+    log_pass "$MODNAME module loaded"
+fi
+
+# /dev node check (warn only, don't fail/skip)
+log_info "Verifying /dev/ipa node"
+if wait_for_path "/dev/ipa" 3; then
+    log_pass "/dev/ipa node is present"
+else
+    log_warn "No /dev/ipa node found (platform/use-case may not expose it)"
+fi
+
+# dmesg scan: errors + success pattern
+# scan_dmesg_errors(label, out_dir, extra_err, ok_kw)
+scan_dmesg_errors "ipa" "." "handshake_complete.*error|stall|abort" "IPA Q6 handshake completed"
+rc=$?
+case "$rc" in
+    0) log_warn "IPA-related errors found in dmesg (see ipa_dmesg_errors.log)" ;;
+    1) log_info "No IPA-related errors in dmesg" ;;
+    2) log_warn "Success pattern 'IPA Q6 handshake completed' not found in dmesg" ;;
+    3) log_warn "scan_dmesg_errors misuse (label missing?)" ;;
+esac
+
+#Cleanup: unload only if we loaded it
+if [ "$PRE_LOADED" -eq 0 ]; then
+    log_info "Unloading $MODNAME (loaded by this test)"
+    unload_kernel_module "$MODNAME" false || log_warn "Unload $MODNAME failed"
+else
+    log_info "$MODNAME was pre-loaded; leaving it loaded"
+fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+log_pass "$TESTNAME PASS"
+echo "$TESTNAME PASS" >"$RES_FILE"
+release_test_lock
+exit 0

--- a/Runner/suites/Kernel/Baseport/RMNET/run.sh
+++ b/Runner/suites/Kernel/Baseport/RMNET/run.sh
@@ -2,6 +2,9 @@
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Test for RMNET driver: skip if CONFIG_RMNET not enabled, then
+# builtin vs module, verify /dev/rmnet, functional sysfs & dmesg checks.
 
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -30,40 +33,89 @@ fi
 TESTNAME="RMNET"
 test_path=$(find_test_case_by_name "$TESTNAME")
 cd "$test_path" || exit 1
-res_file="./$TESTNAME.res"
+RES_FILE="./$TESTNAME.res"
 
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
 log_info "=== Test Initialization ==="
 
-RMNET_MODULE_PATH=$(find_kernel_module "rmnet")
-
-if [ -z "$RMNET_MODULE_PATH" ]; then
-    log_error "rmnet.ko module not found in filesystem."
-    echo "$TESTNAME FAIL" > "$res_file"
+fail() {
+    log_fail "$1"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    release_test_lock
     exit 1
-fi
+}
 
-log_info "Found rmnet.ko at: $RMNET_MODULE_PATH"
+acquire_test_lock "$TESTNAME"
 
-if ! load_kernel_module "$RMNET_MODULE_PATH"; then
-    echo "$TESTNAME FAIL" > "$res_file"
-    exit 1
-fi
-
-if is_module_loaded "rmnet"; then
-    log_info "rmnet module is loaded"
-    log_pass "$TESTNAME : Test Passed"
-    echo "$TESTNAME PASS" > "$res_file"
+# Kernel config gate
+if ! check_kernel_config "CONFIG_RMNET"; then
+    log_skip "$TESTNAME SKIP - CONFIG_RMNET not enabled"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    release_test_lock
     exit 0
-else
-    log_error "rmnet module not listed in lsmod"
-    log_fail "$TESTNAME : Test Failed"
-    echo "$TESTNAME FAIL" > "$res_file"
-    exit 1
 fi
 
-log_info "=== Cleanup ==="
-unload_kernel_module "rmnet" true
+# Load module if needed
+MODNAME="rmnet"
+PRE_LOADED=0
+if is_module_loaded "$MODNAME"; then
+    PRE_LOADED=1
+    log_info "Module $MODNAME already loaded"
+else
+    MODPATH=$(find_kernel_module "$MODNAME")
+    [ -n "$MODPATH" ] || fail "$MODNAME.ko not found in filesystem"
+    load_kernel_module "$MODPATH" || fail "Failed to load $MODNAME"
+    log_pass "$MODNAME module loaded"
+fi
+
+# /dev/rmnet* nodes (authoritative), but do NOT FAIL if absent (common until modem data call)
+log_info "Verifying /dev/rmnet* node(s)"
+first_node=""
+for n in /dev/rmnet*; do
+    case "$n" in
+        /dev/rmnet*) [ -e "$n" ] && { first_node="$n"; break; } ;;
+    esac
+done
+
+if [ -n "$first_node" ]; then
+    if wait_for_path "$first_node" 3; then
+        log_pass "rmnet node $first_node is present"
+    else
+        fail "rmnet node $first_node did not appear within timeout"
+    fi
+else
+    log_warn "No /dev/rmnet* nodes found"
+fi
+
+# dmesg scan for rmnet errors (no positive 'OK' pattern required here)
+scan_dmesg_errors "rmnet" "." "panic|oops|fault|stall|abort" ""
+if [ -s "./rmnet_dmesg_errors.log" ]; then
+    fail "rmnet-related errors found in dmesg"
+else
+    log_info "No rmnet-related errors in dmesg"
+fi
+
+# Optional informational check: ip link (do not fail if absent)
+if command -v ip >/dev/null 2>&1; then
+    if ip -o link show | grep -qi rmnet; then
+        log_info "ip(8): rmnet interface(s) present"
+    else
+        log_info "ip(8): no rmnet interface yet (probably no data call)"
+    fi
+fi
+
+# Cleanup if we loaded it
+if [ "$PRE_LOADED" -eq 0 ]; then
+    log_info "Unloading $MODNAME (loaded by this test)"
+    unload_kernel_module "$MODNAME" false || log_warn "Unload $MODNAME failed"
+else
+    log_info "$MODNAME was pre-loaded; leaving it loaded"
+fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+log_pass "$TESTNAME PASS"
+echo "$TESTNAME PASS" >"$RES_FILE"
+release_test_lock
+exit 0
+

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -61,12 +61,13 @@ is_module_loaded() {
     /sbin/lsmod | awk '{print $1}' | grep -q "^${module_name}$"
 }
 
-# Insert a kernel module with optional parameters
+# load_kernel_module <path-to-ko> [params...]
+# 1) If already loaded, no-op
+# 2) Try insmod <ko> [params]
+# 3) If that fails, try modprobe <modname> [params]
 load_kernel_module() {
-    module_path="$1"
-    shift
+    module_path="$1"; shift
     params="$*"
-
     module_name=$(basename "$module_path" .ko)
 
     if is_module_loaded "$module_name"; then
@@ -76,15 +77,24 @@ load_kernel_module() {
 
     if [ ! -f "$module_path" ]; then
         log_error "Module file not found: $module_path"
-        return 1
+        # still try modprobe if it exists in modules directory
+    else
+        log_info "Loading module via insmod: $module_path $params"
+        if /sbin/insmod "$module_path" "$params" 2>insmod_err.log; then
+            log_info "Module $module_name loaded successfully via insmod"
+            return 0
+        else
+            log_warn "insmod failed: $(cat insmod_err.log)"
+        fi
     fi
 
-    log_info "Loading module: $module_path $params"
-    if /sbin/insmod "$module_path" "$params" 2>insmod_err.log; then
-        log_info "Module $module_name loaded successfully"
+    # fallback to modprobe
+    log_info "Falling back to modprobe $module_name $params"
+    if /sbin/modprobe "$module_name" "$params" 2>modprobe_err.log; then
+        log_info "Module $module_name loaded successfully via modprobe"
         return 0
     else
-        log_error "insmod failed: $(cat insmod_err.log)"
+        log_error "modprobe failed: $(cat modprobe_err.log)"
         return 1
     fi
 }
@@ -171,14 +181,25 @@ find_test_case_script_by_name() {
     find "$base_dir" -type d -iname "$test_name" -print -quit 2>/dev/null
 }
 
+# Check each given kernel config is set to y/m in /proc/config.gz, logs result, returns 0/1.
 check_kernel_config() {
-    configs="$1"
-    for config_key in $configs; do
-        if zcat /proc/config.gz | grep -qE "^$config_key=(y|m)"; then
-            log_pass "Kernel config $config_key is enabled"
+    cfgs=$1
+    for config_key in $cfgs; do
+        if command -v zgrep >/dev/null 2>&1; then
+            if zgrep -qE "^${config_key}=(y|m)" /proc/config.gz 2>/dev/null; then
+                log_pass "Kernel config $config_key is enabled"
+            else
+                log_fail "Kernel config $config_key is missing or not enabled"
+                return 1
+            fi
         else
-            log_fail "Kernel config $config_key is missing or not enabled"
-            return 1
+            # Fallback if zgrep is unavailable
+            if gzip -dc /proc/config.gz 2>/dev/null | grep -qE "^${config_key}=(y|m)"; then
+                log_pass "Kernel config $config_key is enabled"
+            else
+                log_fail "Kernel config $config_key is missing or not enabled"
+                return 1
+            fi
         fi
     done
     return 0
@@ -1437,41 +1458,71 @@ detect_ufs_partition_block() {
     return 1
 }
 
-# Check for dmesg I/O errors and log summary
+# scan_dmesg_check <label> [out_dir] [extra_err_kw] [ok_kw]
+# Returns:
+#   0 -> no errors; ok_kw matched (or not requested)
+#   1 -> error lines found
+#   2 -> no errors, but ok_kw (if given) NOT found
 scan_dmesg_errors() {
-    label="$1"                   # Example: "ufs", "emmc", "wifi"
-    output_dir="$2"              # Directory to store logs
-    extra_keywords="$3"          # (Optional) Space-separated keywords for this label
-
-    [ -z "$label" ] && return 1
-    [ -z "$output_dir" ] && output_dir="."
-
-    snapshot_file="$output_dir/${label}_dmesg_snapshot.log"
-    error_file="$output_dir/${label}_dmesg_errors.log"
-
-    log_info "Scanning dmesg for recent $label-related I/O errors..."
-
-    dmesg | tail -n 300 > "$snapshot_file"
-
-    # Common error indicators
-    common_keywords="error fail timeout reset crc abort fault invalid fatal warn"
-
-    # Build keyword pattern (common + optional extra)
-    pattern="($common_keywords"
-    if [ -n "$extra_keywords" ]; then
-        pattern="$pattern|$extra_keywords"
-    fi
-    pattern="$pattern)"
-
-    # Filter: lines must match label and error pattern
-    grep -iE "$label" "$snapshot_file" | grep -iE "$pattern" > "$error_file"
-
-    if [ -s "$error_file" ]; then
-        log_warn "Detected potential $label-related errors in dmesg:"
+    label="$1"
+    out_dir="${2:-.}"
+    extra_err="${3:-}"
+    ok_kw="${4:-}"
+ 
+    [ -z "$label" ] && return 3  # misuse
+ 
+    lines="${DMESG_LINES:-300}"
+    snap="$out_dir/${label}_dmesg_snapshot.log"
+    errf="$out_dir/${label}_dmesg_errors.log"
+    okf="$out_dir/${label}_dmesg_ok.log"
+ 
+    log_info "Scanning dmesg for ${label}: errors & success patterns"
+ 
+    dmesg | tail -n "$lines" >"$snap"
+ 
+    # Error keywords
+    common_err='error|fail|timeout|reset|crc|abort|fault|invalid|fatal|warn|oops|panic'
+    err_pat="$common_err"
+    [ -n "$extra_err" ] && err_pat="${err_pat}|${extra_err}"
+ 
+    # Find error lines (must match label AND error pattern)
+    grep -iE "$label" "$snap" | grep -iE "($err_pat)" >"$errf" 2>/dev/null
+ 
+    if [ -s "$errf" ]; then
+        log_warn "Detected potential ${label}-related errors:"
         while IFS= read -r line; do
             log_warn " dmesg: $line"
-        done < "$error_file"
-    else
-        log_info "No $label-related errors found in recent dmesg logs."
+        done <"$errf"
+        return 0
     fi
+ 
+    # Optionally look for OK messages
+    if [ -n "$ok_kw" ]; then
+        grep -iE "$ok_kw" "$snap" >"$okf" 2>/dev/null
+        if [ -s "$okf" ]; then
+            log_pass "Found success pattern for $label in dmesg"
+            while IFS= read -r line; do
+                log_info " ok: $line"
+            done <"$okf"
+            return 1
+        else
+            log_warn "No success pattern ('$ok_kw') found for $label"
+            return 2
+        fi
+    fi
+ 
+    log_info "No ${label}-related errors found (no OK pattern requested)"
+    return 1
+}
+
+# wait_for_path <path> [timeout_sec]
+wait_for_path() {
+    _p="$1"; _t="${2:-3}"
+    i=0
+    while [ "$i" -lt "$_t" ]; do
+        [ -e "$_p" ] && return 0
+        sleep 1
+        i=$((i+1))
+    done
+    return 1
 }


### PR DESCRIPTION
This PR updates only the IPA and RMNET testcases (and the shared helpers they use) to be platform-agnostic and CI friendly.
 
What changed
 
IPA (Runner/suites/Kernel/Baseport/IPA/[run.sh](http://run.sh/))
 
Gate on CONFIG_QCOM_IPA with check_kernel_config (no more broken-pipe spam).
 
Load ipa only if not already loaded; unload only if we loaded it.
 
/dev/ipa presence checked with wait_for_path; absence leads to SKIP, not FAIL.
 
Uses scan_dmesg_errors "ipa" … "handshake_complete.*error" "IPA Q6 handshake completed" to:
 
Warn on error patterns.
 
Log PASS when the success line appears.
 
 
Cleaner logging and final .res output strictly IPA PASS|FAIL|SKIP.
 
 
RMNET (Runner/suites/Kernel/Baseport/RMNET/[run.sh](http://run.sh/))
 
Gate on CONFIG_RMNET.
 
Load/unload rmnet symmetrically (respect preloaded state).
 
/dev/rmnet* checked; if missing, WARN only (common when no data call yet).
 
dmesg scanned for rmnet errors via scan_dmesg_errors "rmnet" "." "panic|oops|fault"; logs issues without hard failing unless desired.
 
Optional ip link info printed, but never fails the test if interfaces aren’t up.
 
 
Shared helpers ([functestlib.sh](http://functestlib.sh/))
 
scan_dmesg_errors(label, out_dir, extra_err, ok_kw)
 
Logs both error and success patterns.
 
Return codes: 0=errors seen, 1=no errors, 2=no OK match, 3=misuse.
 
check_kernel_config() now uses zgrep when available; gzip fallback removed the “Broken pipe” noise.