### PR TITLE
Fix: USBHost test results inconsistent

### DIFF
--- a/Runner/suites/Kernel/Baseport/USBHost/run.sh
+++ b/Runner/suites/Kernel/Baseport/USBHost/run.sh
@@ -55,9 +55,10 @@ echo "Enumerated USB devices..."
 echo "$usb_output"
 
 # Check if any USB devices were found
-if [ "$device_count" -eq 0 ]; then
+if [ -z "$usb_output" ] || [ "$device_count" -eq 0 ]; then
     log_fail "$TESTNAME : Test Failed - No USB devices found."
     echo "$TESTNAME FAIL" > "$res_file"
+	exit 1
 
 elif [ "$non_hub_count" -eq 0 ]; then
     log_fail "$TESTNAME : Test Failed - Only USB hubs detected, no functional USB devices."


### PR DESCRIPTION
Resolves #228

Problem: In some platforms, during verification of 'lsusb' command, an empty character may cause false positive in the 'if' check and report test pass even though no USB devices are connected.
Solution: Add additional test condition to verify output of 'lsusb' command and avoid false pass when no USB device is connected.