### PR TITLE
Audio: Reduce AudioPlayback to 10 configs and fix YAML parameter conflicts

### DIFF
--- a/Runner/plans/meta-ar-ci-premerge.yaml
+++ b/Runner/plans/meta-ar-ci-premerge.yaml
@@ -13,49 +13,49 @@ run:
     steps:
         - cd Runner
         
-        # ========== AudioPlayback Test Cases (7 configs) ==========
+        # ========== AudioPlayback Test Cases (5 configs) ==========
         
-        # Playback Test 1: Config1 (16KHz, 16-bit, 2ch)
-        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        # Playback Test 1: playback_config1 (8KHz, 8-bit, 1ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "playback_config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config1.res || true
         
-        # Playback Test 2: Config7 (24KHz, 24-bit, 6ch)
-        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config7" --res-suffix "Config7" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config7.res || true
+        # Playback Test 2: playback_config3 (16KHz, 16-bit, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "playback_config3" --res-suffix "Config3" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config3.res || true
         
-        # Playback Test 3: Config13 (44.1KHz, 16-bit, 1ch)
-        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config13" --res-suffix "Config13" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config13.res || true
-        
-        # Playback Test 4: Config15 (48KHz, 8-bit, 2ch)
-        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config15" --res-suffix "Config15" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config15.res || true
-        
-        # Playback Test 5: Config18 (88.2KHz, 24-bit, 2ch)
-        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config18" --res-suffix "Config18" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config18.res || true
-        
-        # Playback Test 6: Config20 (96KHz, 24-bit, 6ch)
-        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config20" --res-suffix "Config20" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config20.res || true
-        
-        # Playback Test 7: Config5 (192KHz, 32-bit, 8ch)
-        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "Config5" --res-suffix "Config5" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        # Playback Test 3: playback_config5 (24KHz, 24-bit, 6ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "playback_config5" --res-suffix "Config5" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config5.res || true
         
-        # ========== AudioRecord Test Cases (3 configs) ==========
+        # Playback Test 4: playback_config8 (32KHz, 16-bit, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "playback_config8" --res-suffix "Config8" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config8.res || true
+        
+        # Playback Test 5: playback_config10 (48KHz, 8-bit, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioPlayback/run.sh --clip-name "playback_config10" --res-suffix "Config10" --audio-clips-path /home/AudioClips/ --no-extract-assets || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioPlayback/AudioPlayback_Config10.res || true
+        
+        # ========== AudioRecord Test Cases (5 configs) ==========
         
         # Record Test 1: record_config1 (8KHz, 1ch)
         - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config1" --res-suffix "Config1" --record-seconds 10s || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config1.res || true
         
-        # Record Test 2: record_config7 (48KHz, 2ch)
+        # Record Test 2: record_config3 (16KHz, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config3" --res-suffix "Config3" --record-seconds 10s || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config3.res || true
+        
+        # Record Test 3: record_config5 (32KHz, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config5" --res-suffix "Config5" --record-seconds 10s || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config5.res || true
+        
+        # Record Test 4: record_config7 (48KHz, 2ch)
         - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config7" --res-suffix "Config7" --record-seconds 10s || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config7.res || true
         
-        # Record Test 3: record_config10 (96KHz, 6ch)
-        - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config10" --res-suffix "Config10" --record-seconds 10s || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config10.res || true
+        # Record Test 5: record_config9 (96KHz, 2ch)
+        - $PWD/suites/Multimedia/Audio/AudioRecord/run.sh --config-name "record_config9" --res-suffix "Config9" --record-seconds 10s || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/Audio/AudioRecord/AudioRecord_Config9.res || true
         
         # Parse and report results
         - $PWD/utils/result_parse.sh

--- a/Runner/suites/Multimedia/Audio/AudioPlayback/AudioPlayback.yaml
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/AudioPlayback.yaml
@@ -10,7 +10,7 @@ metadata:
 params:
   AUDIO_BACKEND: ""  # Selects backend: pipewire or pulseaudio, default: auto-detect
   SINK_CHOICE: "speakers"  # Playback sink: speakers or null, default: speakers
-  CLIP_NAMES: "Config1"  # Test specific clips (e.g., "Config1 Config2" or "play_48KHz_8b_2ch"), default: Config1
+  CLIP_NAMES: "playback_config1"  # Test specific clips (e.g., "playback_config1 playback_config2" or "play_48KHz_8b_2ch"), default: playback_config1
   CLIP_FILTER: ""  # Filter clips by pattern (e.g., "48KHz" or "16b" or "2ch"), default: unset
   FORMATS: "wav"  # Audio formats: e.g. wav, default: wav
   DURATIONS: "short"  # Playback durations: short, medium, long, default: short
@@ -21,7 +21,7 @@ params:
   VERBOSE: 0  # Enable verbose logging, default: 0
   EXTRACT_AUDIO_ASSETS: true  # Download/extract audio assets if missing, default: true
   ENABLE_NETWORK_DOWNLOAD: false  # Enable network download of missing audio files, default: false
-  AUDIO_CLIPS_BASE_DIR: ""  # Custom path to pre-staged audio clips (for CI), default: unset
+  AUDIO_CLIPS_BASE_DIR: "/home/AudioClips"  # Custom path to pre-staged audio clips (for CI), default: /home/AudioClips
   SSID: ""  # Wi-Fi SSID for network connection, default: unset
   PASSWORD: ""  # Wi-Fi password for network connection, default: unset
   NET_PROBE_ROUTE_IP: "1.1.1.1"  # IP used for route probing, default: 1.1.1.1
@@ -32,5 +32,5 @@ run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/Audio/AudioPlayback/
-    - ./run.sh --backend "${AUDIO_BACKEND}" --sink "${SINK_CHOICE}" --clip-name "${CLIP_NAMES}" --clip-filter "${CLIP_FILTER}" --formats "${FORMATS}" --durations "${DURATIONS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --audio-clips-path "${AUDIO_CLIPS_BASE_DIR}" --res-suffix "${RES_SUFFIX}" --ssid "${SSID}" --password "${PASSWORD}" || true
+    - ./run.sh --backend "${AUDIO_BACKEND}" --sink "${SINK_CHOICE}" --clip-name "${CLIP_NAMES}" --clip-filter "${CLIP_FILTER}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --audio-clips-path "${AUDIO_CLIPS_BASE_DIR}" --res-suffix "${RES_SUFFIX}" --ssid "${SSID}" --password "${PASSWORD}" || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh AudioPlayback${RES_SUFFIX:+_${RES_SUFFIX}}.res || true

--- a/Runner/suites/Multimedia/Audio/AudioPlayback/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/Read_me.md
@@ -8,10 +8,10 @@ This suite automates the validation of audio playback capabilities on Qualcomm L
 ## Features
 
 - Supports **PipeWire** and **PulseAudio** backends
-- **20-clip test coverage**: Comprehensive validation across diverse audio formats (sample rates: 8KHz-352.8KHz, bit depths: 8b-32b, channels: 1ch-8ch)
+- **10-clip test coverage**: Comprehensive validation across diverse audio formats (sample rates: 8KHz-48KHz, bit depths: 8b-32b, channels: 1ch-8ch)
 - **Flexible clip selection**: 
-  - Use generic config names (Config1-Config20) for easy selection
-  - Use descriptive names (e.g., play_48KHz_16b_2ch) for specific formats
+  - Use generic config names (playback_config1-playback_config10) for easy selection
+  - Use descriptive names (e.g., play_48KHz_8b_2ch) for specific formats
   - Auto-discovery mode tests all available clips
 - **Clip filtering**: Filter tests by sample rate, bit rate, or channel configuration
 - Plays audio clips with configurable format, duration, and loop count
@@ -28,35 +28,25 @@ This suite automates the validation of audio playback capabilities on Qualcomm L
 
 ## Audio Clip Configurations
 
-The test suite includes 20 diverse audio clip configurations covering various sample rates, bit depths, and channel configurations:
+The test suite includes 10 diverse audio clip configurations covering various sample rates, bit depths, and channel configurations:
 
-Config         Descriptive Name             Sample Rate	    Bit Rate    Channels
-Config1        play_16KHz_16b_2ch	        16 KHz	        16-bit	    2ch
-Config2        play_176.4KHz_24b_1ch	    176.4 KHz	    24-bit	    1ch
-Config3        play_176.4KHz_32b_6ch	    176.4 KHz	    32-bit	    6ch
-Config4        play_192KHz_16b_6ch          192 KHz	        16-bit	    6ch
-Config5        play_192KHz_32b_8ch          192 KHz	        32-bit	    8ch
-Config6        play_22.050KHz_8b_1ch	    22.05 KHz	    8-bit       1ch
-Config7        play_24KHz_24b_6ch	        24 KHz	        24-bit	    6ch
-Config8        play_24KHz_32b_8ch	        24 KHz	        32-bit	    8ch
-Config9        play_32KHz_16b_2ch	        32 KHz	        16-bit	    2ch
-Config10       play_32KHz_8b_8ch	        32 KHz	        8-bit       8ch
-Config11       play_352.8KHz_32b_1ch	    352.8 KHz	    32-bit	    1ch
-Config12       play_384KHz_32b_2ch          384 KHz	        32-bit	    2ch
-Config13       play_44.1KHz_16b_1ch         44.1 KHz	    16-bit	    1ch
-Config14       play_44.1KHz_8b_6ch          44.1 KHz	    8-bit       6ch
-Config15       play_48KHz_8b_2ch	        48 KHz	        8-bit       2ch
-Config16       play_48KHz_8b_8ch	        48 KHz	        8-bit       8ch
-Config17       play_88.2KHz_16b_8ch         88.2 KHz	    16-bit	    8ch
-Config18       play_88.2KHz_24b_2ch         88.2 KHz	    24-bit	    2ch
-Config19       play_8KHz_8b_1ch             8 KHz	        8-bit       1ch
-Config20       play_96KHz_24b_6ch	        96 KHz	        24-bit	    6ch
+Playback Config     Descriptive Name         Sample Rate    Bit Rate    Channels
+playback_config1    play_16KHz_16b_2ch       16 KHz         16-bit      2ch
+playback_config2    play_16KHz_8b_6ch        16 KHz         8-bit       6ch
+playback_config3    play_22.050KHz_8b_1ch    22.05 KHz      8-bit       1ch
+playback_config4    play_24KHz_24b_6ch       24 KHz         24-bit      6ch
+playback_config5    play_24KHz_32b_1ch       24 KHz         32-bit      1ch
+playback_config6    play_32KHz_16b_2ch       32 KHz         16-bit      2ch
+playback_config7    play_32KHz_8b_8ch        32 KHz         8-bit       8ch
+playback_config8    play_44.1KHz_16b_1ch     44.1 KHz       16-bit      1ch
+playback_config9    play_48KHz_8b_2ch        48 KHz         8-bit       2ch
+playback_config10   play_8KHz_8b_1ch         8 KHz          8-bit       1ch
 
 Coverage Summary:
-- Sample Rates: 8 KHz, 16 KHz, 22.05 KHz, 24 KHz, 32 KHz, 44.1 KHz, 48 KHz, 88.2 KHz, 96 KHz, 176.4 KHz, 192 KHz, 352.8 KHz, 384 KHz
+- Sample Rates: 8 KHz, 16 KHz, 22.05 KHz, 24 KHz, 32 KHz, 44.1 KHz, 48 KHz
 - Bit Depths: 8-bit, 16-bit, 24-bit, 32-bit
 - Channel Configurations: 1ch (Mono), 2ch (Stereo), 6ch (5.1 Surround), 8ch (7.1 Surround)
-- Total Configurations: 20 unique audio format combinations
+- Total Configurations: 10 unique audio format combinations
 
 ## Prerequisites
 
@@ -151,21 +141,21 @@ AUDIO_CLIPS_BASE_DIR="/tmp/ci-audio-staging/AudioClips" ./run-test.sh AudioPlayb
 **Directly from Test Directory**
 cd Runner/suites/Multimedia/Audio/AudioPlayback
 
-# Test all 20 clips (auto-discovery mode)
+# Test all 10 clips (auto-discovery mode)
 ./run.sh --no-extract-assets
 
-# Test specific clips using Config naming (Config1 to Config20)
-./run.sh --no-extract-assets --clip-name "Config1"
-./run.sh --no-extract-assets --clip-name "Config1 Config5 Config10"
+# Test specific clips using playback_config naming (playback_config1 to playback_config10)
+./run.sh --no-extract-assets --clip-name "playback_config1"
+./run.sh --no-extract-assets --clip-name "playback_config1 playback_config5 playback_config10"
 
 # Test specific clips using descriptive names
 ./run.sh --no-extract-assets --clip-name "play_48KHz_8b_2ch"
 ./run.sh --no-extract-assets --clip-name "play_8KHz_8b_1ch"
-./run.sh --no-extract-assets --clip-name "play_192KHz_32b_8ch"
+./run.sh --no-extract-assets --clip-name "play_44.1KHz_16b_1ch"
 
 # Filter clips by sample rate
 ./run.sh --no-extract-assets --clip-filter "48KHz"
-./run.sh --no-extract-assets --clip-filter "192KHz"
+./run.sh --no-extract-assets --clip-filter "16KHz"
 
 # Filter clips by bit depth
 ./run.sh --no-extract-assets --clip-filter "16b"
@@ -193,8 +183,8 @@ cd Runner/suites/Multimedia/Audio/AudioPlayback
 ./run.sh --junit results.xml --no-dmesg
 
 # CI/LAVA workflow: Generate unique result files for each test
-./run.sh --clip-name "Config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets
-./run.sh --clip-name "Config7" --res-suffix "Config7" --audio-clips-path /home/AudioClips/ --no-extract-assets
+./run.sh --clip-name "playback_config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets
+./run.sh --clip-name "playback_config7" --res-suffix "Config7" --audio-clips-path /home/AudioClips/ --no-extract-assets
 # This generates AudioPlayback_Config1.res and AudioPlayback_Config7.res (no overwriting)
 
 
@@ -224,7 +214,7 @@ CLI Options
 Option	                    Description
 --backend	                Select backend: pipewire or pulseaudio
 --sink	                    Playback sink: speakers or null
---clip-name <names>         Test specific clips using Config1-Config20 or descriptive names (space-separated)
+--clip-name <names>         Test specific clips using playback_config1-playback_config10 or descriptive names (space-separated)
 --clip-filter <patterns>    Filter clips by sample rate, bit rate, or channels (space-separated patterns)
 --formats	                Audio formats (space/comma separated): e.g. wav 
 --durations	                Playback durations: short, medium, long
@@ -244,77 +234,105 @@ Option	                    Description
 
 Sample Output:
 
-**Example 1: Testing specific clip using Config naming**
+**Example 1: Testing specific clip using playback_config naming**
 ```
-sh-5.3# ./run.sh --no-extract-assets --clip-name "Config1"
-[INFO] 2025-12-30 11:47:32 - ---------------- Starting AudioPlayback ----------------
-[INFO] 2025-12-30 11:47:32 - Platform Details: machine='Qualcomm Technologies, Inc. Robotics RB3gen2' target='Kodiak' kernel='6.18.0-00393-g27507852413b' arch='aarch64'
-[INFO] 2025-12-30 11:47:32 - Args: backend=auto sink=speakers loops=1 timeout=0 formats='wav' durations='short' strict=0 dmesg=1 extract=false network_download=false clips_path=default
-[INFO] 2025-12-30 11:47:32 - Using backend: pipewire
-[INFO] 2025-12-30 11:47:32 - Routing to sink: id=52 name='Built-in Audio Speaker playback' choice=speakers
-[INFO] 2025-12-30 11:47:32 - Using clip discovery mode
-[INFO] 2025-12-30 11:47:32 - Discovered 1 clips to test
-[INFO] 2025-12-30 11:47:32 - [play_16KHz_16b_2ch] Using clip: yesterday_16KHz_30s_16b_2ch.wav (1922036 bytes)
-[INFO] 2025-12-30 11:47:32 - [play_16KHz_16b_2ch] loop 1/1 start=2025-12-30T11:47:32Z clip=yesterday_16KHz_30s_16b_2ch.wav backend=pipewire sink=speakers(52)
-[INFO] 2025-12-30 11:47:32 - [play_16KHz_16b_2ch] exec: pw-play -v "AudioClips/yesterday_16KHz_30s_16b_2ch.wav"
-[INFO] 2025-12-30 11:48:02 - [play_16KHz_16b_2ch] evidence: pw_streaming=1 pa_streaming=0 alsa_running=1 asoc_path_on=1 pw_log=1
-[PASS] 2025-12-30 11:48:02 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
-[INFO] 2025-12-30 11:48:02 - Summary: total=1 pass=1 fail=0 skip=0
-[PASS] 2025-12-30 11:48:02 - AudioPlayback PASS
+sh-5.3# ./run.sh --no-extract-assets --clip-name "playback_config1"
+[INFO] 2026-01-22 17:46:33 - ---------------- Starting AudioPlayback ----------------
+[INFO] 2026-01-22 17:46:33 - Platform Details: machine='Qualcomm Technologies, Inc. Robotics RB3gen2' target='Kodiak' kernel='6.18.0-00393-g27507852413b' arch='aarch64'
+[INFO] 2026-01-22 17:46:33 - Args: backend=auto sink=speakers loops=1 timeout=0 formats='wav' durations='short' strict=0 dmesg=1 extract=false network_download=false clips_path=default
+[INFO] 2026-01-22 17:46:33 - Using backend: pipewire
+[INFO] 2026-01-22 17:46:33 - Routing to sink: id=52 name='Built-in Audio Speaker playback' choice=speakers
+[INFO] 2026-01-22 17:46:33 - Using clip discovery mode
+[INFO] 2026-01-22 17:46:33 - Discovered 1 clips to test
+[INFO] 2026-01-22 17:46:33 - [play_16KHz_16b_2ch] Using clip: yesterday_16KHz_30s_16b_2ch.wav (1922036 bytes)
+[INFO] 2026-01-22 17:46:33 - [play_16KHz_16b_2ch] loop 1/1 start=2026-01-22T17:46:33Z clip=yesterday_16KHz_30s_16b_2ch.wav backend=pipewire sink=speakers(52)
+[INFO] 2026-01-22 17:46:33 - [play_16KHz_16b_2ch] exec: pw-play -v "AudioClips/yesterday_16KHz_30s_16b_2ch.wav"
+[INFO] 2026-01-22 17:47:04 - [play_16KHz_16b_2ch] evidence: pw_streaming=1 pa_streaming=0 alsa_running=1 asoc_path_on=1 pw_log=1
+[PASS] 2026-01-22 17:47:04 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
+[INFO] 2026-01-22 17:47:04 - Summary: total=1 pass=1 fail=0 skip=0
+[PASS] 2026-01-22 17:47:04 - AudioPlayback PASS
 ```
 
 **Example 2: Testing multiple clips**
 ```
-sh-5.3# ./run.sh --no-extract-assets --clip-name "Config1 Config2 Config3"
-[INFO] 2025-12-30 11:48:13 - Using clip discovery mode
-[INFO] 2025-12-30 11:48:13 - Discovered 3 clips to test
-[INFO] 2025-12-30 11:48:13 - [play_16KHz_16b_2ch] Using clip: yesterday_16KHz_30s_16b_2ch.wav (1922036 bytes)
-[PASS] 2025-12-30 11:48:43 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
-[INFO] 2025-12-30 11:48:43 - [play_176.4KHz_24b_1ch] Using clip: yesterday_176.4KHz_30s_24b_1ch.wav (15892062 bytes)
-[PASS] 2025-12-30 11:49:14 - [play_176.4KHz_24b_1ch] loop 1 OK (rc=0, 31s)
-[INFO] 2025-12-30 11:49:14 - [play_176.4KHz_32b_6ch] Using clip: yesterday_176.4KHz_30s_32b_6ch.wav (127135484 bytes)
-[PASS] 2025-12-30 11:49:44 - [play_176.4KHz_32b_6ch] loop 1 OK (rc=0, 30s)
-[INFO] 2025-12-30 11:49:44 - Summary: total=3 pass=3 fail=0 skip=0
-[PASS] 2025-12-30 11:49:44 - AudioPlayback PASS
+sh-5.3# ./run.sh --no-extract-assets --clip-name "playback_config1 playback_config3 playback_config5"
+[INFO] 2026-01-22 17:42:30 - Using clip discovery mode
+[INFO] 2026-01-22 17:42:30 - Discovered 3 clips to test
+[INFO] 2026-01-22 17:42:30 - [play_16KHz_16b_2ch] Using clip: yesterday_16KHz_30s_16b_2ch.wav (1922036 bytes)
+[PASS] 2026-01-22 17:43:00 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
+[INFO] 2026-01-22 17:43:00 - [play_22.050KHz_8b_1ch] Using clip: yesterday_22.050KHz_30s_8b_1ch.wav (662284 bytes)
+[PASS] 2026-01-22 17:43:30 - [play_22.050KHz_8b_1ch] loop 1 OK (rc=0, 30s)
+[INFO] 2026-01-22 17:43:31 - [play_24KHz_32b_1ch] Using clip: yesterday_24KHz_30s_32b_1ch.wav (2883004 bytes)
+[PASS] 2026-01-22 17:44:01 - [play_24KHz_32b_1ch] loop 1 OK (rc=0, 30s)
+[INFO] 2026-01-22 17:44:01 - Summary: total=3 pass=3 fail=0 skip=0
+[PASS] 2026-01-22 17:44:01 - AudioPlayback PASS
 ```
 
 **Example 3: Filtering clips by sample rate**
 ```
 sh-5.3# ./run.sh --no-extract-assets --clip-filter "48KHz"
-[INFO] 2025-12-30 12:00:08 - Using clip discovery mode
-[INFO] 2025-12-30 12:00:08 - Discovered 2 clips to test
-[INFO] 2025-12-30 12:00:08 - [play_48KHz_8b_2ch] Using clip: yesterday_48KHz_30s_8b_2ch.wav (2883002 bytes)
-[PASS] 2025-12-30 12:00:38 - [play_48KHz_8b_2ch] loop 1 OK (rc=0, 30s)
-[INFO] 2025-12-30 12:00:38 - [play_48KHz_8b_8ch] Using clip: yesterday_48KHz_30s_8b_8ch.wav (11531688 bytes)
-[PASS] 2025-12-30 12:01:08 - [play_48KHz_8b_8ch] loop 1 OK (rc=0, 30s)
-[INFO] 2025-12-30 12:01:08 - Summary: total=2 pass=2 fail=0 skip=0
-[PASS] 2025-12-30 12:01:08 - AudioPlayback PASS
+[INFO] 2026-01-22 17:54:45 - Using clip discovery mode
+[INFO] 2026-01-22 17:54:45 - Discovered 1 clips to test
+[INFO] 2026-01-22 17:54:45 - [play_48KHz_8b_2ch] Using clip: yesterday_48KHz_30s_8b_2ch.wav (2883002 bytes)
+[PASS] 2026-01-22 17:55:15 - [play_48KHz_8b_2ch] loop 1 OK (rc=0, 30s)
+[INFO] 2026-01-22 17:55:15 - Summary: total=1 pass=1 fail=0 skip=0
+[PASS] 2026-01-22 17:55:15 - AudioPlayback PASS
 ```
 
-**Example 4: Invalid config name (shows helpful error)**
+**Example 4: Testing all 10 clips (auto-discovery mode)**
 ```
-sh-5.3# ./run.sh --no-extract-assets --clip-name "Config0"
-[INFO] 2025-12-30 11:59:52 - Using clip discovery mode
-[SKIP] 2025-12-30 11:59:52 - AudioPlayback SKIP - Invalid clip/config name(s) provided. Available range: Config1 to Config20
+sh-5.3# ./run.sh --no-extract-assets --timeout 5s
+[INFO] 2026-01-22 17:51:32 - Auto-detected clip discovery mode (found clips in /home/AudioClips/)
+[INFO] 2026-01-22 17:51:32 - Using clip discovery mode
+[INFO] 2026-01-22 17:51:32 - Discovered 10 clips to test
+[INFO] 2026-01-22 17:51:32 - [play_16KHz_16b_2ch] Using clip: yesterday_16KHz_30s_16b_2ch.wav (1922036 bytes)
+[PASS] 2026-01-22 17:51:37 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:51:37 - [play_16KHz_8b_6ch] Using clip: yesterday_16KHz_30s_8b_6ch.wav (2883002 bytes)
+[PASS] 2026-01-22 17:51:43 - [play_16KHz_8b_6ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:51:43 - [play_22.050KHz_8b_1ch] Using clip: yesterday_22.050KHz_30s_8b_1ch.wav (662284 bytes)
+[PASS] 2026-01-22 17:51:48 - [play_22.050KHz_8b_1ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:51:48 - [play_24KHz_24b_6ch] Using clip: yesterday_24KHz_30s_24b_6ch.wav (12973134 bytes)
+[PASS] 2026-01-22 17:51:53 - [play_24KHz_24b_6ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:51:53 - [play_24KHz_32b_1ch] Using clip: yesterday_24KHz_30s_32b_1ch.wav (2883004 bytes)
+[PASS] 2026-01-22 17:51:58 - [play_24KHz_32b_1ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:51:58 - [play_32KHz_16b_2ch] Using clip: yesterday_32KHz_30s_16b_2ch.wav (3843964 bytes)
+[PASS] 2026-01-22 17:52:03 - [play_32KHz_16b_2ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:52:03 - [play_32KHz_8b_8ch] Using clip: yesterday_32KHz_30s_8b_8ch.wav (7687832 bytes)
+[PASS] 2026-01-22 17:52:09 - [play_32KHz_8b_8ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:52:09 - [play_44.1KHz_16b_1ch] Using clip: yesterday_44.1KHz_30s_16b_1ch.wav (2648774 bytes)
+[PASS] 2026-01-22 17:52:14 - [play_44.1KHz_16b_1ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:52:14 - [play_48KHz_8b_2ch] Using clip: yesterday_48KHz_30s_8b_2ch.wav (2883002 bytes)
+[PASS] 2026-01-22 17:52:19 - [play_48KHz_8b_2ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:52:19 - [play_8KHz_8b_1ch] Using clip: yesterday_8KHz_30s_8b_1ch.wav (240362 bytes)
+[PASS] 2026-01-22 17:52:24 - [play_8KHz_8b_1ch] loop 1 OK (rc=0, 5s)
+[INFO] 2026-01-22 17:52:24 - Summary: total=10 pass=10 fail=0 skip=0
+[PASS] 2026-01-22 17:52:24 - AudioPlayback PASS
 ```
 
-**Example 5: CI/LAVA workflow with unique result files**
+**Example 5: Invalid config name (shows helpful error)**
 ```
-sh-5.3# ./run.sh --clip-name "Config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets
-[INFO] 2026-01-12 06:56:47 - Using unique result file: ./AudioPlayback_Config1.res
-[INFO] 2026-01-12 06:56:47 - ---------------- Starting AudioPlayback ----------------
-[INFO] 2026-01-12 06:56:48 - Using clip discovery mode
-[INFO] 2026-01-12 06:56:48 - Discovered 1 clips to test
-[INFO] 2026-01-12 06:56:48 - [play_16KHz_16b_2ch] Clip duration: 30s (timeout threshold: 29s)
-[PASS] 2026-01-12 06:57:18 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
-[PASS] 2026-01-12 06:57:18 - AudioPlayback PASS
+sh-5.3# ./run.sh --no-extract-assets --clip-name "playback_config99"
+[INFO] 2026-01-22 17:59:52 - Using clip discovery mode
+[SKIP] 2026-01-22 17:59:52 - AudioPlayback SKIP - Invalid clip/config name(s) provided. Available range: playback_config1 to playback_config10
+```
+
+**Example 6: CI/LAVA workflow with unique result files**
+```
+sh-5.3# ./run.sh --clip-name "playback_config1" --res-suffix "Config1" --audio-clips-path /home/AudioClips/ --no-extract-assets
+[INFO] 2026-01-22 17:46:33 - Using unique result file: ./AudioPlayback_Config1.res
+[INFO] 2026-01-22 17:46:33 - ---------------- Starting AudioPlayback ----------------
+[INFO] 2026-01-22 17:46:33 - Using clip discovery mode
+[INFO] 2026-01-22 17:46:33 - Discovered 1 clips to test
+[INFO] 2026-01-22 17:46:33 - [play_16KHz_16b_2ch] Clip duration: 30s (timeout threshold: 29s)
+[PASS] 2026-01-22 17:47:04 - [play_16KHz_16b_2ch] loop 1 OK (rc=0, 30s)
+[PASS] 2026-01-22 17:47:04 - AudioPlayback PASS
 
 sh-5.3# cat AudioPlayback_Config1.res
 AudioPlayback PASS
 
-sh-5.3# ./run.sh --clip-name "Config7" --res-suffix "Config7" --audio-clips-path /home/AudioClips/ --no-extract-assets
-[INFO] 2026-01-12 06:57:42 - Using unique result file: ./AudioPlayback_Config7.res
-[PASS] 2026-01-12 06:58:13 - AudioPlayback PASS
+sh-5.3# ./run.sh --clip-name "playback_config7" --res-suffix "Config7" --audio-clips-path /home/AudioClips/ --no-extract-assets
+[INFO] 2026-01-22 17:48:34 - Using unique result file: ./AudioPlayback_Config7.res
+[PASS] 2026-01-22 17:49:05 - AudioPlayback PASS
 
 sh-5.3# cat AudioPlayback_Config7.res
 AudioPlayback PASS

--- a/Runner/suites/Multimedia/Audio/AudioRecord/AudioRecord.yaml
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/AudioRecord.yaml
@@ -25,5 +25,5 @@ run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/Audio/AudioRecord/
-    - ./run.sh --backend "${AUDIO_BACKEND}" --source "${SOURCE_CHOICE}" --config-name "${CONFIG_NAMES}" --config-filter "${CONFIG_FILTER}" --durations "${DURATIONS}" --record-seconds "${RECORD_SECONDS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --res-suffix "${RES_SUFFIX}" || true
+    - ./run.sh --backend "${AUDIO_BACKEND}" --source "${SOURCE_CHOICE}" --config-name "${CONFIG_NAMES}" --config-filter "${CONFIG_FILTER}" --record-seconds "${RECORD_SECONDS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --res-suffix "${RES_SUFFIX}" || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh AudioRecord${RES_SUFFIX:+_${RES_SUFFIX}}.res || true

--- a/Runner/utils/audio_common.sh
+++ b/Runner/utils/audio_common.sh
@@ -796,47 +796,55 @@ audio_check_clips_available() {
 # ---------- New Clip Discovery Functions (for 20-clip enhancement) ----------
 
 # ---------- Config Mapping ----------
-# Provides stable, deterministic mapping from Config1-Config20 to specific
+# Provides stable, deterministic mapping from playback_config1-playback_config10 to specific
 # audio format test cases. This ensures reproducible test coverage across
 # different systems and releases.
 #
-# Config numbers map to specific sample rate, bit depth, and channel combinations:
-#   Config1  → 16 KHz, 16-bit, 2ch    Config11 → 352.8 KHz, 32-bit, 1ch
-#   Config2  → 176.4 KHz, 24-bit, 1ch Config12 → 384 KHz, 32-bit, 2ch
-#   Config3  → 176.4 KHz, 32-bit, 6ch Config13 → 44.1 KHz, 16-bit, 1ch
-#   Config4  → 192 KHz, 16-bit, 6ch   Config14 → 44.1 KHz, 8-bit, 6ch
-#   Config5  → 192 KHz, 32-bit, 8ch   Config15 → 48 KHz, 8-bit, 2ch
-#   Config6  → 22.05 KHz, 8-bit, 1ch  Config16 → 48 KHz, 8-bit, 8ch
-#   Config7  → 24 KHz, 24-bit, 6ch    Config17 → 88.2 KHz, 16-bit, 8ch
-#   Config8  → 24 KHz, 32-bit, 8ch    Config18 → 88.2 KHz, 24-bit, 2ch
-#   Config9  → 32 KHz, 16-bit, 2ch    Config19 → 8 KHz, 8-bit, 1ch
-#   Config10 → 32 KHz, 8-bit, 8ch     Config20 → 96 KHz, 24-bit, 6ch
+# Playback config numbers map to specific sample rate, bit depth, and channel combinations:
+#   playback_config1  → 8 KHz, 8-bit, 1ch
+#   playback_config2  → 16 KHz, 8-bit, 6ch
+#   playback_config3  → 16 KHz, 16-bit, 2ch
+#   playback_config4  → 22.05 KHz, 8-bit, 1ch
+#   playback_config5  → 24 KHz, 24-bit, 6ch
+#   playback_config6  → 24 KHz, 32-bit, 1ch
+#   playback_config7  → 32 KHz, 8-bit, 8ch
+#   playback_config8  → 32 KHz, 16-bit, 2ch
+#   playback_config9  → 44.1 KHz, 16-bit, 1ch
+#   playback_config10 → 48 KHz, 8-bit, 2ch
 
-# Translate Config number to test case name
-# Returns descriptive test case name for given config number
+# Translate playback_config name to test case name
+# Returns descriptive test case name for given config
 map_config_to_testcase() {
-  config_num="$1"
+  config="$1"
+  
+  # Extract config number if using playback_config format
+  config_num=""
+  case "$config" in
+    playback_config*)
+      config_num="$(printf '%s' "$config" | sed -n 's/^playback_config\([0-9][0-9]*\)$/\1/p')"
+      ;;
+    Config*)
+      # For backward compatibility
+      config_num="$(printf '%s' "$config" | sed -n 's/^Config\([0-9][0-9]*\)$/\1/p')"
+      ;;
+    [0-9]*)
+      # Direct number input
+      config_num="$config"
+      ;;
+  esac
+  
+  # Map config number to test case name
   case "$config_num" in
-    1)  printf 'play_16KHz_16b_2ch\n' ;;
-    2)  printf 'play_176.4KHz_24b_1ch\n' ;;
-    3)  printf 'play_176.4KHz_32b_6ch\n' ;;
-    4)  printf 'play_192KHz_16b_6ch\n' ;;
-    5)  printf 'play_192KHz_32b_8ch\n' ;;
-    6)  printf 'play_22.05KHz_8b_1ch\n' ;;
-    7)  printf 'play_24KHz_24b_6ch\n' ;;
-    8)  printf 'play_24KHz_32b_8ch\n' ;;
-    9)  printf 'play_32KHz_16b_2ch\n' ;;
-    10) printf 'play_32KHz_8b_8ch\n' ;;
-    11) printf 'play_352.8KHz_32b_1ch\n' ;;
-    12) printf 'play_384KHz_32b_2ch\n' ;;
-    13) printf 'play_44.1KHz_16b_1ch\n' ;;
-    14) printf 'play_44.1KHz_8b_6ch\n' ;;
-    15) printf 'play_48KHz_8b_2ch\n' ;;
-    16) printf 'play_48KHz_8b_8ch\n' ;;
-    17) printf 'play_88.2KHz_16b_8ch\n' ;;
-    18) printf 'play_88.2KHz_24b_2ch\n' ;;
-    19) printf 'play_8KHz_8b_1ch\n' ;;
-    20) printf 'play_96KHz_24b_6ch\n' ;;
+    1)  printf 'play_8KHz_8b_1ch\n' ;;
+    2)  printf 'play_16KHz_8b_6ch\n' ;;
+    3)  printf 'play_16KHz_16b_2ch\n' ;;
+    4)  printf 'play_22.05KHz_8b_1ch\n' ;;
+    5)  printf 'play_24KHz_24b_6ch\n' ;;
+    6)  printf 'play_24KHz_32b_1ch\n' ;;
+    7)  printf 'play_32KHz_8b_8ch\n' ;;
+    8)  printf 'play_32KHz_16b_2ch\n' ;;
+    9)  printf 'play_44.1KHz_16b_1ch\n' ;;
+    10) printf 'play_48KHz_8b_2ch\n' ;;
     *) return 1 ;;
   esac
   return 0
@@ -960,7 +968,7 @@ resolve_clip_by_name() {
 }
 
 # Validate clip name against available clips
-# Input: requested_name (e.g., play_48KHz_16b_2ch OR Config1), available_clips (list)
+# Input: requested_name (e.g., play_48KHz_16b_2ch OR playback_config1), available_clips (list)
 # Output: matching clip filename to stdout
 # Logs error messages to stderr
 # Returns: 0=found, 1=not found
@@ -968,9 +976,17 @@ validate_clip_name() {
   requested_name="$1"
   available_clips="$2"
   
-  # Check if requested_name is a generic config name (Config1, Config2, etc.)
-  # Support both "Config1" and "config1" (case-insensitive)
-  config_num="$(printf '%s' "$requested_name" | sed -n 's/^[Cc]onfig\([0-9][0-9]*\)$/\1/p')"
+  # Check if requested_name is a generic config name (playback_config1, Config1, etc.)
+  # Support both formats for backward compatibility
+  config_num=""
+  case "$requested_name" in
+    playback_config*)
+      config_num="$(printf '%s' "$requested_name" | sed -n 's/^playback_config\([0-9][0-9]*\)$/\1/p')"
+      ;;
+    [Cc]onfig*)
+      config_num="$(printf '%s' "$requested_name" | sed -n 's/^[Cc]onfig\([0-9][0-9]*\)$/\1/p')"
+      ;;
+  esac
   
   if [ -n "$config_num" ]; then
     # Generic config name - map to clip by index (1-based)
@@ -1013,7 +1029,7 @@ validate_clip_name() {
   idx=$#
   
   # No match found - provide helpful error message with range
-  log_error "Wrong clip name: '$requested_name'. Available range: Config1 to Config$idx. Please check again." >&2
+  log_error "Wrong clip name: '$requested_name'. Available range: playback_config1 to playback_config$idx. Please check again." >&2
   return 1
 }
 


### PR DESCRIPTION
Optimized AudioPlayback test suite by reducing configurations from 20 to 10 and resolved YAML parameter conflicts causing LAVA execution failures.

Changes:
- AudioPlayback: Reduced from 20 to 10 test configurations
- Renamed Config1-20 to playback_config1-10 for naming consistency
- meta-ar-ci-premerge.yaml: Rebalanced to 5 playback + 5 record tests
- Fixed YAML parameter conflicts in both AudioPlayback and AudioRecord
- Updated documentation to reflect new configuration structure

AudioPlayback reduction (20→10 configs):
* Reduced clip configurations from 20 to 10 to optimize test suite size
* Updated naming convention: Config1-20 → playback_config1-10
* Modified audio_common.sh to map new 10-clip configuration
* Updated sample rate coverage: 8 KHz to 48 KHz
* Updated Read_me.md with new configuration table and examples

YAML parameter conflict resolution:
* AudioPlayback.yaml: Removed --formats and --durations from run command
* AudioRecord.yaml: Removed --durations from run command
* Fixed "Cannot mix discovery parameters with legacy matrix parameters" error

Pre-merge CI rebalancing:
* AudioPlayback: 5 tests (playback_config1, 3, 5, 8, 10)
* AudioRecord: 5 tests (record_config1, 3, 5, 7, 9)
* Total remains 10 test cases with balanced 5+5 split
* Uses pre-staged clips at /home/AudioClips/
* Unique result files prevent overwriting in parallel execution

Test coverage:
- AudioPlayback: 8-48 KHz, 8-32 bit, 1-8 channels
- AudioRecord: 8-96 KHz, 1-6 channels
- 10 diverse configurations ensure comprehensive audio validation