### PR TITLE
Update fastrpc-premerge.yaml to use run.sh with --bin-dir /usr/local/bin

### DIFF
--- a/Runner/plans/fastrpc-premerge.yaml
+++ b/Runner/plans/fastrpc-premerge.yaml
@@ -14,6 +14,6 @@ metadata:
 run:
     steps:
         - cd Runner
-        - $PWD/suites/Multimedia/CDSP/fastrpc_test/run.sh || true
+        - $PWD/suites/Multimedia/CDSP/fastrpc_test/run.sh --bin-dir /usr/local/bin || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.res || true
         - $PWD/utils/result_parse.sh


### PR DESCRIPTION
This pull request updates the Runner/plans/fastrpc-premerge.yaml plan to invoke run.sh with the --bin-dir argument set to /usr/local/bin.

Details:

- Modified the run.sh command to include --bin-dir /usr/local/bin.
- Ensures binaries are executed from the correct directory during pre-merge checks.
- Improves consistency with deployment and runtime environments.

Impact:

- Pre-merge validation now uses binaries from /usr/local/bin.
- Reduces risk of path-related issues in CI/CD workflows.