### PR TITLE
Standardize AudioRecord to use --record-seconds parameter

### DIFF
--- a/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
@@ -101,10 +101,10 @@ Variable	      Description	                                   Default
 AUDIO_BACKEND	  Selects backend: pipewire or pulseaudio	       auto-detect
 SOURCE_CHOICE	  Recording source: mic or null	                   mic
 DURATIONS	      Recording durations: short, medium, long	       short
-RECORD_SECONDS	  Number of seconds to record (numeric or mapped)  5
+RECORD_SECONDS	  Number of seconds to record (numeric or mapped), default: 30s  30
 LOOPS	          Number of recording loops	                       1
 TIMEOUT	          Recording timeout per loop (e.g., 15s, 0=none)   0
-STRICT	          Enable strict mode (fail on any error)	       0
+STRICT	          Strict mode (0=disabled, 1=enabled, fail on any error)	       0
 DMESG_SCAN	      Scan dmesg for errors after recording	           1
 VERBOSE	          Enable verbose logging	                       0
 JUNIT_OUT	      Path to write JUnit XML output	               unset
@@ -118,7 +118,7 @@ Option	          Description
 --record-seconds  Number of seconds to record (numeric or mapped)
 --loops	          Number of recording loops
 --timeout	      Recording timeout per loop (e.g., 15s)
---strict	      Enable strict mode
+--strict [0|1]    Enable strict mode (0=disabled, 1=enabled)
 --no-dmesg	      Disable dmesg scan
 --junit<file.xml> Write JUnit XML output
 --verbose	      Enable verbose logging
@@ -130,7 +130,7 @@ Sample Output:
 sh-5.2# ./run.sh --backend pipewire
 [INFO] 2025-09-12 06:06:04 - ---------------- Starting AudioRecord ----------------
 [INFO] 2025-09-12 06:06:04 - SoC: 498
-[INFO] 2025-09-12 06:06:04 - Args: backend=pipewire source=mic loops=1 durations='short' rec_secs=30s timeout=0 strict=0 dmesg=1
+[INFO] 2025-09-12 06:06:04 - Args: backend=pipewire source=mic loops=1 durations='short' record_seconds=30s timeout=0 strict=0 dmesg=1
 [INFO] 2025-09-12 06:06:04 - Using backend: pipewire
 [INFO] 2025-09-12 06:06:04 - Routing to source: id/name=48 label='pal source handset mic' choice=mic
 [INFO] 2025-09-12 06:06:04 - Watchdog/timeout: 0
@@ -163,4 +163,3 @@ Results:
 
 SPDX-License-Identifier: BSD-3-Clause-Clear  
 (C) Qualcomm Technologies, Inc. and/or its subsidiaries.
-

--- a/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
@@ -44,8 +44,8 @@ mkdir -p "$LOGDIR"
 # ---------------- Defaults / CLI ----------------
 AUDIO_BACKEND=""
 SRC_CHOICE="${SRC_CHOICE:-mic}" # mic|null
-DURATIONS="${DURATIONS:-short}" # label set OR numeric tokens when REC_SECS=auto
-REC_SECS="${REC_SECS:-30s}" # DEFAULT: 30s; 'auto' maps short/med/long
+DURATIONS="${DURATIONS:-short}" # label set OR numeric tokens when RECORD_SECONDS=auto
+RECORD_SECONDS="${RECORD_SECONDS:-30s}" # DEFAULT: 30s; 'auto' maps short/med/long
 LOOPS="${LOOPS:-1}"
 TIMEOUT="${TIMEOUT:-0}" # 0 = no watchdog
 STRICT="${STRICT:-0}"
@@ -58,11 +58,11 @@ usage() {
 Usage: $0 [options]
   --backend {pipewire|pulseaudio}
   --source {mic|null}
-  --rec-secs SECS|auto (default: 30s; 'auto' maps short=5s, medium=15s, long=30s)
-  --durations "short [medium] [long] [10s] [35secs]" (used when --rec-secs auto)
+  --record-seconds SECS|auto (default: 30s; 'auto' maps short=5s, medium=15s, long=30s)
+  --durations "short [medium] [long] [10s] [35secs]" (used when --record-seconds auto)
   --loops N
   --timeout SECS
-  --strict
+  --strict [0|1]
   --no-dmesg
   --junit FILE.xml
   --verbose
@@ -84,8 +84,8 @@ while [ $# -gt 0 ]; do
       DURATIONS="$2"
       shift 2
       ;;
-    --rec-secs|--record-seconds)
-      REC_SECS="$2"
+    --record-seconds)
+      RECORD_SECONDS="$2"
       shift 2
       ;;
     --loops)
@@ -148,7 +148,7 @@ else
   log_info "Platform Details: unknown"
 fi
 
-log_info "Args: backend=${AUDIO_BACKEND:-auto} source=$SRC_CHOICE loops=$LOOPS durations='$DURATIONS' rec_secs=$REC_SECS timeout=$TIMEOUT strict=$STRICT dmesg=$DMESG_SCAN"
+log_info "Args: backend=${AUDIO_BACKEND:-auto} source=$SRC_CHOICE loops=$LOOPS durations='$DURATIONS' record_seconds=$RECORD_SECONDS timeout=$TIMEOUT strict=$STRICT dmesg=$DMESG_SCAN"
 
 # Resolve backend
 if [ -z "$AUDIO_BACKEND" ]; then
@@ -364,7 +364,7 @@ append_junit() {
   } >> "$JUNIT_TMP"
 }
 
-# Auto map if REC_SECS=auto, and accept numeric tokens like 35s/35sec/35secs/35seconds
+# Auto map if RECORD_SECONDS=auto, and accept numeric tokens like 35s/35sec/35secs/35seconds
 auto_secs_for() {
   case "$1" in
     short) echo "5s" ;;
@@ -405,7 +405,7 @@ for dur in $DURATIONS; do
   : > "$logf"
   export AUDIO_LOGCTX="$logf"
 
-  secs="$REC_SECS"
+  secs="$RECORD_SECONDS"
   if [ "$secs" = "auto" ]; then
     tok="$(printf '%s' "$dur" | tr '[:upper:]' '[:lower:]')"
     tok_secs="$(printf '%s' "$tok" | sed -n 's/^\([0-9][0-9]*\)\(s\|sec\|secs\|seconds\)$/\1s/p')"


### PR DESCRIPTION
Fixes #233

- Removed --rec-secs alias, standardized on --record-seconds
- Updated internal variable from REC_SECS to RECORD_SECONDS
- Updated usage() function to show --record-seconds
- Updated --strict to show it accepts optional values [0|1]
- Updated README documentation for consistency

All documentation and code now consistently use --record-seconds.