### PR TITLE
Fix: AudioPlayback no longer requires network when clips exist

### DIFF
--- a/Runner/suites/Multimedia/Audio/AudioPlayback/AudioPlayback.yaml
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/AudioPlayback.yaml
@@ -18,6 +18,8 @@ params:
   DMESG_SCAN: 1  # Scan dmesg for errors after playback, default: 1
   VERBOSE: 0  # Enable verbose logging, default: 0
   EXTRACT_AUDIO_ASSETS: true  # Download/extract audio assets if missing, default: true
+  ENABLE_NETWORK_DOWNLOAD: false  # Enable network download of missing audio files, default: false
+  AUDIO_CLIPS_BASE_DIR: ""  # Custom path to pre-staged audio clips (for CI), default: unset
   SSID: ""  # Wi-Fi SSID for network connection, default: unset
   PASSWORD: ""  # Wi-Fi password for network connection, default: unset
   NET_PROBE_ROUTE_IP: "1.1.1.1"  # IP used for route probing, default: 1.1.1.1
@@ -27,5 +29,5 @@ run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/Audio/AudioPlayback/
-    - ./run.sh --backend "${AUDIO_BACKEND}" --sink "${SINK_CHOICE}" --format "${FORMAT}" --durations "${DURATIONS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --ssid "${SSID}" --password "${PASSWORD}" || true
+    - ./run.sh --backend "${AUDIO_BACKEND}" --sink "${SINK_CHOICE}" --formats "${FORMATS}" --durations "${DURATIONS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --audio-clips-path "${AUDIO_CLIPS_BASE_DIR}" --ssid "${SSID}" --password "${PASSWORD}" || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh AudioPlayback.res || true

--- a/Runner/utils/audio_common.sh
+++ b/Runner/utils/audio_common.sh
@@ -30,7 +30,8 @@ check_audio_daemon() {
 
 # ---------- Assets / clips ----------
 resolve_clip() {
-  fmt="$1"; dur="$2"; base="AudioClips"
+  fmt="$1"; dur="$2"
+  base="${AUDIO_CLIPS_BASE_DIR:-AudioClips}"
   case "$fmt:$dur" in
     wav:short|wav:medium|wav:long) printf '%s\n' "$base/yesterday_48KHz.wav" ;;
     *) printf '%s\n' "" ;;
@@ -734,4 +735,23 @@ alsa_pick_virtual_pcm() {
     fi
   done
   return 1
+}
+
+
+# Check if all required audio clips are available locally
+# Usage: audio_check_clips_available "$FORMATS" "$DURATIONS"
+# Returns: 0 if all clips present and non-empty, 1 if any clip missing or empty
+audio_check_clips_available() {
+  formats="$1"
+  durations="$2"
+  
+  for fmt in $formats; do
+    for dur in $durations; do
+      clip="$(resolve_clip "$fmt" "$dur")"
+      if [ -n "$clip" ] && [ ! -s "$clip" ]; then
+        return 1  # At least one clip missing or empty
+      fi
+    done
+  done
+  return 0  # All clips present and non-empty
 }


### PR DESCRIPTION
Resolves #229

Problem:
AudioPlayback test was forcing network connections even when audio files were already present locally, causing tests to fail in offline environments.

Solution:
- Add --enable-network-download flag (opt-in, default: disabled)
- Add audio_check_clips_available() to check files before network ops
- Implement smart network gating: only connect if files missing AND flag enabled
- Auto-enable network download when WiFi credentials provided via CLI