### PR TITLE
Fix AudioRecord parameter parsing

### DIFF
--- a/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
@@ -84,7 +84,7 @@ while [ $# -gt 0 ]; do
       DURATIONS="$2"
       shift 2
       ;;
-    --rec-secs)
+    --rec-secs|--record-seconds)
       REC_SECS="$2"
       shift 2
       ;;
@@ -97,8 +97,16 @@ while [ $# -gt 0 ]; do
       shift 2
       ;;
     --strict)
-      STRICT=1
-      shift
+      case "$2" in
+        --*|"")
+          STRICT=1
+          shift
+          ;;
+        *)
+          STRICT="$2"
+          shift 2
+          ;;
+      esac
       ;;
     --no-dmesg)
       DMESG_SCAN=0


### PR DESCRIPTION
## Issue
Fixes #234 - AudioRecord test freezes on RB8

## Root Cause
- run.sh only accepted `--rec-secs` but YAML was using `--record-seconds`
- run.sh `--strict` flag didn't accept values, but YAML was passing `--strict 0`

## Solution
Updated run.sh to:
1. Accept both `--rec-secs` and `--record-seconds` as aliases
2. Allow `--strict` to accept optional values 0 or 1 