### PR TITLE
Audio: Increase pre-merge test coverage to 10 test cases

### DIFF
--- a/Runner/plans/meta-ar-ci-premerge.yaml
+++ b/Runner/plans/meta-ar-ci-premerge.yaml
@@ -1,22 +1,61 @@
 metadata:
     format: Lava-Test Test Definition 1.0
     name: SmokeSanity
-    description: "Pre-merge LAVA plan to run AudioRecord and AudioPlayback on every PR"
+    description: "Pre-merge LAVA plan to run AudioPlayback and AudioRecord test cases on every PR"
     maintainer:
-        - abbajaj@qti.qualcomm.com
+        - tmoida@qti.qualcomm.com
     os:
         - openembedded
     scope:
         - functional
-    devices:
-        - rb3gen2
 
 run:
     steps:
         - cd Runner
-        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback.res || true  
-        - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord.res || true
+        
+        # ========== AudioPlayback Test Cases (7 configs) ==========
+        
+        # Playback Test 1: Config1 (16KHz, 16-bit, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config1.res || true
+        
+        # Playback Test 2: Config7 (24KHz, 24-bit, 6ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config7" --res-suffix "Config7" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config7.res || true
+        
+        # Playback Test 3: Config13 (44.1KHz, 16-bit, 1ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config13" --res-suffix "Config13" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config13.res || true
+        
+        # Playback Test 4: Config15 (48KHz, 8-bit, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config15" --res-suffix "Config15" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config15.res || true
+        
+        # Playback Test 5: Config18 (88.2KHz, 24-bit, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config18" --res-suffix "Config18" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config18.res || true
+        
+        # Playback Test 6: Config20 (96KHz, 24-bit, 6ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config20" --res-suffix "Config20" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config20.res || true
+        
+        # Playback Test 7: Config5 (192KHz, 32-bit, 8ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config5" --res-suffix "Config5" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config5.res || true
+        
+        # ========== AudioRecord Test Cases (3 configs) ==========
+        
+        # Record Test 1: record_config1 (8KHz, 1ch)
+        - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config1" --res-suffix "Config1" --record-seconds 10s || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config1.res || true
+        
+        # Record Test 2: record_config7 (48KHz, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config7" --res-suffix "Config7" --record-seconds 10s || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config7.res || true
+        
+        # Record Test 3: record_config10 (96KHz, 6ch)
+        - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config10" --res-suffix "Config10" --record-seconds 10s || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config10.res || true
+        
+        # Parse and report results
         - $PWD/utils/result_parse.sh
-

--- a/Runner/suites/Multimedia/Audio/AudioPlayback/AudioPlayback.yaml
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/AudioPlayback.yaml
@@ -8,8 +8,10 @@ metadata:
     - functional
 
 params:
-  AUDIO_BACKEND: ""	 # Selects backend: pipewire or pulseaudio, default: auto-detect
+  AUDIO_BACKEND: ""  # Selects backend: pipewire or pulseaudio, default: auto-detect
   SINK_CHOICE: "speakers"  # Playback sink: speakers or null, default: speakers
+  CLIP_NAMES: "Config1"  # Test specific clips (e.g., "Config1 Config2" or "play_48KHz_8b_2ch"), default: Config1
+  CLIP_FILTER: ""  # Filter clips by pattern (e.g., "48KHz" or "16b" or "2ch"), default: unset
   FORMATS: "wav"  # Audio formats: e.g. wav, default: wav
   DURATIONS: "short"  # Playback durations: short, medium, long, default: short
   LOOPS: 1  # Number of playback loops, default: 1
@@ -24,10 +26,11 @@ params:
   PASSWORD: ""  # Wi-Fi password for network connection, default: unset
   NET_PROBE_ROUTE_IP: "1.1.1.1"  # IP used for route probing, default: 1.1.1.1
   NET_PING_HOST: "8.8.8.8"  # Host used for ping reachability check, default: 8.8.8.8
+  RES_SUFFIX: ""  # Suffix for unique result file and log directory (e.g., "Config1" generates AudioPlayback_Config1.res and results/AudioPlayback_Config1/), default: unset
 
 run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/Audio/AudioPlayback/
-    - ./run.sh --backend "${AUDIO_BACKEND}" --sink "${SINK_CHOICE}" --formats "${FORMATS}" --durations "${DURATIONS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --audio-clips-path "${AUDIO_CLIPS_BASE_DIR}" --ssid "${SSID}" --password "${PASSWORD}" || true
-    - $REPO_PATH/Runner/utils/send-to-lava.sh AudioPlayback.res || true
+    - ./run.sh --backend "${AUDIO_BACKEND}" --sink "${SINK_CHOICE}" --clip-name "${CLIP_NAMES}" --clip-filter "${CLIP_FILTER}" --formats "${FORMATS}" --durations "${DURATIONS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --audio-clips-path "${AUDIO_CLIPS_BASE_DIR}" --res-suffix "${RES_SUFFIX}" --ssid "${SSID}" --password "${PASSWORD}" || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh AudioPlayback${RES_SUFFIX:+_${RES_SUFFIX}}.res || true

--- a/Runner/suites/Multimedia/Audio/AudioPlayback/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/Read_me.md
@@ -8,6 +8,12 @@ This suite automates the validation of audio playback capabilities on Qualcomm L
 ## Features
 
 - Supports **PipeWire** and **PulseAudio** backends
+- **20-clip test coverage**: Comprehensive validation across diverse audio formats (sample rates: 8KHz-352.8KHz, bit depths: 8b-32b, channels: 1ch-8ch)
+- **Flexible clip selection**: 
+  - Use generic config names (Config1-Config20) for easy selection
+  - Use descriptive names (e.g., play_48KHz_16b_2ch) for specific formats
+  - Auto-discovery mode tests all available clips
+- **Clip filtering**: Filter tests by sample rate, bit rate, or channel configuration
 - Plays audio clips with configurable format, duration, and loop count
 - **Network operations are optional**: By default, no network connection is attempted. Use `--enable-network-download` to enable downloading missing audio files
 - Automatically downloads and extracts audio assets if missing
@@ -19,6 +25,38 @@ This suite automates the validation of audio playback capabilities on Qualcomm L
 - Evidence-based validation (user-space, ALSA, ASoC, dmesg)	
 - Generates `.res` result file and optional JUnit XML output
 								 
+
+## Audio Clip Configurations
+
+The test suite includes 20 diverse audio clip configurations covering various sample rates, bit depths, and channel configurations:
+
+Config         Descriptive Name             Sample Rate	    Bit Rate    Channels
+Config1        play_16KHz_16b_2ch	        16 KHz	        16-bit	    2ch
+Config2        play_176.4KHz_24b_1ch	    176.4 KHz	    24-bit	    1ch
+Config3        play_176.4KHz_32b_6ch	    176.4 KHz	    32-bit	    6ch
+Config4        play_192KHz_16b_6ch          192 KHz	        16-bit	    6ch
+Config5        play_192KHz_32b_8ch          192 KHz	        32-bit	    8ch
+Config6        play_22.050KHz_8b_1ch	    22.05 KHz	    8-bit       1ch
+Config7        play_24KHz_24b_6ch	        24 KHz	        24-bit	    6ch
+Config8        play_24KHz_32b_8ch	        24 KHz	        32-bit	    8ch
+Config9        play_32KHz_16b_2ch	        32 KHz	        16-bit	    2ch
+Config10       play_32KHz_8b_8ch	        32 KHz	        8-bit       8ch
+Config11       play_352.8KHz_32b_1ch	    352.8 KHz	    32-bit	    1ch
+Config12       play_384KHz_32b_2ch          384 KHz	        32-bit	    2ch
+Config13       play_44.1KHz_16b_1ch         44.1 KHz	    16-bit	    1ch
+Config14       play_44.1KHz_8b_6ch          44.1 KHz	    8-bit       6ch
+Config15       play_48KHz_8b_2ch	        48 KHz	        8-bit       2ch
+Config16       play_48KHz_8b_8ch	        48 KHz	        8-bit       8ch
+Config17       play_88.2KHz_16b_8ch         88.2 KHz	    16-bit	    8ch
+Config18       play_88.2KHz_24b_2ch         88.2 KHz	    24-bit	    2ch
+Config19       play_8KHz_8b_1ch             8 KHz	        8-bit       1ch
+Config20       play_96KHz_24b_6ch	        96 KHz	        24-bit	    6ch
+
+Coverage Summary:
+- Sample Rates: 8 KHz, 16 KHz, 22.05 KHz, 24 KHz, 32 KHz, 44.1 KHz, 48 KHz, 88.2 KHz, 96 KHz, 176.4 KHz, 192 KHz, 352.8 KHz, 384 KHz
+- Bit Depths: 8-bit, 16-bit, 24-bit, 32-bit
+- Channel Configurations: 1ch (Mono), 2ch (Stereo), 6ch (5.1 Surround), 8ch (7.1 Surround)
+- Total Configurations: 20 unique audio format combinations
 
 ## Prerequisites
 
@@ -112,6 +150,33 @@ AUDIO_CLIPS_BASE_DIR="/tmp/ci-audio-staging/AudioClips" ./run-test.sh AudioPlayb
 
 **Directly from Test Directory**
 cd Runner/suites/Multimedia/Audio/AudioPlayback
+
+# Test all 20 clips (auto-discovery mode)
+./run.sh --no-extract-assets
+
+# Test specific clips using Config naming (Config1 to Config20)
+./run.sh --no-extract-assets --clip-name "Config1"
+./run.sh --no-extract-assets --clip-name "Config1 Config5 Config10"
+
+# Test specific clips using descriptive names
+./run.sh --no-extract-assets --clip-name "play_48KHz_8b_2ch"
+./run.sh --no-extract-assets --clip-name "play_8KHz_8b_1ch"
+./run.sh --no-extract-assets --clip-name "play_192KHz_32b_8ch"
+
+# Filter clips by sample rate
+./run.sh --no-extract-assets --clip-filter "48KHz"
+./run.sh --no-extract-assets --clip-filter "192KHz"
+
+# Filter clips by bit depth
+./run.sh --no-extract-assets --clip-filter "16b"
+./run.sh --no-extract-assets --clip-filter "24b"
+
+# Filter clips by channel configuration
+./run.sh --no-extract-assets --clip-filter "2ch"
+./run.sh --no-extract-assets --clip-filter "8ch"
+
+# Combine filters (tests clips matching any pattern)
+./run.sh --no-extract-assets --clip-filter "48KHz 16b"
 # Show usage/help
 ./run.sh --help
 
@@ -127,34 +192,41 @@ cd Runner/suites/Multimedia/Audio/AudioPlayback
 # Provide JUnit output and disable dmesg scan
 ./run.sh --junit results.xml --no-dmesg
 
+# CI/LAVA workflow: Generate unique result files for each test
+./run.sh --clip-name "Config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets
+./run.sh --clip-name "Config7" --res-suffix "Config7" --audio-clips-path /home/AudioClips/ --no-extract-assets
+# This generates AudioPlayback_Config1.res and AudioPlayback_Config7.res (no overwriting)
+
 
 
 Environment Variables:
-Variable	             Description	                                 Default
-AUDIO_BACKEND	         Selects backend: pipewire or pulseaudio	     auto-detect
-SINK_CHOICE	             Playback sink: speakers or null	             speakers
-FORMATS	                 Audio formats: e.g. wav	                     wav
-DURATIONS	             Playback durations: short, medium, long	     short
-LOOPS	                 Number of playback loops	                     1
-TIMEOUT	                 Playback timeout per loop (e.g., 15s, 0=none)	 0
-STRICT	                 Enable strict mode (fail on any error)	         0
-DMESG_SCAN	             Scan dmesg for errors after playback	         1
-VERBOSE	                 Enable verbose logging	                         0
-EXTRACT_AUDIO_ASSETS     Download/extract audio assets if missing	     true
-ENABLE_NETWORK_DOWNLOAD  Enable network download of missing audio files  false
-AUDIO_CLIPS_BASE_DIR     Custom path to pre-staged audio clips (CI use)  unset
-JUNIT_OUT	             Path to write JUnit XML output	                 unset
-SSID                     Wi-Fi SSID for network connection               unset
-PASSWORD                 Wi-Fi password for network connection           unset
-NET_PROBE_ROUTE_IP       IP used for route probing (default: 1.1.1.1)    1.1.1.1
-NET_PING_HOST            Host used for ping reachability check           8.8.8.8
+Variable	             Description	                                   Default
+AUDIO_BACKEND	         Selects backend: pipewire or pulseaudio	       auto-detect
+SINK_CHOICE	             Playback sink: speakers or null	               speakers
+FORMATS	                 Audio formats: e.g. wav	                       wav
+DURATIONS	             Playback durations: short, medium, long	       short
+LOOPS	                 Number of playback loops	                       1
+TIMEOUT	                 Playback timeout per loop (e.g., 15s, 0=none)     0
+STRICT	                 Enable strict mode (fail on any error)            0
+DMESG_SCAN	             Scan dmesg for errors after playback	           1
+VERBOSE	                 Enable verbose logging                            0
+EXTRACT_AUDIO_ASSETS     Download/extract audio assets if missing	       true
+ENABLE_NETWORK_DOWNLOAD  Enable network download of missing audio files    false
+AUDIO_CLIPS_BASE_DIR     Custom path to pre-staged audio clips (CI use)    unset
+JUNIT_OUT                Path to write JUnit XML output                    unset
+SSID                     Wi-Fi SSID for network connection                 unset
+PASSWORD                 Wi-Fi password for network connection             unset
+NET_PROBE_ROUTE_IP       IP used for route probing (default: 1.1.1.1)      1.1.1.1
+NET_PING_HOST            Host used for ping reachability check             8.8.8.8
 
 
 CLI Options
 Option	                    Description
 --backend	                Select backend: pipewire or pulseaudio
 --sink	                    Playback sink: speakers or null
---formats	                Audio formats (space/comma separated): e.g. wav
+--clip-name <names>         Test specific clips using Config1-Config20 or descriptive names (space-separated)
+--clip-filter <patterns>    Filter clips by sample rate, bit rate, or channels (space-separated patterns)
+--formats	                Audio formats (space/comma separated): e.g. wav 
 --durations	                Playback durations: short, medium, long
 --loops	                    Number of playback loops
 --timeout	                Playback timeout per loop (e.g., 15s)
@@ -163,6 +235,7 @@ Option	                    Description
 --no-extract-assets         Disable asset extraction entirely (skips all asset operations)
 --enable-network-download   Enable network operations to download missing audio files (default: disabled)
 --audio-clips-path <path>   Custom location for audio clips (for CI with pre-staged clips)
+--res-suffix <suffix>       Suffix for unique result file and log directory (e.g., "Config1" generates AudioPlayback_Config1.res and results/AudioPlayback_Config1/)
 --junit <file.xml>	        Write JUnit XML output
 --verbose	                Enable verbose logging
 --help	                    Show usage instructions
@@ -170,29 +243,94 @@ Option	                    Description
 ```
 
 Sample Output:
+
+**Example 1: Testing specific clip using Config naming**
 ```
-sh-5.3# ./run.sh --backend pipewire
-[INFO] 2025-09-12 05:24:47 - ---------------- Starting AudioPlayback ----------------
-[INFO] 2025-09-12 05:24:47 - SoC: 498
-[INFO] 2025-09-12 05:24:47 - Args: backend=pipewire sink=speakers loops=1 timeout=0 formats='wav' durations='short' strict=0 dmesg=1 extract=true
-[INFO] 2025-09-12 05:24:47 - Using backend: pipewire
-[INFO] 2025-09-12 05:24:47 - Routing to sink: id=72 name='Built-in Audio Speaker playback' choice=speakers
-[INFO] 2025-09-12 05:24:47 - Watchdog/timeout: 0
-[INFO] 2025-09-12 05:24:47 - [play_wav_short] loop 1/1 start=2025-09-12T05:24:47Z clip=AudioClips/yesterday_48KHz.wav backend=pipewire sink=speakers(72)
-[INFO] 2025-09-12 05:24:47 - [play_wav_short] exec: pw-play -v "AudioClips/yesterday_48KHz.wav"
-[INFO] 2025-09-12 05:26:52 - [play_wav_short] evidence: pw_streaming=1 pa_streaming=0 alsa_running=1 asoc_path_on=1 pw_log=1
-[PASS] 2025-09-12 05:26:52 - [play_wav_short] loop 1 OK (rc=0, 125s)
-[INFO] 2025-09-12 05:26:52 - Scanning dmesg for snd|audio|pipewire|pulseaudio: errors & success patterns
-[INFO] 2025-09-12 05:26:52 - No snd|audio|pipewire|pulseaudio-related errors found (no OK pattern requested)
-[INFO] 2025-09-12 05:26:52 - Summary: total=1 pass=1 fail=0 skip=0
-[PASS] 2025-09-12 05:26:52 - AudioPlayback PASS
+sh-5.3# ./run.sh --no-extract-assets --clip-name "Config1"
+[INFO] 2025-12-30 11:47:32 - ---------------- Starting AudioPlayback ----------------
+[INFO] 2025-12-30 11:47:32 - Platform Details: machine='Qualcomm Technologies, Inc. Robotics RB3gen2' target='Kodiak' kernel='6.18.0-00393-g27507852413b' arch='aarch64'
+[INFO] 2025-12-30 11:47:32 - Args: backend=auto sink=speakers loops=1 timeout=0 formats='wav' durations='short' strict=0 dmesg=1 extract=false network_download=false clips_path=default
+[INFO] 2025-12-30 11:47:32 - Using backend: pipewire
+[INFO] 2025-12-30 11:47:32 - Routing to sink: id=52 name='Built-in Audio Speaker playback' choice=speakers
+[INFO] 2025-12-30 11:47:32 - Using clip discovery mode
+[INFO] 2025-12-30 11:47:32 - Discovered 1 clips to test
+[INFO] 2025-12-30 11:47:32 - [play_16KHz_16b_2ch] Using clip: yesterday_16KHz_30s_16b_2ch.wav (1922036 bytes)
+[INFO] 2025-12-30 11:47:32 - [play_16KHz_16b_2ch] loop 1/1 start=2025-12-30T11:47:32Z clip=yesterday_16KHz_30s_16b_2ch.wav backend=pipewire sink=speakers(52)
+[INFO] 2025-12-30 11:47:32 - [play_16KHz_16b_2ch] exec: pw-play -v "AudioClips/yesterday_16KHz_30s_16b_2ch.wav"
+[INFO] 2025-12-30 11:48:02 - [play_16KHz_16b_2ch] evidence: pw_streaming=1 pa_streaming=0 alsa_running=1 asoc_path_on=1 pw_log=1
+[PASS] 2025-12-30 11:48:02 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
+[INFO] 2025-12-30 11:48:02 - Summary: total=1 pass=1 fail=0 skip=0
+[PASS] 2025-12-30 11:48:02 - AudioPlayback PASS
+```
+
+**Example 2: Testing multiple clips**
+```
+sh-5.3# ./run.sh --no-extract-assets --clip-name "Config1 Config2 Config3"
+[INFO] 2025-12-30 11:48:13 - Using clip discovery mode
+[INFO] 2025-12-30 11:48:13 - Discovered 3 clips to test
+[INFO] 2025-12-30 11:48:13 - [play_16KHz_16b_2ch] Using clip: yesterday_16KHz_30s_16b_2ch.wav (1922036 bytes)
+[PASS] 2025-12-30 11:48:43 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
+[INFO] 2025-12-30 11:48:43 - [play_176.4KHz_24b_1ch] Using clip: yesterday_176.4KHz_30s_24b_1ch.wav (15892062 bytes)
+[PASS] 2025-12-30 11:49:14 - [play_176.4KHz_24b_1ch] loop 1 OK (rc=0, 31s)
+[INFO] 2025-12-30 11:49:14 - [play_176.4KHz_32b_6ch] Using clip: yesterday_176.4KHz_30s_32b_6ch.wav (127135484 bytes)
+[PASS] 2025-12-30 11:49:44 - [play_176.4KHz_32b_6ch] loop 1 OK (rc=0, 30s)
+[INFO] 2025-12-30 11:49:44 - Summary: total=3 pass=3 fail=0 skip=0
+[PASS] 2025-12-30 11:49:44 - AudioPlayback PASS
+```
+
+**Example 3: Filtering clips by sample rate**
+```
+sh-5.3# ./run.sh --no-extract-assets --clip-filter "48KHz"
+[INFO] 2025-12-30 12:00:08 - Using clip discovery mode
+[INFO] 2025-12-30 12:00:08 - Discovered 2 clips to test
+[INFO] 2025-12-30 12:00:08 - [play_48KHz_8b_2ch] Using clip: yesterday_48KHz_30s_8b_2ch.wav (2883002 bytes)
+[PASS] 2025-12-30 12:00:38 - [play_48KHz_8b_2ch] loop 1 OK (rc=0, 30s)
+[INFO] 2025-12-30 12:00:38 - [play_48KHz_8b_8ch] Using clip: yesterday_48KHz_30s_8b_8ch.wav (11531688 bytes)
+[PASS] 2025-12-30 12:01:08 - [play_48KHz_8b_8ch] loop 1 OK (rc=0, 30s)
+[INFO] 2025-12-30 12:01:08 - Summary: total=2 pass=2 fail=0 skip=0
+[PASS] 2025-12-30 12:01:08 - AudioPlayback PASS
+```
+
+**Example 4: Invalid config name (shows helpful error)**
+```
+sh-5.3# ./run.sh --no-extract-assets --clip-name "Config0"
+[INFO] 2025-12-30 11:59:52 - Using clip discovery mode
+[SKIP] 2025-12-30 11:59:52 - AudioPlayback SKIP - Invalid clip/config name(s) provided. Available range: Config1 to Config20
+```
+
+**Example 5: CI/LAVA workflow with unique result files**
+```
+sh-5.3# ./run.sh --clip-name "Config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets
+[INFO] 2026-01-12 06:56:47 - Using unique result file: ./AudioPlayback_Config1.res
+[INFO] 2026-01-12 06:56:47 - ---------------- Starting AudioPlayback ----------------
+[INFO] 2026-01-12 06:56:48 - Using clip discovery mode
+[INFO] 2026-01-12 06:56:48 - Discovered 1 clips to test
+[INFO] 2026-01-12 06:56:48 - [play_16KHz_16b_2ch] Clip duration: 30s (timeout threshold: 29s)
+[PASS] 2026-01-12 06:57:18 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
+[PASS] 2026-01-12 06:57:18 - AudioPlayback PASS
+
+sh-5.3# cat AudioPlayback_Config1.res
+AudioPlayback PASS
+
+sh-5.3# ./run.sh --clip-name "Config7" --res-suffix "Config7" --audio-clips-path /home/AudioClips/ --no-extract-assets
+[INFO] 2026-01-12 06:57:42 - Using unique result file: ./AudioPlayback_Config7.res
+[PASS] 2026-01-12 06:58:13 - AudioPlayback PASS
+
+sh-5.3# cat AudioPlayback_Config7.res
+AudioPlayback PASS
+
+# Both result files exist without overwriting
+sh-5.3# ls -1 AudioPlayback*.res
+AudioPlayback_Config1.res
+AudioPlayback_Config7.res
 ```
 
 Results:
-Results are stored in: results/AudioPlayback/
-Summary result file: AudioPlayback.res
-JUnit XML (if enabled): <your-path>.xml
-Diagnostic logs: dmesg snapshots, mixer dumps, playback logs per test case
+- Results are stored in: results/AudioPlayback/ (or results/AudioPlayback_<suffix>/ when using --res-suffix)
+- Summary result file: AudioPlayback.res (or AudioPlayback_<suffix>.res when using --res-suffix)
+- JUnit XML (if enabled): <your-path>.xml
+- Diagnostic logs: dmesg snapshots, mixer dumps, playback logs per test case
+- **Note**: When using --res-suffix, both result files AND log directories are unique per invocation, preventing log collisions in CI/LAVA workflows
 
 
 ## Notes
@@ -211,5 +349,3 @@ Diagnostic logs: dmesg snapshots, mixer dumps, playback logs per test case
 
 SPDX-License-Identifier: BSD-3-Clause-Clear  
 (C) Qualcomm Technologies, Inc. and/or its subsidiaries.
-
-

--- a/Runner/suites/Multimedia/Audio/AudioRecord/AudioRecord.yaml
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/AudioRecord.yaml
@@ -8,19 +8,22 @@ metadata:
     - functional
 
 params:
-  AUDIO_BACKEND: ""	 # Selects backend: pipewire or pulseaudio, default: auto-detect
+  AUDIO_BACKEND: ""  # Selects backend: pipewire or pulseaudio, default: auto-detect
   SOURCE_CHOICE: "mic"  # Recording source: mic or null, default: mic
-  DURATIONS: "short"  # Playback durations: short, medium, long, default: short
-  RECORD_SECONDS: 5  # Number of seconds to record (numeric or mapped), default: 5
-  LOOPS: 1  # Number of playback loops, default: 1
-  TIMEOUT: 0  # Playback timeout per loop (e.g., 15s, 0=none), default: 0
+  CONFIG_NAMES: "record_config1"  # Test specific configs (e.g., "record_config1 record_config2"), default: record_config1
+  CONFIG_FILTER: ""  # Filter configs by pattern (e.g., "48KHz" or "2ch"), default: unset
+  DURATIONS: "short"  # Recording durations: short, medium, long, default: short
+  RECORD_SECONDS: "5s"  # Recording duration with unit suffix (e.g., "5s", "10s", "30s"), default: 5s
+  LOOPS: 1  # Number of recording loops, default: 1
+  TIMEOUT: 0  # Recording timeout per loop (e.g., 15s, 0=none), default: 0
   STRICT: 0  # Enable strict mode (fail on any error), default: 0
-  DMESG_SCAN: 1  # Scan dmesg for errors after playback, default: 1
+  DMESG_SCAN: 1  # Scan dmesg for errors after recording, default: 1
   VERBOSE: 0  # Enable verbose logging, default: 0
+  RES_SUFFIX: ""  # Suffix for unique result file and log directory (e.g., "Config1" generates AudioRecord_Config1.res and results/AudioRecord_Config1/), default: unset
 
 run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/Audio/AudioRecord/
-    - ./run.sh --backend "${AUDIO_BACKEND}" --source "${SOURCE_CHOICE}" --durations "${DURATIONS}" --record-seconds "${RECORD_SECONDS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" || true
-    - $REPO_PATH/Runner/utils/send-to-lava.sh AudioRecord.res || true
+    - ./run.sh --backend "${AUDIO_BACKEND}" --source "${SOURCE_CHOICE}" --config-name "${CONFIG_NAMES}" --config-filter "${CONFIG_FILTER}" --durations "${DURATIONS}" --record-seconds "${RECORD_SECONDS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --res-suffix "${RES_SUFFIX}" || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh AudioRecord${RES_SUFFIX:+_${RES_SUFFIX}}.res || true

--- a/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
@@ -6,18 +6,43 @@ This suite automates the validation of audio recording capabilities on Qualcomm 
 
 ## Features
 
-
 - Supports **PipeWire** and **PulseAudio** backends
-- Records audio clips with configurable duration and loop count
+- **10-config test coverage**: Comprehensive validation across diverse audio formats (sample rates: 8KHz-96KHz, channels: 1ch-6ch)
+- **Flexible config selection**: 
+  - Use generic config names (record_config1-record_config10) for easy selection
+  - Use descriptive names (e.g., record_48KHz_2ch) for specific formats
+  - Auto-discovery mode tests all available configs
+- **Config filtering**: Filter tests by sample rate or channel configuration
+- Records audio with configurable duration and loop count
 - Automatically detects and routes to appropriate source (e.g., mic, null)
 - Validates recording using multiple evidence sources:
   - PipeWire/PulseAudio streaming state
   - ALSA and ASoC runtime status
   - Kernel logs (`dmesg`)
-- Diagnostic logs: dmesg scan, mixer dumps, playback logs
+- Diagnostic logs: dmesg scan, mixer dumps, recording logs
 - Evidence-based validation (user-space, ALSA, ASoC, dmesg)
 - Generates `.res` result file and optional JUnit XML output
 
+## Audio Record Configurations
+
+The test suite includes 10 diverse audio record configurations covering various sample rates and channel configurations:
+
+Config           Descriptive Name    Sample Rate  Channels 
+record_config1   record_8KHz_1ch     8 KHz        1ch
+record_config2   record_16KHz_1ch    16 KHz       1ch
+record_config3   record_16KHz_2ch    16 KHz       2ch
+record_config4   record_24KHz_1ch    24 KHz       1ch
+record_config5   record_32KHz_2ch    32 KHz       2ch
+record_config6   record_44.1KHz_2ch  44.1 KHz     2ch
+record_config7   record_48KHz_2ch    48 KHz       2ch
+record_config8   record_48KHz_6ch    48 KHz       6ch
+record_config9   record_96KHz_2ch    96 KHz       2ch
+record_config10  record_96KHz_6ch    96 KHz       6ch
+
+**Coverage Summary:**
+- **Sample Rates**: 8 KHz, 16 KHz, 24 KHz, 32 KHz, 44.1 KHz, 48 KHz, 96 KHz
+- **Channel Configurations**: 1ch (Mono), 2ch (Stereo), 6ch (5.1 Surround)
+- **Total Configurations**: 10 unique audio format combinations
 
 ## Prerequisites
 
@@ -25,6 +50,7 @@ Ensure the following components are present in the target Yocto build:
 
 - PipeWire: `pw-record`, `wpctl`
 - PulseAudio: `parecord`, `pactl`
+- ALSA: `arecord`
 - Common tools: `pgrep`, `timeout`, `grep`, `sed`
 - Daemon: `pipewire` or `pulseaudio` must be running
 
@@ -36,7 +62,7 @@ For overlay builds using audioreach kernel modules, the test automatically:
 - Restarts PipeWire service
 - Waits for the service to be ready
 
-This happens transparently before tests run. No manual configuration needed.								
+This happens transparently before tests run. No manual configuration needed.
 
 ## Directory Structure
 
@@ -71,20 +97,44 @@ scp -r Runner user@target_device_ip:<Path in device>
 ssh user@target_device_ip 
 
 **Using Unified Runner**
-cd <Path in device>Runner
+cd <Path in device>/Runner
 
-# Run Audiorecord using PipeWire (auto-detects backend if not specified)
-./run-test.sh Audiorecord
+# Run AudioRecord using PipeWire (auto-detects backend if not specified)
+./run-test.sh AudioRecord
 
 # Force PulseAudio backend
-AUDIO_BACKEND=pulseaudio ./run-test.sh Audiorecord
+AUDIO_BACKEND=pulseaudio ./run-test.sh AudioRecord
 
 # Custom options via environment variables
-AUDIO_BACKEND=pipewire RECORD_TIMEOUT=20s RECORD_LOOPS=2 RECORD_VOLUME=0.5 ./run-test.sh Audiorecord
+AUDIO_BACKEND=pipewire RECORD_SECONDS=10s LOOPS=2 ./run-test.sh AudioRecord
 
 
 **Directly from Test Directory**
-cd Runner/suites/Multimedia/Audio/Audiorecord
+cd Runner/suites/Multimedia/Audio/AudioRecord
+
+# Test all 10 configs (auto-discovery mode)
+./run.sh
+
+# Test specific configs using config naming (record_config1 to record_config10)
+./run.sh --config-name "record_config1"
+./run.sh --config-name "record_config1 record_config2 record_config3"
+
+# Test specific configs using descriptive names
+./run.sh --config-name "record_48KHz_2ch"
+./run.sh --config-name "record_8KHz_1ch"
+./run.sh --config-name "record_96KHz_6ch"
+
+# Filter configs by sample rate
+./run.sh --config-filter "48KHz"
+./run.sh --config-filter "96KHz"
+
+# Filter configs by channel configuration
+./run.sh --config-filter "1ch"
+./run.sh --config-filter "2ch"
+./run.sh --config-filter "6ch"
+
+# Combine filters (tests configs matching any pattern)
+./run.sh --config-filter "48KHz 2ch"
 
 # Show usage/help
 ./run.sh --help
@@ -95,61 +145,189 @@ cd Runner/suites/Multimedia/Audio/Audiorecord
 # Run with PulseAudio, null source, strict mode, verbose
 ./run.sh --backend pulseaudio --source null --strict --verbose
 
+# Provide JUnit output and disable dmesg scan
+./run.sh --junit results.xml --no-dmesg
+
+# CI/LAVA workflow: Generate unique result files for each test
+./run.sh --config-name "record_config1" --res-suffix "Config1" --record-seconds 10s
+./run.sh --config-name "record_config7" --res-suffix "Config7" --record-seconds 10s
+./run.sh --config-name "record_config10" --res-suffix "Config10" --record-seconds 10s
+# This generates AudioRecord_Config1.res, AudioRecord_Config7.res, and AudioRecord_Config10.res (no overwriting)
+
 
 Environment Variables:
-Variable	      Description	                                   Default
-AUDIO_BACKEND	  Selects backend: pipewire or pulseaudio	       auto-detect
-SOURCE_CHOICE	  Recording source: mic or null	                   mic
-DURATIONS	      Recording durations: short, medium, long	       short
-RECORD_SECONDS	  Number of seconds to record (numeric or mapped), default: 30s  30
-LOOPS	          Number of recording loops	                       1
-TIMEOUT	          Recording timeout per loop (e.g., 15s, 0=none)   0
-STRICT	          Strict mode (0=disabled, 1=enabled, fail on any error)	       0
-DMESG_SCAN	      Scan dmesg for errors after recording	           1
-VERBOSE	          Enable verbose logging	                       0
-JUNIT_OUT	      Path to write JUnit XML output	               unset
+Variable	      Description	                                                  Default
+AUDIO_BACKEND	  Selects backend: pipewire or pulseaudio	                      auto-detect
+SOURCE_CHOICE	  Recording source: mic or null                                   mic
+DURATIONS	      Recording durations: short, medium, long(legacy matrix mode)    short
+RECORD_SECONDS	  Number of seconds to record (e.g., 5s, 10s)                     30s
+LOOPS	          Number of recording loops	                                      1
+TIMEOUT	          Recording timeout per loop (e.g., 15s, 0=none)                  0
+STRICT	          Strict mode (0=disabled, 1=enabled, fail on any error)	      0
+DMESG_SCAN	      Scan dmesg for errors after recording	                          1
+VERBOSE	          Enable verbose logging	                                      0
+JUNIT_OUT	      Path to write JUnit XML output	                              unset
 
 
 CLI Options:
-Option	          Description
---backend	      Select backend: pipewire or pulseaudio
---source	      Recording source: mic or null
---durations	      Recording durations: short, medium, long
---record-seconds  Number of seconds to record (numeric or mapped)
---loops	          Number of recording loops
---timeout	      Recording timeout per loop (e.g., 15s)
---strict [0|1]    Enable strict mode (0=disabled, 1=enabled)
---no-dmesg	      Disable dmesg scan
---junit<file.xml> Write JUnit XML output
---verbose	      Enable verbose logging
---help	          Show usage instructions
+Option	                      Description
+--backend	                  Select backend: pipewire or pulseaudio
+--source	                  Recording source: mic or null
+--config-name <names>         Test specific configs using record_config1-record_config10 or descriptive names (space-separated)
+--config-filter <patterns>    Filter configs by sample rate or channels (space-separated patterns)
+--record-seconds <duration>   Number of seconds to record (e.g., 5s, 10s)
+--durations	                  Recording durations: short, medium, long (legacy matrix mode only)
+--loops	                      Number of recording loops
+--timeout	                  Recording timeout per loop (e.g., 15s)
+--strict [0|1]                Enable strict mode (0=disabled, 1=enabled)
+--no-dmesg	                  Disable dmesg scan
+--res-suffix <suffix>         Suffix for unique result file and log directory (e.g., "Config1" generates AudioRecord_Config1.res and results/AudioRecord_Config1/)
+--junit <file.xml>            Write JUnit XML output
+--verbose	                  Enable verbose logging
+--help	                      Show usage instructions
 ```
 
 Sample Output:
+
+**Example 1: Testing specific config using config naming**
 ```
-sh-5.2# ./run.sh --backend pipewire
-[INFO] 2025-09-12 06:06:04 - ---------------- Starting AudioRecord ----------------
-[INFO] 2025-09-12 06:06:04 - SoC: 498
-[INFO] 2025-09-12 06:06:04 - Args: backend=pipewire source=mic loops=1 durations='short' record_seconds=30s timeout=0 strict=0 dmesg=1
-[INFO] 2025-09-12 06:06:04 - Using backend: pipewire
-[INFO] 2025-09-12 06:06:04 - Routing to source: id/name=48 label='pal source handset mic' choice=mic
-[INFO] 2025-09-12 06:06:04 - Watchdog/timeout: 0
-[INFO] 2025-09-12 06:06:04 - [record_short] loop 1/1 start=2025-09-12T06:06:04Z secs=30s backend=pipewire source=mic(48)
-[INFO] 2025-09-12 06:06:04 - [record_short] exec: pw-record -v "results/AudioRecord/record_short.wav"
-[WARN] 2025-09-12 06:06:34 - [record_short] nonzero rc=124 but recording looks valid (bytes=5738540) - PASS
-[INFO] 2025-09-12 06:06:34 - [record_short] evidence: pw_streaming=1 pa_streaming=0 alsa_running=1 asoc_path_on=1 bytes=5738540 pw_log=1
-[PASS] 2025-09-12 06:06:34 - [record_short] loop 1 OK (rc=0, 30s, bytes=5738540)
-[INFO] 2025-09-12 06:06:34 - Scanning dmesg for snd|audio|pipewire|pulseaudio: errors & success patterns
-[INFO] 2025-09-12 06:06:34 - No snd|audio|pipewire|pulseaudio-related errors found (no OK pattern requested)
-[INFO] 2025-09-12 06:06:34 - Summary: total=1 pass=1 fail=0 skip=0
-[PASS] 2025-09-12 06:06:34 - AudioRecord PASS
+sh-5.3# ./run.sh --config-name "record_config1"
+[INFO] 2026-01-02 12:00:46 - Base build detected (no audioreach modules), skipping overlay setup
+[INFO] 2026-01-02 12:00:46 - ---------------- Starting AudioRecord ----------------
+[INFO] 2026-01-02 12:00:46 - Platform Details: machine='Qualcomm Technologies, Inc. Robotics RB3gen2' target='Kodiak' kernel='6.18.0-00393-g27507852413b' arch='aarch64'
+[INFO] 2026-01-02 12:00:46 - Args: backend=auto source=mic loops=1 durations='short' record_seconds=30s timeout=0 strict=0 dmesg=1
+[INFO] 2026-01-02 12:00:46 - Backend fallback chain: pipewire pulseaudio alsa
+[INFO] 2026-01-02 12:00:46 - Using backend: pipewire
+[INFO] 2026-01-02 12:00:46 - Routing to source: id/name=45 label='Built-in Audio internal Mic' choice=mic
+[INFO] 2026-01-02 12:00:46 - Watchdog/timeout: disabled (no timeout)
+[INFO] 2026-01-02 12:00:46 - Using config discovery mode
+[INFO] 2026-01-02 12:00:46 - Discovered 1 configs to test
+[INFO] 2026-01-02 12:00:46 - [record_8KHz_1ch] Using config: record_config1 (rate=8000Hz channels=1)
+[INFO] 2026-01-02 12:00:46 - [record_8KHz_1ch] loop 1/1 start=2026-01-02T12:00:46Z rate=8000Hz channels=1 backend=pipewire source=mic(45)
+[INFO] 2026-01-02 12:00:46 - [record_8KHz_1ch] exec: pw-record -v --rate=8000 --channels=1 "results/AudioRecord/record_8KHz_1ch.wav"
+[WARN] 2026-01-02 12:01:16 - [record_8KHz_1ch] nonzero rc=124 but recording looks valid (bytes=482634) - PASS
+[INFO] 2026-01-02 12:01:16 - [record_8KHz_1ch] evidence: pw_streaming=1 pa_streaming=0 alsa_running=1 asoc_path_on=1 bytes=482634 pw_log=1
+[PASS] 2026-01-02 12:01:16 - [record_8KHz_1ch] loop 1 OK (rc=0, 30s, bytes=482634)
+[INFO] 2026-01-02 12:01:16 - No relevant, non-benign errors for modules [results/AudioRecord] in recent dmesg.
+[INFO] 2026-01-02 12:01:16 - Summary: total=1 pass=1 fail=0 skip=0
+[PASS] 2026-01-02 12:01:16 - AudioRecord PASS
+```
+
+**Example 2: Testing multiple configs**
+```
+sh-5.3# ./run.sh --config-name "record_config1 record_config2"
+[INFO] 2026-01-02 11:47:53 - Using config discovery mode
+[INFO] 2026-01-02 11:47:53 - Discovered 2 configs to test
+[INFO] 2026-01-02 11:47:53 - [record_8KHz_1ch] Using config: record_config1 (rate=8000Hz channels=1)
+[PASS] 2026-01-02 11:48:23 - [record_8KHz_1ch] loop 1 OK (rc=0, 30s, bytes=482292)
+[INFO] 2026-01-02 11:48:23 - [record_16KHz_1ch] Using config: record_config2 (rate=16000Hz channels=1)
+[PASS] 2026-01-02 11:48:53 - [record_16KHz_1ch] loop 1 OK (rc=0, 30s, bytes=957768)
+[INFO] 2026-01-02 11:48:53 - Summary: total=2 pass=2 fail=0 skip=0
+[PASS] 2026-01-02 11:48:53 - AudioRecord PASS
+```
+
+**Example 3: Filtering configs by sample rate**
+```
+sh-5.3# ./run.sh --config-filter "48KHz"
+[INFO] 2026-01-02 11:52:22 - Using config discovery mode
+[INFO] 2026-01-02 11:52:22 - Discovered 2 configs to test
+[INFO] 2026-01-02 11:52:22 - [record_48KHz_2ch] Using config: record_config7 (rate=48000Hz channels=2)
+[PASS] 2026-01-02 11:52:53 - [record_48KHz_2ch] loop 1 OK (rc=0, 31s, bytes=5791788)
+[INFO] 2026-01-02 11:52:53 - [record_48KHz_6ch] Using config: record_config8 (rate=48000Hz channels=6)
+[PASS] 2026-01-02 11:53:23 - [record_48KHz_6ch] loop 1 OK (rc=0, 30s, bytes=17240144)
+[INFO] 2026-01-02 11:53:23 - Summary: total=2 pass=2 fail=0 skip=0
+[PASS] 2026-01-02 11:53:23 - AudioRecord PASS
+```
+
+**Example 4: Filtering configs by channel configuration**
+```
+sh-5.3# ./run.sh --config-filter "2ch"
+[INFO] 2026-01-02 11:53:38 - Using config discovery mode
+[INFO] 2026-01-02 11:53:38 - Discovered 5 configs to test
+[INFO] 2026-01-02 11:53:38 - [record_16KHz_2ch] Using config: record_config3 (rate=16000Hz channels=2)
+[PASS] 2026-01-02 11:54:08 - [record_16KHz_2ch] loop 1 OK (rc=0, 30s, bytes=1930512)
+[INFO] 2026-01-02 11:54:08 - [record_32KHz_2ch] Using config: record_config5 (rate=32000Hz channels=2)
+[PASS] 2026-01-02 11:54:38 - [record_32KHz_2ch] loop 1 OK (rc=0, 30s, bytes=3833788)
+[INFO] 2026-01-02 11:54:38 - [record_44.1KHz_2ch] Using config: record_config6 (rate=44100Hz channels=2)
+[PASS] 2026-01-02 11:55:08 - [record_44.1KHz_2ch] loop 1 OK (rc=0, 30s, bytes=5283464)
+[INFO] 2026-01-02 11:55:08 - [record_48KHz_2ch] Using config: record_config7 (rate=48000Hz channels=2)
+[PASS] 2026-01-02 11:55:38 - [record_48KHz_2ch] loop 1 OK (rc=0, 30s, bytes=5746732)
+[INFO] 2026-01-02 11:55:38 - [record_96KHz_2ch] Using config: record_config9 (rate=96000Hz channels=2)
+[PASS] 2026-01-02 11:56:09 - [record_96KHz_2ch] loop 1 OK (rc=0, 30s, bytes=11509556)
+[INFO] 2026-01-02 11:56:09 - Summary: total=5 pass=5 fail=0 skip=0
+[PASS] 2026-01-02 11:56:09 - AudioRecord PASS
+```
+
+**Example 5: Invalid config name (shows helpful error)**
+```
+sh-5.3# ./run.sh --config-name "record_config99"
+[INFO] 2026-01-02 11:59:34 - Using config discovery mode
+[SKIP] 2026-01-02 11:59:34 - AudioRecord SKIP - [ERROR] 2026-01-02 11:59:34 - Available range: record_config1 to record_config10
+```
+
+**Example 6: CI/LAVA workflow with unique result files**
+```
+sh-5.3# ./run.sh --config-name "record_config1" --res-suffix "Config1" --record-seconds 10s
+[INFO] 2026-01-12 07:14:09 - Using unique result file: ./AudioRecord_Config1.res
+[INFO] 2026-01-12 07:14:09 - ---------------- Starting AudioRecord ----------------
+[INFO] 2026-01-12 07:14:09 - Using config discovery mode
+[INFO] 2026-01-12 07:14:09 - Discovered 1 configs to test
+[INFO] 2026-01-12 07:14:09 - [record_8KHz_1ch] Using config: record_config1 (rate=8000Hz channels=1)
+[PASS] 2026-01-12 07:14:19 - [record_8KHz_1ch] loop 1 OK (rc=0, 10s, bytes=162462)
+[PASS] 2026-01-12 07:14:19 - AudioRecord PASS
+
+sh-5.3# cat AudioRecord_Config1.res
+AudioRecord PASS
+
+sh-5.3# ./run.sh --config-name "record_config7" --res-suffix "Config7" --record-seconds 10s
+[INFO] 2026-01-12 07:16:01 - Using unique result file: ./AudioRecord_Config7.res
+[PASS] 2026-01-12 07:16:11 - AudioRecord PASS
+
+sh-5.3# cat AudioRecord_Config7.res
+AudioRecord PASS
+
+# Both result files exist without overwriting
+sh-5.3# ls -1 AudioRecord*.res
+AudioRecord_Config1.res
+AudioRecord_Config7.res
+```
+
+**Example 7: Testing all 10 configs with short duration**
+```
+sh-5.3# ./run.sh --record-seconds 3s
+[INFO] 2026-01-02 12:05:26 - Auto-detected config discovery mode (testing all 10 record configs)
+[INFO] 2026-01-02 12:05:26 - Using config discovery mode
+[INFO] 2026-01-02 12:05:26 - Discovered 10 configs to test
+[INFO] 2026-01-02 12:05:26 - [record_8KHz_1ch] Using config: record_config1 (rate=8000Hz channels=1)
+[PASS] 2026-01-02 12:05:30 - [record_8KHz_1ch] loop 1 OK (rc=0, 3s, bytes=49822)
+[INFO] 2026-01-02 12:05:30 - [record_16KHz_1ch] Using config: record_config2 (rate=16000Hz channels=1)
+[PASS] 2026-01-02 12:05:33 - [record_16KHz_1ch] loop 1 OK (rc=0, 3s, bytes=96242)
+[INFO] 2026-01-02 12:05:33 - [record_16KHz_2ch] Using config: record_config3 (rate=16000Hz channels=2)
+[PASS] 2026-01-02 12:05:36 - [record_16KHz_2ch] loop 1 OK (rc=0, 3s, bytes=186980)
+[INFO] 2026-01-02 12:05:36 - [record_24KHz_1ch] Using config: record_config4 (rate=24000Hz channels=1)
+[PASS] 2026-01-02 12:05:39 - [record_24KHz_1ch] loop 1 OK (rc=0, 3s, bytes=142322)
+[INFO] 2026-01-02 12:05:39 - [record_32KHz_2ch] Using config: record_config5 (rate=32000Hz channels=2)
+[PASS] 2026-01-02 12:05:42 - [record_32KHz_2ch] loop 1 OK (rc=0, 3s, bytes=376764)
+[INFO] 2026-01-02 12:05:42 - [record_44.1KHz_2ch] Using config: record_config6 (rate=44100Hz channels=2)
+[PASS] 2026-01-02 12:05:46 - [record_44.1KHz_2ch] loop 1 OK (rc=0, 4s, bytes=523016)
+[INFO] 2026-01-02 12:05:46 - [record_48KHz_2ch] Using config: record_config7 (rate=48000Hz channels=2)
+[PASS] 2026-01-02 12:05:49 - [record_48KHz_2ch] loop 1 OK (rc=0, 3s, bytes=565292)
+[INFO] 2026-01-02 12:05:49 - [record_48KHz_6ch] Using config: record_config8 (rate=48000Hz channels=6)
+[PASS] 2026-01-02 12:05:52 - [record_48KHz_6ch] loop 1 OK (rc=0, 3s, bytes=1695824)
+[INFO] 2026-01-02 12:05:52 - [record_96KHz_2ch] Using config: record_config9 (rate=96000Hz channels=2)
+[PASS] 2026-01-02 12:05:55 - [record_96KHz_2ch] loop 1 OK (rc=0, 3s, bytes=1138484)
+[INFO] 2026-01-02 12:05:55 - [record_96KHz_6ch] Using config: record_config10 (rate=96000Hz channels=6)
+[PASS] 2026-01-02 12:05:59 - [record_96KHz_6ch] loop 1 OK (rc=0, 3s, bytes=3415400)
+[INFO] 2026-01-02 12:05:59 - Summary: total=10 pass=10 fail=0 skip=0
+[PASS] 2026-01-02 12:05:59 - AudioRecord PASS
 ```
 
 Results:
-- Results are stored in: results/Audiorecord/
-- Summary result file: Audiorecord.res
+- Results are stored in: results/AudioRecord/ (or results/AudioRecord_<suffix>/ when using --res-suffix)
+- Summary result file: AudioRecord.res (or AudioRecord_<suffix>.res when using --res-suffix)
 - JUnit XML (if enabled): <your-path>.xml
 - Diagnostic logs: dmesg snapshots, mixer dumps, record logs per test case
+- **Note**: When using --res-suffix, both result files AND log directories are unique per invocation, preventing log collisions in CI/LAVA workflows
 
 
 ## Notes
@@ -158,6 +336,9 @@ Results:
 - If any critical tool is missing, the script exits with an error message.
 - Logs include dmesg snapshots, mixer dumps, and record logs.
 - Evidence-based PASS/FAIL logic ensures reliability even if backend quirks occur.
+- **Config discovery mode** is enabled by default, testing all 10 configurations automatically.
+- Use `--config-name` to test specific configurations or `--config-filter` to filter by sample rate or channels.
+- The `--durations` option is for legacy matrix mode only; use `--config-name` or `--config-filter` for config discovery mode (recommended).
 
 ## License
 

--- a/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
@@ -30,21 +30,40 @@ fi
 # shellcheck disable=SC1091
 . "$TOOLS/audio_common.sh"
 
+TESTNAME="AudioRecord"
+RES_SUFFIX=""  # Optional suffix for unique result files (e.g., "Config1")
+# RES_FILE will be set after parsing command-line arguments
+
+# Pre-parse --res-suffix for early failure handling
+# This ensures unique result files even if setup fails in parallel CI runs
+prev_arg=""
+for arg in "$@"; do
+  case "$prev_arg" in
+    --res-suffix)
+      RES_SUFFIX="$arg"
+      break
+      ;;
+  esac
+  prev_arg="$arg"
+done
+
+# Early failure handling with suffix support
 if ! setup_overlay_audio_environment; then
     log_fail "Overlay audio environment setup failed"
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 1
+    if [ -n "$RES_SUFFIX" ]; then
+      echo "$TESTNAME FAIL" > "$SCRIPT_DIR/${TESTNAME}_${RES_SUFFIX}.res"
+    else
+      echo "$TESTNAME FAIL" > "$SCRIPT_DIR/${TESTNAME}.res"
+    fi
+    exit 0
 fi
 
-TESTNAME="AudioRecord"
-RES_FILE="./${TESTNAME}.res"
-LOGDIR="results/${TESTNAME}"
-mkdir -p "$LOGDIR"
+# LOGDIR will be set after parsing command-line arguments (to apply RES_SUFFIX correctly)
 
 # ---------------- Defaults / CLI ----------------
 AUDIO_BACKEND=""
 SRC_CHOICE="${SRC_CHOICE:-mic}" # mic|null
-DURATIONS="${DURATIONS:-short}" # label set OR numeric tokens when RECORD_SECONDS=auto
+DURATIONS=""  # Will be set to default only if using legacy mode
 RECORD_SECONDS="${RECORD_SECONDS:-30s}" # DEFAULT: 30s; 'auto' maps short/med/long
 LOOPS="${LOOPS:-1}"
 TIMEOUT="${TIMEOUT:-0}" # 0 = no watchdog
@@ -53,11 +72,21 @@ DMESG_SCAN="${DMESG_SCAN:-1}"
 VERBOSE=0
 JUNIT_OUT=""
 
+# New config-based testing options
+CONFIG_NAMES=""        # Explicit config names to test (e.g., "record_config1 record_config2")
+CONFIG_FILTER=""       # Filter pattern for configs (e.g., "48KHz" or "2ch")
+USE_CONFIG_DISCOVERY="${USE_CONFIG_DISCOVERY:-auto}"  # auto|true|false
+
 usage() {
   cat <<EOF
 Usage: $0 [options]
   --backend {pipewire|pulseaudio}
   --source {mic|null}
+  --config-name "record_config1"        # Test specific config(s) by name (space-separated)
+                                         # Also supports record_config1, record_config2, ..., record_config10
+  --config-filter "48KHz"               # Filter configs by pattern
+  --res-suffix SUFFIX                   # Suffix for unique result file (e.g., "Config1")
+                                         # Generates AudioRecord_SUFFIX.res instead of AudioRecord.res
   --record-seconds SECS|auto (default: 30s; 'auto' maps short=5s, medium=15s, long=30s)
   --durations "short [medium] [long] [10s] [35secs]" (used when --record-seconds auto)
   --loops N
@@ -67,6 +96,19 @@ Usage: $0 [options]
   --junit FILE.xml
   --verbose
   --help
+
+Examples:
+  # Test all 10 record configs
+  $0
+
+  # Test specific configs by name
+  $0 --config-name "record_config1 record_config2 record_config3"
+
+  # Test specific configs by descriptive name
+  $0 --config-name "record_48KHz_2ch record_8KHz_1ch"
+
+  # Filter configs by pattern
+  $0 --config-filter "48KHz"
 EOF
 }
 
@@ -80,8 +122,23 @@ while [ $# -gt 0 ]; do
       SRC_CHOICE="$2"
       shift 2
       ;;
+    --config-name)
+      CONFIG_NAMES="$2"
+      USE_CONFIG_DISCOVERY=true
+      shift 2
+      ;;
+    --config-filter)
+      CONFIG_FILTER="$2"
+      USE_CONFIG_DISCOVERY=true
+      shift 2
+      ;;
+    --res-suffix)
+      RES_SUFFIX="$2"
+      shift 2
+      ;;
     --durations)
       DURATIONS="$2"
+      USE_CONFIG_DISCOVERY=false  # Explicit durations = use old matrix mode
       shift 2
       ;;
     --record-seconds)
@@ -131,6 +188,28 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Generate result file path with optional suffix (after parsing CLI args)
+# Use absolute path anchored to SCRIPT_DIR for consistency
+if [ -n "$RES_SUFFIX" ]; then
+  RES_FILE="$SCRIPT_DIR/${TESTNAME}_${RES_SUFFIX}.res"
+  log_info "Using unique result file: $RES_FILE"
+else
+  RES_FILE="$SCRIPT_DIR/${TESTNAME}.res"
+fi
+
+# Initialize LOGDIR after parsing CLI args (to apply RES_SUFFIX correctly)
+# Use absolute paths for LOGDIR to work from any directory
+# Apply suffix for unique log directories per invocation (matches RES_FILE behavior)
+LOGDIR="$SCRIPT_DIR/results/${TESTNAME}"
+if [ -n "$RES_SUFFIX" ]; then
+  LOGDIR="${LOGDIR}_${RES_SUFFIX}"
+  log_info "Using unique log directory: $LOGDIR"
+fi
+mkdir -p "$LOGDIR"
+
+# Initialize summary file to prevent accumulation from previous test runs
+: > "$LOGDIR/summary.txt"
+
 # Ensure we run from the testcase dir
 test_path="$(find_test_case_by_name "$TESTNAME" 2>/dev/null || echo "$SCRIPT_DIR")"
 if ! cd "$test_path"; then
@@ -148,6 +227,36 @@ else
   log_info "Platform Details: unknown"
 fi
 
+# ------------- Mode Detection and Validation -------------
+
+# Check for conflicting parameters (discovery vs legacy mode)
+if { [ -n "$CONFIG_NAMES" ] || [ -n "$CONFIG_FILTER" ]; } && [ -n "$DURATIONS" ]; then
+  log_error "Cannot mix config discovery parameters (--config-name, --config-filter) with legacy matrix parameters (--durations)"
+  log_error "Please use either config discovery mode OR legacy matrix mode, not both"
+  echo "$TESTNAME SKIP" > "$RES_FILE"
+  exit 0
+fi
+
+# Set defaults for legacy mode parameters only if using legacy mode
+if [ "$USE_CONFIG_DISCOVERY" = "false" ]; then
+  DURATIONS="${DURATIONS:-short}"  # label set OR numeric tokens when RECORD_SECONDS=auto
+fi
+
+# Determine whether to use config discovery or legacy matrix mode
+if [ "$USE_CONFIG_DISCOVERY" = "auto" ]; then
+  # Auto mode: use config discovery by default (no external dependencies needed)
+  USE_CONFIG_DISCOVERY=true
+  log_info "Auto-detected config discovery mode (testing all 10 record configs)"
+fi
+
+
+# Validate CLI option conflicts
+if [ -n "$CONFIG_NAMES" ] && [ -n "$CONFIG_FILTER" ]; then
+  log_warn "Both --config-name and --config-filter specified"
+  log_info "Using --config-name (ignoring --config-filter)"
+  CONFIG_FILTER=""
+fi
+
 log_info "Args: backend=${AUDIO_BACKEND:-auto} source=$SRC_CHOICE loops=$LOOPS durations='$DURATIONS' record_seconds=$RECORD_SECONDS timeout=$TIMEOUT strict=$STRICT dmesg=$DMESG_SCAN"
 
 # Resolve backend
@@ -160,14 +269,14 @@ log_info "Backend fallback chain: $BACKENDS_TO_TRY"
 if [ -z "$AUDIO_BACKEND" ]; then
   log_skip "$TESTNAME SKIP - no audio backend running"
   echo "$TESTNAME SKIP" > "$RES_FILE"
-  exit 2
+  exit 0
 fi
 log_info "Using backend: $AUDIO_BACKEND"
 
 if ! check_audio_daemon "$AUDIO_BACKEND"; then
   log_skip "$TESTNAME SKIP - backend not available: $AUDIO_BACKEND"
   echo "$TESTNAME SKIP" > "$RES_FILE"
-  exit 2
+  exit 0
 fi
 
 # Dependencies per backend
@@ -175,13 +284,13 @@ if [ "$AUDIO_BACKEND" = "pipewire" ]; then
   if ! check_dependencies wpctl pw-record; then
     log_skip "$TESTNAME SKIP - missing PipeWire utils"
     echo "$TESTNAME SKIP" > "$RES_FILE"
-    exit 2
+    exit 0
   fi
 else
   if ! check_dependencies pactl parecord; then
     log_skip "$TESTNAME SKIP - missing PulseAudio utils"
     echo "$TESTNAME SKIP" > "$RES_FILE"
-    exit 2
+    exit 0
   fi
 fi
 
@@ -240,17 +349,17 @@ fi
 if [ -z "$SRC_ID" ] && [ "$AUDIO_BACKEND" != "pipewire" ]; then
   log_skip "$TESTNAME SKIP - requested source '$SRC_CHOICE' not available on any backend ($BACKENDS_TO_TRY)"
   echo "$TESTNAME SKIP" > "$RES_FILE"
-  exit 2
+  exit 0
 fi
 
 # ---- Normalize ALSA device id (fix "hw:0 1," → "hw:0,1") ----
 if [ "$AUDIO_BACKEND" = "alsa" ]; then
   case "$SRC_ID" in
     hw:*" "*,)
-      SRC_ID=$(printf '%s' "$SRC_ID" | sed -E 's/^hw:([0-9]+) ([0-9]+),$/hw:\1,\2/')
+      SRC_ID=$(printf '%s' "$SRC_ID" | sed 's/^hw:\([0-9][0-9]*\) \([0-9][0-9]*\),$/hw:\1,\2/')
       ;;
     hw:*" "*)
-      SRC_ID=$(printf '%s' "$SRC_ID" | sed -E 's/^hw:([0-9]+) ([0-9]+)$/hw:\1,\2/')
+      SRC_ID=$(printf '%s' "$SRC_ID" | sed 's/^hw:\([0-9][0-9]*\) \([0-9][0-9]*\)$/hw:\1,\2/')
       ;;
   esac
 fi
@@ -268,13 +377,13 @@ if [ "$AUDIO_BACKEND" = "alsa" ]; then
       if [ -z "$cand" ]; then
         cand="$(sed -n 's/.*\[\s*\([0-9][0-9]*\)-\s*\([0-9][0-9]*\)\]:.*capture.*/hw:\1,\2/p' /proc/asound/devices 2>/dev/null | head -n 1)"
       fi
-      if printf '%s\n' "$cand" | grep -Eq '^hw:[0-9]+,[0-9]+$'; then
+      if printf '%s\n' "$cand" | grep -Eq '^hw:[0-9][0-9]*,[0-9][0-9]*$'; then
         SRC_ID="$cand"
         log_info "ALSA auto-pick: using $SRC_ID"
       else
         log_skip "$TESTNAME SKIP - no valid ALSA capture device found"
         echo "$TESTNAME SKIP" > "$RES_FILE"
-        exit 2
+        exit 0
       fi
       ;;
   esac
@@ -305,17 +414,17 @@ case "$AUDIO_BACKEND" in
   pipewire)
     if ! check_dependencies wpctl pw-record; then
       log_skip "$TESTNAME SKIP - missing PipeWire utils"
-      echo "$TESTNAME SKIP" > "$RES_FILE"; exit 2
+      echo "$TESTNAME SKIP" > "$RES_FILE"; exit 0
     fi ;;
   pulseaudio)
     if ! check_dependencies pactl parecord; then
       log_skip "$TESTNAME SKIP - missing PulseAudio utils"
-      echo "$TESTNAME SKIP" > "$RES_FILE"; exit 2
+      echo "$TESTNAME SKIP" > "$RES_FILE"; exit 0
     fi ;;
   alsa)
     if ! check_dependencies arecord; then
       log_skip "$TESTNAME SKIP - missing arecord"
-      echo "$TESTNAME SKIP" > "$RES_FILE"; exit 2
+      echo "$TESTNAME SKIP" > "$RES_FILE"; exit 0
     fi ;;
 esac
 
@@ -378,7 +487,7 @@ auto_secs_for() {
 alsa_pick_virtual_pcm() {
   command -v arecord >/dev/null 2>&1 || return 1
 
-  pcs="$(arecord -L 2>/dev/null | sed -n 's/^[[:space:]]*\([[:alnum:]_]\+\)[[:space:]]*$/\1/p')"
+  pcs="$(arecord -L 2>/dev/null | sed -n 's/^[[:space:]]*\([[:alnum:]_][[:alnum:]_]*\)[[:space:]]*$/\1/p')"
 
   for pcm in pipewire pulse default; do
     if printf '%s\n' "$pcs" | grep -m1 -x "$pcm" >/dev/null 2>&1; then
@@ -390,246 +499,522 @@ alsa_pick_virtual_pcm() {
   return 1
 }
 
-# ---------------- Matrix execution ----------------
+# ------------- Test Execution (Matrix or Config Discovery) -------------
 total=0
 pass=0
 fail=0
 skip=0
 suite_rc=0
 
-for dur in $DURATIONS; do
-  case_name="record_${dur}"
-  total=$((total + 1))
-
-  logf="$LOGDIR/${case_name}.log"
-  : > "$logf"
-  export AUDIO_LOGCTX="$logf"
-
-  secs="$RECORD_SECONDS"
-  if [ "$secs" = "auto" ]; then
-    tok="$(printf '%s' "$dur" | tr '[:upper:]' '[:lower:]')"
-    tok_secs="$(printf '%s' "$tok" | sed -n 's/^\([0-9][0-9]*\)\(s\|sec\|secs\|seconds\)$/\1s/p')"
-    if [ -n "$tok_secs" ]; then
-      secs="$tok_secs"
-    else
-      secs="$(auto_secs_for "$dur")"
-    fi
+if [ "$USE_CONFIG_DISCOVERY" = "true" ]; then
+  # ========== NEW: Config Discovery Mode ==========
+  log_info "Using config discovery mode"
+  
+  # Discover and filter configs
+  if [ -n "$CONFIG_NAMES" ] || [ -n "$CONFIG_FILTER" ]; then
+    # Use discover_and_filter_record_configs helper (logs go to stderr automatically)
+    CONFIGS_TO_TEST="$(discover_and_filter_record_configs "$CONFIG_NAMES" "$CONFIG_FILTER")" || {
+      # Error messages already printed to stderr, just skip
+      log_skip "$TESTNAME SKIP - Invalid config name(s) provided"
+      echo "$TESTNAME SKIP" > "$RES_FILE"
+      exit 0
+    }
+  else
+    # Discover all configs (logs go to stderr automatically)
+    CONFIGS_TO_TEST="$(discover_record_configs)" || {
+      # Error messages already printed to stderr, just skip
+      log_skip "$TESTNAME SKIP - No record configs found"
+      echo "$TESTNAME SKIP" > "$RES_FILE"
+      exit 0
+    }
   fi
-
-  i=1
-  ok_runs=0
-  last_elapsed=0
-
-  while [ "$i" -le "$LOOPS" ]; do
-    iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    effective_timeout="$secs"
-    if [ -n "$TIMEOUT" ] && [ "$TIMEOUT" != "0" ]; then
-      effective_timeout="$TIMEOUT"
-    fi
-
-    loop_hdr="source=$SRC_CHOICE"
-    if [ "$AUDIO_BACKEND" = "pipewire" ]; then
-      if [ -n "$SRC_ID" ]; then
-        loop_hdr="$loop_hdr($SRC_ID)"
-      else
-        loop_hdr="$loop_hdr(default)"
-      fi
-    else
-      loop_hdr="$loop_hdr($SRC_LABEL)"
-    fi
-
-    log_info "[$case_name] loop $i/$LOOPS start=$iso secs=$secs backend=$AUDIO_BACKEND $loop_hdr"
-
-    out="$LOGDIR/${case_name}.wav"
-    : > "$out"
-
-    start_s="$(date +%s 2>/dev/null || echo 0)"
-
-    if [ "$AUDIO_BACKEND" = "pipewire" ]; then
-      log_info "[$case_name] exec: pw-record -v \"$out\""
-      audio_exec_with_timeout "$effective_timeout" pw-record -v "$out" >> "$logf" 2>&1
-      rc=$?
-      bytes="$(stat -c '%s' "$out" 2>/dev/null || wc -c < "$out")"
-
-      # If we already got real audio, accept and skip fallbacks
-      if [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
-        if [ "$rc" -ne 0 ]; then
-          log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
-          rc=0
-        fi
-      else
-        # Only if output is tiny/empty do we try a virtual PCM (pipewire/pulse/default)
-        if command -v arecord >/dev/null 2>&1; then
-          pcm="$(alsa_pick_virtual_pcm || true)"
-          if [ -n "$pcm" ]; then
-            secs_int="$(audio_parse_secs "$secs" 2>/dev/null || echo 0)"; [ -z "$secs_int" ] && secs_int=0
-            : > "$out"
-            log_info "[$case_name] fallback: arecord -D $pcm -f S16_LE -r 48000 -c 2 -d $secs_int \"$out\""
-            audio_exec_with_timeout "$effective_timeout" \
-              arecord -D "$pcm" -f S16_LE -r 48000 -c 2 -d "$secs_int" "$out" >> "$logf" 2>&1
-            rc=$?
-            bytes="$(stat -c '%s' "$out" 2>/dev/null || wc -c < "$out")"
-          fi
-        fi
-
-        # As a last resort, retry pw-record with --target (only if we have a source id)
-        if { [ "$rc" -ne 0 ] || [ "${bytes:-0}" -le 1024 ] 2>/dev/null; } && [ -n "$SRC_ID" ]; then
-          : > "$out"
-          log_info "[$case_name] exec: pw-record -v --target \"$SRC_ID\" \"$out\""
-          audio_exec_with_timeout "$effective_timeout" pw-record -v --target "$SRC_ID" "$out" >> "$logf" 2>&1
-          rc=$?
-          bytes="$(stat -c '%s' "$out" 2>/dev/null || wc -c < "$out")"
-        fi
-      fi
-
-      # (Optional safety) If nonzero rc but output is clearly valid, accept.
-      if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
-        log_warn "[$case_name] nonzero rc==$rc but recording looks valid (bytes=$bytes) - PASS"
-        rc=0
-      fi
-    else
-      if [ "$AUDIO_BACKEND" = "alsa" ]; then
-        secs_int="$(audio_parse_secs "$secs" 2>/dev/null || echo 0)"
-        [ -z "$secs_int" ] && secs_int=0
-        log_info "[$case_name] exec: arecord -D \"$SRC_ID\" -f S16_LE -r 48000 -c 2 -d $secs_int \"$out\""
-        audio_exec_with_timeout "$effective_timeout" \
-          arecord -D "$SRC_ID" -f S16_LE -r 48000 -c 2 -d "$secs_int" "$out" >> "$logf" 2>&1
-        rc=$?
-        bytes="$(stat -c '%s' "$out" 2>/dev/null || wc -c < "$out")"
-
-        if [ "$rc" -ne 0 ] || [ "${bytes:-0}" -le 1024 ] 2>/dev/null; then
-          if printf '%s\n' "$SRC_ID" | grep -q '^hw:'; then
-            alt_dev="plughw:${SRC_ID#hw:}"
-          else
-            alt_dev="$SRC_ID"
-          fi
-          for combo in "S16_LE 48000 2" "S16_LE 44100 2" "S16_LE 16000 1"; do
-            fmt=$(printf '%s\n' "$combo" | awk '{print $1}')
-            rate=$(printf '%s\n' "$combo" | awk '{print $2}')
-            ch=$(printf '%s\n' "$combo" | awk '{print $3}')
-            [ -z "$fmt" ] || [ -z "$rate" ] || [ -z "$ch" ] && continue
-            : > "$out"
-            log_info "[$case_name] retry: arecord -D \"$alt_dev\" -f $fmt -r $rate -c $ch -d $secs_int \"$out\""
-            audio_exec_with_timeout "$effective_timeout" \
-              arecord -D "$alt_dev" -f "$fmt" -r "$rate" -c "$ch" -d "$secs_int" "$out" >> "$logf" 2>&1
-            rc=$?
-            bytes="$(stat -c '%s' "$out" 2>/dev/null || wc -c < "$out")"
-            if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
-              break
-            fi
-          done
-        fi
-
-        if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
-          log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
-          rc=0
-        fi
-      else
-        log_info "[$case_name] exec: parecord --file-format=wav \"$out\""
-        audio_exec_with_timeout "$effective_timeout" parecord --file-format=wav "$out" >> "$logf" 2>&1
-        rc=$?
-        bytes="$(stat -c '%s' "$out" 2>/dev/null || wc -c < "$out")"
-        if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
-          log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
-          rc=0
-        fi
-      fi
-    fi
-
-    end_s="$(date +%s 2>/dev/null || echo 0)"
-    last_elapsed=$((end_s - start_s))
-    [ "$last_elapsed" -lt 0 ] && last_elapsed=0
-
-    # Evidence
-    pw_ev=$(audio_evidence_pw_streaming || echo 0)
-    pa_ev=$(audio_evidence_pa_streaming || echo 0)
-
-    if [ "$AUDIO_BACKEND" = "pulseaudio" ] && [ "$pa_ev" -eq 0 ]; then
-      if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
-        pa_ev=1
-      fi
-    fi
-
-    alsa_ev=$(audio_evidence_alsa_running_any || echo 0)
-    asoc_ev=$(audio_evidence_asoc_path_on || echo 0)
-    pwlog_ev=$(audio_evidence_pw_log_seen || echo 0)
-    if [ "$AUDIO_BACKEND" = "pulseaudio" ]; then
-      pwlog_ev=0
-    fi
-
-    if [ "$alsa_ev" -eq 0 ]; then
-      if [ "$AUDIO_BACKEND" = "pipewire" ] && [ "$pw_ev" -eq 1 ]; then
-        alsa_ev=1
-      fi
-      if [ "$AUDIO_BACKEND" = "pulseaudio" ] && [ "$pa_ev" -eq 1 ]; then
-        alsa_ev=1
-      fi
-    fi
-
-    if [ "$asoc_ev" -eq 0 ] && [ "$alsa_ev" -eq 1 ]; then
-      asoc_ev=1
-    fi
-
-    log_info "[$case_name] evidence: pw_streaming=$pw_ev pa_streaming=$pa_ev alsa_running=$alsa_ev asoc_path_on=$asoc_ev bytes=${bytes:-0} pw_log=$pwlog_ev"
-
-    if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
-      log_pass "[$case_name] loop $i OK (rc=0, ${last_elapsed}s, bytes=$bytes)"
-      ok_runs=$((ok_runs + 1))
-    else
-      log_fail "[$case_name] loop $i FAILED (rc=$rc, ${last_elapsed}s, bytes=${bytes:-0}) - see $logf"
-    fi
-
-    i=$((i + 1))
+  
+  if [ -z "$CONFIGS_TO_TEST" ]; then
+    log_skip "$TESTNAME SKIP - No valid record configs found"
+    echo "$TESTNAME SKIP" > "$RES_FILE"
+    exit 0
+  fi
+  
+  # Count configs
+  config_count=0
+  for config in $CONFIGS_TO_TEST; do
+    config_count=$(expr $config_count + 1)
   done
+  
+  log_info "Discovered $config_count configs to test"
+  
+  # Test each config
+  for config in $CONFIGS_TO_TEST; do
+    # Generate test case name
+    case_name="$(generate_record_testcase_name "$config")" || {
+      log_warn "Skipping config with invalid name: $config"
+      continue
+    }
+    
+    # Get recording parameters
+    params="$(get_record_config_params "$config")" || {
+      log_warn "Skipping config with invalid parameters: $config"
+      continue
+    }
+    
+    rate="$(printf '%s' "$params" | awk '{print $1}')"
+    channels="$(printf '%s' "$params" | awk '{print $2}')"
+    
+    total=$(expr $total + 1)
+    logf="$LOGDIR/${case_name}.log"
+    : > "$logf"
+    export AUDIO_LOGCTX="$logf"
+    
+    log_info "[$case_name] Using config: $config (rate=${rate}Hz channels=$channels)"
+    
+    # Determine recording duration
+    secs="$RECORD_SECONDS"
+    if [ "$secs" = "auto" ]; then
+      secs="5s"  # Default for config discovery mode
+    fi
+    
+    i=1
+    ok_runs=0
+    last_elapsed=0
+    
+    while [ "$i" -le "$LOOPS" ]; do
+      iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      effective_timeout="$secs"
+      if [ -n "$TIMEOUT" ] && [ "$TIMEOUT" != "0" ]; then
+        effective_timeout="$TIMEOUT"
+      fi
+      
+      loop_hdr="source=$SRC_CHOICE"
+      if [ "$AUDIO_BACKEND" = "pipewire" ]; then
+        if [ -n "$SRC_ID" ]; then
+          loop_hdr="$loop_hdr($SRC_ID)"
+        else
+          loop_hdr="$loop_hdr(default)"
+        fi
+      else
+        loop_hdr="$loop_hdr($SRC_LABEL)"
+      fi
+      
+      log_info "[$case_name] loop $i/$LOOPS start=$iso rate=${rate}Hz channels=$channels backend=$AUDIO_BACKEND $loop_hdr"
+      
+      out="$LOGDIR/${case_name}.wav"
+      : > "$out"
+      
+      start_s="$(date +%s 2>/dev/null || echo 0)"
+      
+      if [ "$AUDIO_BACKEND" = "pipewire" ]; then
+        log_info "[$case_name] exec: pw-record -v --rate=$rate --channels=$channels \"$out\""
+        audio_exec_with_timeout "$effective_timeout" pw-record -v --rate="$rate" --channels="$channels" "$out" >> "$logf" 2>&1
+        rc=$?
+        bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+        
+        # If we already got real audio, accept and skip fallbacks
+        if [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+          if [ "$rc" -ne 0 ]; then
+            log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
+            rc=0
+          fi
+        else
+          # Only if output is tiny/empty do we try a virtual PCM (pipewire/pulse/default)
+          if command -v arecord >/dev/null 2>&1; then
+            pcm="$(alsa_pick_virtual_pcm || true)"
+            if [ -n "$pcm" ]; then
+              secs_int="$(audio_parse_secs "$secs" 2>/dev/null || echo 0)"; [ -z "$secs_int" ] && secs_int=0
+              : > "$out"
+              log_info "[$case_name] fallback: arecord -D $pcm -f S16_LE -r $rate -c $channels -d $secs_int \"$out\""
+              audio_exec_with_timeout "$effective_timeout" \
+                arecord -D "$pcm" -f S16_LE -r "$rate" -c "$channels" -d "$secs_int" "$out" >> "$logf" 2>&1
+              rc=$?
+              bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+            fi
+          fi
+          
+          # As a last resort, retry pw-record with --target (only if we have a source id)
+          if { [ "$rc" -ne 0 ] || [ "${bytes:-0}" -le 1024 ] 2>/dev/null; } && [ -n "$SRC_ID" ]; then
+            : > "$out"
+            log_info "[$case_name] exec: pw-record -v --rate=$rate --channels=$channels --target \"$SRC_ID\" \"$out\""
+            audio_exec_with_timeout "$effective_timeout" pw-record -v --rate="$rate" --channels="$channels" --target "$SRC_ID" "$out" >> "$logf" 2>&1
+            rc=$?
+            bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+          fi
+        fi
+        
+        # (Optional safety) If nonzero rc but output is clearly valid, accept.
+        if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+          log_warn "[$case_name] nonzero rc==$rc but recording looks valid (bytes=$bytes) - PASS"
+          rc=0
+        fi
+      else
+        if [ "$AUDIO_BACKEND" = "alsa" ]; then
+          secs_int="$(audio_parse_secs "$secs" 2>/dev/null || echo 0)"
+          [ -z "$secs_int" ] && secs_int=0
+          log_info "[$case_name] exec: arecord -D \"$SRC_ID\" -f S16_LE -r $rate -c $channels -d $secs_int \"$out\""
+          audio_exec_with_timeout "$effective_timeout" \
+            arecord -D "$SRC_ID" -f S16_LE -r "$rate" -c "$channels" -d "$secs_int" "$out" >> "$logf" 2>&1
+          rc=$?
+          bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+          
+          if [ "$rc" -ne 0 ] || [ "${bytes:-0}" -le 1024 ] 2>/dev/null; then
+            if printf '%s\n' "$SRC_ID" | grep -q '^hw:'; then
+              alt_dev="plughw:${SRC_ID#hw:}"
+            else
+              alt_dev="$SRC_ID"
+            fi
+            
+            # Try with the specific config parameters
+            : > "$out"
+            log_info "[$case_name] retry: arecord -D \"$alt_dev\" -f S16_LE -r $rate -c $channels -d $secs_int \"$out\""
+            audio_exec_with_timeout "$effective_timeout" \
+              arecord -D "$alt_dev" -f S16_LE -r "$rate" -c "$channels" -d "$secs_int" "$out" >> "$logf" 2>&1
+            rc=$?
+            bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+            
+            # If still failing, try fallback combinations
+            if [ "$rc" -ne 0 ] || [ "${bytes:-0}" -le 1024 ] 2>/dev/null; then
+              for combo in "S16_LE 48000 2" "S16_LE 44100 2" "S16_LE 16000 1"; do
+                fmt=$(printf '%s\n' "$combo" | awk '{print $1}')
+                fallback_rate=$(printf '%s\n' "$combo" | awk '{print $2}')
+                fallback_ch=$(printf '%s\n' "$combo" | awk '{print $3}')
+                [ -z "$fmt" ] || [ -z "$fallback_rate" ] || [ -z "$fallback_ch" ] && continue
+                : > "$out"
+                log_info "[$case_name] fallback: arecord -D \"$alt_dev\" -f $fmt -r $fallback_rate -c $fallback_ch -d $secs_int \"$out\""
+                audio_exec_with_timeout "$effective_timeout" \
+                  arecord -D "$alt_dev" -f "$fmt" -r "$fallback_rate" -c "$fallback_ch" -d "$secs_int" "$out" >> "$logf" 2>&1
+                rc=$?
+                bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+                if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+                  break
+                fi
+              done
+            fi
+          fi
+          
+          if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+            log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
+            rc=0
+          fi
+        else
+          # PulseAudio
+          log_info "[$case_name] exec: parecord --rate=$rate --channels=$channels --file-format=wav \"$out\""
+          audio_exec_with_timeout "$effective_timeout" parecord --rate="$rate" --channels="$channels" --file-format=wav "$out" >> "$logf" 2>&1
+          rc=$?
+          bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+          if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+            log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
+            rc=0
+          fi
+        fi
+      fi
+      
+      end_s="$(date +%s 2>/dev/null || echo 0)"
+      last_elapsed=$(expr $end_s - $start_s)
+      [ "$last_elapsed" -lt 0 ] && last_elapsed=0
+      
+      # Evidence
+      pw_ev=$(audio_evidence_pw_streaming || echo 0)
+      pa_ev=$(audio_evidence_pa_streaming || echo 0)
+      
+      if [ "$AUDIO_BACKEND" = "pulseaudio" ] && [ "$pa_ev" -eq 0 ]; then
+        if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+          pa_ev=1
+        fi
+      fi
+      
+      alsa_ev=$(audio_evidence_alsa_running_any || echo 0)
+      asoc_ev=$(audio_evidence_asoc_path_on || echo 0)
+      pwlog_ev=$(audio_evidence_pw_log_seen || echo 0)
+      if [ "$AUDIO_BACKEND" = "pulseaudio" ]; then
+        pwlog_ev=0
+      fi
+      
+      if [ "$alsa_ev" -eq 0 ]; then
+        if [ "$AUDIO_BACKEND" = "pipewire" ] && [ "$pw_ev" -eq 1 ]; then
+          alsa_ev=1
+        fi
+        if [ "$AUDIO_BACKEND" = "pulseaudio" ] && [ "$pa_ev" -eq 1 ]; then
+          alsa_ev=1
+        fi
+      fi
+      
+      if [ "$asoc_ev" -eq 0 ] && [ "$alsa_ev" -eq 1 ]; then
+        asoc_ev=1
+      fi
+      
+      log_info "[$case_name] evidence: pw_streaming=$pw_ev pa_streaming=$pa_ev alsa_running=$alsa_ev asoc_path_on=$asoc_ev bytes=${bytes:-0} pw_log=$pwlog_ev"
+      
+      if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+        log_pass "[$case_name] loop $i OK (rc=0, ${last_elapsed}s, bytes=$bytes)"
+        ok_runs=$(expr $ok_runs + 1)
+      else
+        log_fail "[$case_name] loop $i FAILED (rc=$rc, ${last_elapsed}s, bytes=${bytes:-0}) - see $logf"
+      fi
+      
+      i=$(expr $i + 1)
+    done
+    
+    # Aggregate result for this config
+    status="FAIL"
+    if [ "$ok_runs" -ge 1 ]; then
+      status="PASS"
+    fi
+    
+    append_junit "$case_name" "$last_elapsed" "$status" "$logf"
+    
+    case "$status" in
+      PASS)
+        pass=$(expr $pass + 1)
+        echo "$case_name PASS" >> "$LOGDIR/summary.txt"
+        ;;
+      SKIP)
+        skip=$(expr $skip + 1)
+        echo "$case_name SKIP" >> "$LOGDIR/summary.txt"
+        ;;
+      FAIL)
+        fail=$(expr $fail + 1)
+        echo "$case_name FAIL" >> "$LOGDIR/summary.txt"
+        suite_rc=1
+        ;;
+    esac
+  done
+else
+  # ========== LEGACY: Matrix Mode ==========
+  for dur in $DURATIONS; do
+    case_name="record_${dur}"
+    total=$(expr $total + 1)
 
-  if [ "$DMESG_SCAN" -eq 1 ]; then
-    scan_audio_dmesg "$LOGDIR"
-    dump_mixers "$LOGDIR/mixer_dump.txt"
-  fi
+    logf="$LOGDIR/${case_name}.log"
+    : > "$logf"
+    export AUDIO_LOGCTX="$logf"
 
-  status="FAIL"
-  if [ "$ok_runs" -ge 1 ]; then
-    status="PASS"
-  fi
+    secs="$RECORD_SECONDS"
+    if [ "$secs" = "auto" ]; then
+      tok="$(printf '%s' "$dur" | tr '[:upper:]' '[:lower:]')"
+      tok_secs="$(printf '%s' "$tok" | sed -n 's/^\([0-9][0-9]*\)\(s\|sec\|secs\|seconds\)$/\1s/p')"
+      if [ -n "$tok_secs" ]; then
+        secs="$tok_secs"
+      else
+        secs="$(auto_secs_for "$dur")"
+      fi
+    fi
 
-  append_junit "$case_name" "$last_elapsed" "$status" "$logf"
+    i=1
+    ok_runs=0
+    last_elapsed=0
 
-  case "$status" in
-    PASS)
-      pass=$((pass + 1))
-      echo "$case_name PASS" >> "$LOGDIR/summary.txt"
-      ;;
-    SKIP)
-      skip=$((skip + 1))
-      echo "$case_name SKIP" >> "$LOGDIR/summary.txt"
-      ;;
-    FAIL)
-      fail=$((fail + 1))
-      echo "$case_name FAIL" >> "$LOGDIR/summary.txt"
-      suite_rc=1
-      ;;
-  esac
-done
+    while [ "$i" -le "$LOOPS" ]; do
+      iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      effective_timeout="$secs"
+      if [ -n "$TIMEOUT" ] && [ "$TIMEOUT" != "0" ]; then
+        effective_timeout="$TIMEOUT"
+      fi
+
+      loop_hdr="source=$SRC_CHOICE"
+      if [ "$AUDIO_BACKEND" = "pipewire" ]; then
+        if [ -n "$SRC_ID" ]; then
+          loop_hdr="$loop_hdr($SRC_ID)"
+        else
+          loop_hdr="$loop_hdr(default)"
+        fi
+      else
+        loop_hdr="$loop_hdr($SRC_LABEL)"
+      fi
+
+      log_info "[$case_name] loop $i/$LOOPS start=$iso secs=$secs backend=$AUDIO_BACKEND $loop_hdr"
+
+      out="$LOGDIR/${case_name}.wav"
+      : > "$out"
+
+      start_s="$(date +%s 2>/dev/null || echo 0)"
+
+      if [ "$AUDIO_BACKEND" = "pipewire" ]; then
+        log_info "[$case_name] exec: pw-record -v \"$out\""
+        audio_exec_with_timeout "$effective_timeout" pw-record -v "$out" >> "$logf" 2>&1
+        rc=$?
+        bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+
+        # If we already got real audio, accept and skip fallbacks
+        if [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+          if [ "$rc" -ne 0 ]; then
+            log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
+            rc=0
+          fi
+        else
+          # Only if output is tiny/empty do we try a virtual PCM (pipewire/pulse/default)
+          if command -v arecord >/dev/null 2>&1; then
+            pcm="$(alsa_pick_virtual_pcm || true)"
+            if [ -n "$pcm" ]; then
+              secs_int="$(audio_parse_secs "$secs" 2>/dev/null || echo 0)"; [ -z "$secs_int" ] && secs_int=0
+              : > "$out"
+              log_info "[$case_name] fallback: arecord -D $pcm -f S16_LE -r 48000 -c 2 -d $secs_int \"$out\""
+              audio_exec_with_timeout "$effective_timeout" \
+                arecord -D "$pcm" -f S16_LE -r 48000 -c 2 -d "$secs_int" "$out" >> "$logf" 2>&1
+              rc=$?
+              bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+            fi
+          fi
+
+          # As a last resort, retry pw-record with --target (only if we have a source id)
+          if { [ "$rc" -ne 0 ] || [ "${bytes:-0}" -le 1024 ] 2>/dev/null; } && [ -n "$SRC_ID" ]; then
+            : > "$out"
+            log_info "[$case_name] exec: pw-record -v --target \"$SRC_ID\" \"$out\""
+            audio_exec_with_timeout "$effective_timeout" pw-record -v --target "$SRC_ID" "$out" >> "$logf" 2>&1
+            rc=$?
+            bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+          fi
+        fi
+
+        # (Optional safety) If nonzero rc but output is clearly valid, accept.
+        if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+          log_warn "[$case_name] nonzero rc==$rc but recording looks valid (bytes=$bytes) - PASS"
+          rc=0
+        fi
+      else
+        if [ "$AUDIO_BACKEND" = "alsa" ]; then
+          secs_int="$(audio_parse_secs "$secs" 2>/dev/null || echo 0)"
+          [ -z "$secs_int" ] && secs_int=0
+          log_info "[$case_name] exec: arecord -D \"$SRC_ID\" -f S16_LE -r 48000 -c 2 -d $secs_int \"$out\""
+          audio_exec_with_timeout "$effective_timeout" \
+            arecord -D "$SRC_ID" -f S16_LE -r 48000 -c 2 -d "$secs_int" "$out" >> "$logf" 2>&1
+          rc=$?
+          bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+
+          if [ "$rc" -ne 0 ] || [ "${bytes:-0}" -le 1024 ] 2>/dev/null; then
+            if printf '%s\n' "$SRC_ID" | grep -q '^hw:'; then
+              alt_dev="plughw:${SRC_ID#hw:}"
+            else
+              alt_dev="$SRC_ID"
+            fi
+            for combo in "S16_LE 48000 2" "S16_LE 44100 2" "S16_LE 16000 1"; do
+              fmt=$(printf '%s\n' "$combo" | awk '{print $1}')
+              rate=$(printf '%s\n' "$combo" | awk '{print $2}')
+              ch=$(printf '%s\n' "$combo" | awk '{print $3}')
+              [ -z "$fmt" ] || [ -z "$rate" ] || [ -z "$ch" ] && continue
+              : > "$out"
+              log_info "[$case_name] retry: arecord -D \"$alt_dev\" -f $fmt -r $rate -c $ch -d $secs_int \"$out\""
+              audio_exec_with_timeout "$effective_timeout" \
+                arecord -D "$alt_dev" -f "$fmt" -r "$rate" -c "$ch" -d "$secs_int" "$out" >> "$logf" 2>&1
+              rc=$?
+              bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+              if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+                break
+              fi
+            done
+          fi
+
+          if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+            log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
+            rc=0
+          fi
+        else
+          log_info "[$case_name] exec: parecord --file-format=wav \"$out\""
+          audio_exec_with_timeout "$effective_timeout" parecord --file-format=wav "$out" >> "$logf" 2>&1
+          rc=$?
+          bytes="$(file_size_bytes "$out" 2>/dev/null || echo 0)"
+          if [ "$rc" -ne 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+            log_warn "[$case_name] nonzero rc=$rc but recording looks valid (bytes=$bytes) - PASS"
+            rc=0
+          fi
+        fi
+      fi
+
+      end_s="$(date +%s 2>/dev/null || echo 0)"
+      last_elapsed=$(expr $end_s - $start_s)
+      [ "$last_elapsed" -lt 0 ] && last_elapsed=0
+
+      # Evidence
+      pw_ev=$(audio_evidence_pw_streaming || echo 0)
+      pa_ev=$(audio_evidence_pa_streaming || echo 0)
+
+      if [ "$AUDIO_BACKEND" = "pulseaudio" ] && [ "$pa_ev" -eq 0 ]; then
+        if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+          pa_ev=1
+        fi
+      fi
+
+      alsa_ev=$(audio_evidence_alsa_running_any || echo 0)
+      asoc_ev=$(audio_evidence_asoc_path_on || echo 0)
+      pwlog_ev=$(audio_evidence_pw_log_seen || echo 0)
+      if [ "$AUDIO_BACKEND" = "pulseaudio" ]; then
+        pwlog_ev=0
+      fi
+
+      if [ "$alsa_ev" -eq 0 ]; then
+        if [ "$AUDIO_BACKEND" = "pipewire" ] && [ "$pw_ev" -eq 1 ]; then
+          alsa_ev=1
+        fi
+        if [ "$AUDIO_BACKEND" = "pulseaudio" ] && [ "$pa_ev" -eq 1 ]; then
+          alsa_ev=1
+        fi
+      fi
+
+      if [ "$asoc_ev" -eq 0 ] && [ "$alsa_ev" -eq 1 ]; then
+        asoc_ev=1
+      fi
+
+      log_info "[$case_name] evidence: pw_streaming=$pw_ev pa_streaming=$pa_ev alsa_running=$alsa_ev asoc_path_on=$asoc_ev bytes=${bytes:-0} pw_log=$pwlog_ev"
+
+      if [ "$rc" -eq 0 ] && [ "${bytes:-0}" -gt 1024 ] 2>/dev/null; then
+        log_pass "[$case_name] loop $i OK (rc=0, ${last_elapsed}s, bytes=$bytes)"
+        ok_runs=$(expr $ok_runs + 1)
+      else
+        log_fail "[$case_name] loop $i FAILED (rc=$rc, ${last_elapsed}s, bytes=${bytes:-0}) - see $logf"
+      fi
+
+      i=$(expr $i + 1)
+    done
+
+    # Aggregate result for this duration
+    status="FAIL"
+    if [ "$ok_runs" -ge 1 ]; then
+      status="PASS"
+    fi
+
+    append_junit "$case_name" "$last_elapsed" "$status" "$logf"
+
+    case "$status" in
+      PASS)
+        pass=$(expr $pass + 1)
+        echo "$case_name PASS" >> "$LOGDIR/summary.txt"
+        ;;
+      SKIP)
+        skip=$(expr $skip + 1)
+        echo "$case_name SKIP" >> "$LOGDIR/summary.txt"
+        ;;
+      FAIL)
+        fail=$(expr $fail + 1)
+        echo "$case_name FAIL" >> "$LOGDIR/summary.txt"
+        suite_rc=1
+        ;;
+    esac
+  done
+fi
+
+# Collect evidence once at end
+if [ "$DMESG_SCAN" -eq 1 ]; then
+  scan_audio_dmesg "$LOGDIR"
+  dump_mixers "$LOGDIR/mixer_dump.txt"
+fi
+
+# JUnit finalize (optional)
+if [ -n "$JUNIT_OUT" ]; then
+  {
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+    printf '<testsuites>\n'
+    printf '<testsuite name="%s" tests="%d" failures="%d" skipped="%d">\n' "Audio.Record" "$total" "$fail" "$skip"
+    cat "$JUNIT_TMP"
+    printf '</testsuite>\n'
+    printf '</testsuites>\n'
+  } > "$JUNIT_OUT"
+  rm -f "$JUNIT_TMP"
+fi
 
 log_info "Summary: total=$total pass=$pass fail=$fail skip=$skip"
 
-if [ -n "$JUNIT_OUT" ]; then
-  tests=$((pass + fail + skip))
-  failures="$fail"
-  skipped="$skip"
-  {
-    printf '<testsuite name="%s" tests="%s" failures="%s" skipped="%s">\n' "$TESTNAME" "$tests" "$failures" "$skipped"
-    cat "$JUNIT_TMP"
-    printf '</testsuite>\n'
-  } > "$JUNIT_OUT"
-  log_info "Wrote JUnit: $JUNIT_OUT"
-fi
-
-# Exit codes: PASS=0, FAIL=1, SKIP=2
+# --- Proper exit codes: PASS=0, FAIL=1, SKIP-only=0 ---
 if [ "$pass" -eq 0 ] && [ "$fail" -eq 0 ] && [ "$skip" -gt 0 ]; then
   log_skip "$TESTNAME SKIP"
   echo "$TESTNAME SKIP" > "$RES_FILE"
-  exit 2
+  exit 0
 fi
 
 if [ "$suite_rc" -eq 0 ]; then


### PR DESCRIPTION
Expanded audio testing from 2 to 10 test cases in the pre-merge CI pipeline to improve validation coverage across different audio formats and configurations.

Changes:
- AudioRecord: Added support for 10 recording configurations
- AudioPlayback: Added support for 20 playback configurations
- meta-ar-ci-premerge.yaml: Updated to run 7 playback + 3 record tests

AudioRecord enhancements:
* Implemented config discovery mode with 10 predefined test configurations
* Added --config-name and --config-filter CLI options for flexible test selection
* Updated documentation with configuration table and usage examples
* Modified YAML to support new config parameters (defaults to record_config1)

AudioPlayback enhancements:
* Implemented clip discovery mode with 20 predefined test configurations
* Added --clip-name and --clip-filter CLI options for flexible test selection
* Updated documentation with configuration table and usage examples
* Modified YAML to support new clip parameters (defaults to Config1)

Pre-merge CI updates:
* 7 playback tests: Config1, Config7, Config13, Config15, Config18, Config20, Config5
* 3 record tests: record_config1, record_config7, record_config10
* Uses pre-staged clips at /home/AudioClips/ for faster execution
* 10-second recording duration for efficient CI runtime

Test coverage now includes:
- Sample rates: 8KHz to 384KHz
- Bit depths: 8-bit to 32-bit
- Channel configs: Mono, Stereo, 5.1, 7.1 surround