### PR TITLE
Ethernet: Added force link speed on eth interface via ethtool

### DIFF
--- a/Runner/suites/Connectivity/Ethernet/README.md
+++ b/Runner/suites/Connectivity/Ethernet/README.md
@@ -7,9 +7,15 @@ SPDX-License-Identifier: BSD-3-Clause-Clear
 
 This test case validates the basic functionality of the Ethernet interface (`eth0`) on the device. It checks for:
 
-- Interface presence
+- Interface detection (auto or user-specified)
 - Interface status (UP/DOWN)
 - Basic connectivity via ping to `8.8.8.8`
+- Optional: forcing Ethernet link speed using ethtool
+
+By default, the script:
+
+Auto-detects available Ethernet interfaces if none is specified
+Forces the link speed to 1000 Mbps, full duplex, autoneg off (using ethtool) unless a different speed is provided
 
 ## Usage
 
@@ -29,7 +35,7 @@ scp -r common Runner user@target_device_ip:<Path in device>
 ssh user@target_device_ip
 cd <Path in device>/Runner && ./run-test.sh Ethernet
 # Optional: specify preferred interface (e.g., eth1)
-./run.sh [preferred-interface]
+./run.sh [--interface <preferred-interface>] [--speed <mbps>]
 ```
 
 ## Prerequisites

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -3796,3 +3796,25 @@ get_pid() {
         return 1
     fi
 }
+
+get_machine_model() {
+    if [ -r /sys/firmware/devicetree/base/model ]; then
+        raw=`cat /sys/firmware/devicetree/base/model`
+    else
+        log_info "Model not found"
+        return 0
+    fi
+
+    # Strip leading "Qualcomm Technologies, Inc. " if present
+    case "$raw" in
+        "Qualcomm Technologies, Inc. "*)
+            model=`printf '%s\n' "$raw" | sed 's/^Qualcomm Technologies, Inc. //'`
+            ;;
+        *)
+            model="$raw"
+            ;;
+    esac
+
+    printf '%s\n' "$model"
+    return 0
+}


### PR DESCRIPTION
- Add --interface/-i and --speed/-s options
- Default link speed to 1000 Mbps when no speed is provided
- Force link speed on eth interface via ethtool
- Update README to document new CLI