### PR TITLE
WiFi connectivity: CLI creds for Dynamic/Manual IP + remoteproc firmware fix

### DIFF
--- a/Runner/suites/Connectivity/WiFi/WiFi_Dynamic_IP/run.sh
+++ b/Runner/suites/Connectivity/WiFi/WiFi_Dynamic_IP/run.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
@@ -33,42 +32,106 @@ TESTNAME="WiFi_Dynamic_IP"
 test_path=$(find_test_case_by_name "$TESTNAME")
 cd "$test_path" || exit 1
 
+# ---------------- CLI (SSID/PASSWORD) ----------------
+SSID=""
+PASSWORD=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ssid)
+            shift
+            if [ -n "${1:-}" ]; then
+                SSID="$1"
+            fi
+            ;;
+        --password)
+            shift
+            if [ -n "${1:-}" ]; then
+                PASSWORD="$1"
+            fi
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--ssid SSID] [--password PASS]"
+            exit 0
+            ;;
+        *)
+            log_warn "Unknown argument: $1"
+            ;;
+    esac
+    shift
+done
+
 log_info "-------------------------------------------------------------"
 log_info "------------------- Starting $TESTNAME Test -----------------"
+log_info "Host: $(hostname 2>/dev/null || printf 'unknown')"
+log_info "Kernel: $(uname -r 2>/dev/null || printf 'unknown')"
+log_info "Date: $(date -u 2>/dev/null || printf 'unknown')"
 
 # Credential extraction
-creds=$(get_wifi_credentials "$1" "$2") || log_skip_exit "$TESTNAME" "WiFi: SSID and/or password missing. Skipping test." wifi_cleanup ""
+creds=$(get_wifi_credentials "$SSID" "$PASSWORD") || \
+    log_skip_exit "$TESTNAME" "WiFi: SSID and/or password missing. Skipping test." wifi_cleanup ""
+
 SSID=$(echo "$creds" | awk '{print $1}')
 PASSWORD=$(echo "$creds" | awk '{print $2}')
+
 log_info "Using SSID='$SSID' and PASSWORD='[hidden]'"
 
 check_dependencies iw ping
 
 # If not a kernel-only/minimal build, systemd is checked, else skipped automatically
-check_systemd_services systemd-networkd.service || log_fail_exit "$TESTNAME" "Network services check failed" wifi_cleanup ""
+log_info "Checking network service: systemd-networkd.service"
+check_systemd_services systemd-networkd.service || \
+    log_fail_exit "$TESTNAME" "Network services check failed" wifi_cleanup ""
 
-WIFI_IFACE=$(get_wifi_interface) || log_fail_exit "$TESTNAME" "No WiFi interface found" wifi_cleanup ""
+WIFI_IFACE=$(get_wifi_interface) || \
+    log_fail_exit "$TESTNAME" "No WiFi interface found" wifi_cleanup ""
+
 log_info "Using WiFi interface: $WIFI_IFACE"
 
+# Prepare a ping log file for command output (appended across retries)
+PING_LOG="./wifi_ping_${WIFI_IFACE}.log"
+: > "$PING_LOG"
+log_info "Ping output will be logged to: $PING_LOG"
+
 # nmcli with retry
+log_info "Attempting connection via nmcli…"
 if wifi_connect_nmcli "$WIFI_IFACE" "$SSID" "$PASSWORD"; then
     IP=$(wifi_get_ip "$WIFI_IFACE")
-    [ -z "$IP" ] && log_fail_exit "$TESTNAME" "No IP after nmcli" wifi_cleanup "$WIFI_IFACE"
-    if retry_command "ping -I \"$WIFI_IFACE\" -c 3 -W 2 8.8.8.8 >/dev/null 2>&1" 3 3; then
-        log_pass_exit "$TESTNAME" "Internet connectivity verified via ping" wifi_cleanup "$WIFI_IFACE"
+
+    if [ -z "$IP" ]; then
+        log_fail_exit "$TESTNAME" "No IP after nmcli" wifi_cleanup "$WIFI_IFACE"
+    fi
+
+    log_info "Acquired IP via nmcli: $IP"
+
+    PING_CMD="ping -I \"$WIFI_IFACE\" -c 3 -W 2 8.8.8.8 2>&1 | tee -a \"$PING_LOG\""
+    log_info "Connectivity check command: $PING_CMD"
+
+    if retry_command "$PING_CMD" 3 3; then
+        log_pass_exit "$TESTNAME" "Internet connectivity verified via ping (iface=$WIFI_IFACE ip=$IP)" wifi_cleanup "$WIFI_IFACE"
     else
-        log_fail_exit "$TESTNAME" "Ping test failed after nmcli connection" wifi_cleanup "$WIFI_IFACE"
+        log_fail_exit "$TESTNAME" "Ping test failed after nmcli connection (iface=$WIFI_IFACE ip=$IP). See $PING_LOG" wifi_cleanup "$WIFI_IFACE"
     fi
 fi
 
 # wpa_supplicant+udhcpc with retry
+log_info "Attempting connection via wpa_supplicant + udhcpc…"
 if wifi_connect_wpa_supplicant "$WIFI_IFACE" "$SSID" "$PASSWORD"; then
     IP=$(wifi_get_ip "$WIFI_IFACE")
-    [ -z "$IP" ] && log_fail_exit "$TESTNAME" "No IP after wpa_supplicant" wifi_cleanup "$WIFI_IFACE"
-    if retry_command "ping -I \"$WIFI_IFACE\" -c 3 -W 2 8.8.8.8 >/dev/null 2>&1" 3 3; then
-        log_pass_exit "$TESTNAME" "Internet connectivity verified via ping" wifi_cleanup "$WIFI_IFACE"
+
+    if [ -z "$IP" ]; then
+        log_fail_exit "$TESTNAME" "No IP after wpa_supplicant" wifi_cleanup "$WIFI_IFACE"
+    fi
+
+    log_info "Acquired IP via wpa_supplicant: $IP"
+
+    PING_CMD="ping -I \"$WIFI_IFACE\" -c 3 -W 2 8.8.8.8 2>&1 | tee -a \"$PING_LOG\""
+    log_info "Connectivity check command: $PING_CMD"
+
+    if retry_command "$PING_CMD" 3 3; then
+        log_pass_exit "$TESTNAME" "Internet connectivity verified via ping (iface=$WIFI_IFACE ip=$IP)" wifi_cleanup "$WIFI_IFACE"
     else
-        log_fail_exit "$TESTNAME" "Ping test failed after wpa_supplicant connection" wifi_cleanup "$WIFI_IFACE"
+        log_fail_exit "$TESTNAME" "Ping test failed after wpa_supplicant connection (iface=$WIFI_IFACE ip=$IP). See $PING_LOG" wifi_cleanup "$WIFI_IFACE"
     fi
 fi
 

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -1264,6 +1264,19 @@ dt_has_remoteproc_fw() {
     return 1
 }
 
+# Find the remoteproc path for a given firmware substring (e.g., "adsp", "cdsp", "gdsp").
+get_remoteproc_path_by_firmware() {
+    name="$1"
+    idx path
+    # List all remoteproc firmware nodes, match name, and return the remoteproc path
+    idx=$(cat /sys/class/remoteproc/remoteproc*/firmware 2>/dev/null | grep -n "$name" | cut -d: -f1 | head -n1)
+    [ -z "$idx" ] && return 1
+    idx=$((idx - 1))
+    path="/sys/class/remoteproc/remoteproc${idx}"
+    [ -d "$path" ] && echo "$path" && return 0
+    return 1
+}
+
 # Get remoteproc state
 get_remoteproc_state() {
     rp="$1"


### PR DESCRIPTION
What this PR brings in to address #186 & #188 

- Add --ssid/--password to WiFi_Dynamic_IP; preserve existing credential resolution.
- Add --ssid/--password to WiFi_Manual_IP; same fallback behavior.
- Expand one-liners to multi-line; no logic changes or exports of secrets.
- CI logging: report iface, acquired IP, ping command, and ping output in Dynamic_IP.
- Keep nmcli and wpa_supplicant+udhcpc paths, retries, and gating unchanged.
- Add functestlib:get_remoteproc_path_by_firmware(); integrate with WiFi_Firmware_Driver.
- Fixes "command not found" and validates wpss remoteproc on Kodiak/RB3gen2.
- Backward compatible with ssid_list/env; no behavior change when flags unused.
- Idempotent, readable, and safe to re-run across CI/CD.