### PR TITLE
This PR introduces a standalone LAVA job definition that executes only the FastRPC test suite from qcom-linux-testkit.

### DIFF
--- a/Runner/plans/fastrpc-premerge.yaml
+++ b/Runner/plans/fastrpc-premerge.yaml
@@ -1,0 +1,19 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: fastrpc-only
+    description: "Run only FastRPC tests from qcom-linux-testkit"
+    maintainer:
+        - smuppand@qti.qualcomm.com
+    os:
+        - yocto open embedded
+    scope:
+        - functional
+    devices:
+        - rb3gen2
+
+run:
+    steps:
+        - cd Runner
+        - $PWD/suites/Multimedia/CDSP/fastrpc_test/run.sh || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.res || true
+        - $PWD/utils/result_parse.sh


### PR DESCRIPTION
Key points:
- New file: fastrpc-premerge.yaml
- Uses the standard deploy → boot → test flow, left generic for easy reuse
- Limits execution to FastRPC 
- No impact on existing jobs; this is an additive change