### PR TITLE
fix(wpss_remoteproc): write .res next to test by cd’ing into testcase dir  

### DIFF
--- a/Runner/suites/Kernel/Baseport/wpss_remoteproc/run.sh
+++ b/Runner/suites/Kernel/Baseport/wpss_remoteproc/run.sh
@@ -33,6 +33,12 @@ TESTNAME="wpss_remoteproc"
 FW="wpss"
 RES_FILE="./$TESTNAME.res"
 
+# Run from the testcase directory so relative outputs (like .res) land next to run.sh
+test_path="$(find_test_case_by_name "$TESTNAME")"
+cd "$test_path" || {
+    echo "[ERROR] Could not cd to testcase path: $test_path" >&2
+    exit 1
+}
 log_info "-----------------------------------------------------------------------------------------"
 log_info "------------------- Starting $TESTNAME Testcase ----------------------------"
 log_info "=== Test Initialization ==="


### PR DESCRIPTION
LAVA was missing the result because [run.sh](http://run.sh/) wrote ./wpss_remoteproc.res from the Runner CWD.
This change mirrors other remoteproc tests by cd’ing into the testcase directory (via find_test_case_by_name)
so the .res is created beside [run.sh](http://run.sh/) at suites/Kernel/Baseport/wpss_remoteproc/.
No test logic changes—just reliable result placement and removal of the “Result file missing” warning.