### PR TITLE
Video Encoder Json File change as per the QLI Mainline feature enablement

### DIFF
--- a/Runner/suites/Multimedia/Video/Video_V4L2_Runner/h265Encoder.json
+++ b/Runner/suites/Multimedia/Video/Video_V4L2_Runner/h265Encoder.json
@@ -58,41 +58,6 @@
                         "Id": "GOPSize",
                         "Vtype": "Int",
                         "Value": 59
-                    },
-                    {
-                        "Id": "MultiSliceMode",
-                        "Vtype": "String",
-                        "Value": "SINGLE"
-                    },
-                    {
-                        "Id": "MinIQP",
-                        "Vtype": "Int",
-                        "Value": 10
-                    },
-                    {
-                        "Id": "MinPQP",
-                        "Vtype": "Int",
-                        "Value": 10
-                    },
-                    {
-                        "Id": "MinBQP",
-                        "Vtype": "Int",
-                        "Value": 10
-                    },
-                    {
-                        "Id": "MaxIQP",
-                        "Vtype": "Int",
-                        "Value": 51
-                    },
-                    {
-                        "Id": "MaxPQP",
-                        "Vtype": "Int",
-                        "Value": 51
-                    },
-                    {
-                        "Id": "MaxBQP",
-                        "Vtype": "Int",
-                        "Value": 51
                     }
                 ],
                 "DynamicControls": []


### PR DESCRIPTION
Video Encoder Json File change as per the QLI Mainline feature enablement

Earlier Json file has Multislice and QP related configurations which are not yet enabled on QLI Mainline Base variant. 