### PR TITLE
audio: add overlay build environment setup for audioreach

### DIFF
--- a/Runner/suites/Multimedia/Audio/AudioPlayback/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/Read_me.md
@@ -28,6 +28,16 @@ Ensure the following components are present in the target Yocto build:
 - Common tools: `pgrep`, `timeout`, `grep`, `wget`, `tar`
 - Daemon: `pipewire` or `pulseaudio` must be running
 
+## Overlay Build Support
+
+For overlay builds using audioreach kernel modules, the test automatically:
+- Detects the overlay build configuration
+- Sets required DMA heap permissions
+- Restarts PipeWire service
+- Waits for the service to be ready
+
+This happens transparently before tests run. No manual configuration needed.
+
 ## Directory Structure
 
 ```bash

--- a/Runner/suites/Multimedia/Audio/AudioPlayback/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/run.sh
@@ -41,6 +41,12 @@ fi
 # shellcheck disable=SC1091
 . "$TOOLS/lib_video.sh"
 
+if ! setup_overlay_audio_environment; then
+    log_fail "Overlay audio environment setup failed"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 1
+fi
+
 TESTNAME="AudioPlayback"
 RES_FILE="./${TESTNAME}.res"
 LOGDIR="results/${TESTNAME}"

--- a/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
@@ -27,7 +27,16 @@ Ensure the following components are present in the target Yocto build:
 - PulseAudio: `parecord`, `pactl`
 - Common tools: `pgrep`, `timeout`, `grep`, `sed`
 - Daemon: `pipewire` or `pulseaudio` must be running
-								
+
+## Overlay Build Support
+
+For overlay builds using audioreach kernel modules, the test automatically:
+- Detects the overlay build configuration
+- Sets required DMA heap permissions
+- Restarts PipeWire service
+- Waits for the service to be ready
+
+This happens transparently before tests run. No manual configuration needed.								
 
 ## Directory Structure
 

--- a/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
@@ -30,6 +30,12 @@ fi
 # shellcheck disable=SC1091
 . "$TOOLS/audio_common.sh"
 
+if ! setup_overlay_audio_environment; then
+    log_fail "Overlay audio environment setup failed"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 1
+fi
+
 TESTNAME="AudioRecord"
 RES_FILE="./${TESTNAME}.res"
 LOGDIR="results/${TESTNAME}"


### PR DESCRIPTION
Overlay builds using audioreach modules need special configuration before audio tests can run properly. Without this setup, PipeWire fails to communicate with the audio hardware.

Changes:
- Added setup_overlay_audio_environment() in audio_common.sh
  * Detects overlay builds via lsmod audioreach check
  * Sets /dev/dma_heap/system permissions (chmod 666)
  * Restarts pipewire service via systemctl
  * Waits up to 60s for service to be ready
  * Validates both process and wpctl communication
- Integrated setup call in AudioPlayback and AudioRecord tests
  * Runs early, before backend detection
  * Fails test if setup fails on overlay builds
  * Zero overhead on base builds
- Updated README files with overlay build documentation