### PR TITLE
Add YAML configuration for qcom_hwrng test scripts to support the LAVA framework

### DIFF
--- a/Runner/suites/Kernel/Baseport/qcom_hwrng/qcom_hwrng.yaml
+++ b/Runner/suites/Kernel/Baseport/qcom_hwrng/qcom_hwrng.yaml
@@ -1,0 +1,21 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: qcom_hwrng
+    description: "Validates Qualcomm hardware random number generator functionality."
+    maintainer:
+        - suprband@qti.qualcomm.com
+    os:
+        - openembedded
+    scope:
+        - functional
+    devices:
+        - rb3gen2
+        - ridesx
+        - lemans evk
+        - monaco evk
+
+run:
+    steps:
+        - cd Runner
+        - $PWD/suites/Kernel/Baseport/qcom_hwrng/run.sh || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/Baseport/qcom_hwrng/qcom_hwrng.res || true


### PR DESCRIPTION
This commit introduces a YAML file that defines the qcom_hwrng test scripts for integration with the LAVA automated testing framework. 

The changes include:
- Added YAML configuration to enable qcom_hwrng test execution in LAVA jobs.
- Defined metadata and dependencies required for proper test scheduling.

Signed-off-by: Suprith Bandi suprband@qti.qualcomm.com
