### PR TITLE
Added automation of Virsh commands

### DIFF
--- a/Runner/suites/Kernel/Virtualization/Kvm-Reboot/Kvm-Reboot.yaml
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Reboot/Kvm-Reboot.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: kvm-reboot
+  format: "Lava-Test Test Definition 1.0"
+  description: "Reboot an active Gunyah KVM Virtual Machine"
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Kernel/Virtualization/Kvm-Reboot
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Kvm-Reboot.res || true

--- a/Runner/suites/Kernel/Virtualization/Kvm-Reboot/README.md
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Reboot/README.md
@@ -1,0 +1,23 @@
+# Kvm-Reboot Test
+© Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+This test validates the reboot functionality of the Guest VM. It issues a reboot command via `virsh` and ensures the VM returns to a running state.
+
+### The test checks for:
+- Successful execution of `virsh reboot`.
+- VM returning to **"running"** state.
+
+## Usage
+### Quick Example
+```bash
+cd /var/Runner/suites/Kernel/Virtualization/Kvm-Reboot
+./run.sh
+```
+
+### Result Format
+Test result will be saved in Kvm-Reboot.res.
+
+### Output
+Kvm-Reboot PASS OR Kvm-Reboot FAIL

--- a/Runner/suites/Kernel/Virtualization/Kvm-Reboot/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Reboot/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SEARCH_PATH="$SCRIPT_DIR"
+LIB_PATH=""
+while [ "$SEARCH_PATH" != "/" ]; do
+    if [ -f "$SEARCH_PATH/utils/kvm_common.sh" ]; then
+        LIB_PATH="$SEARCH_PATH/utils/kvm_common.sh"
+        break
+    fi
+    SEARCH_PATH=$(dirname "$SEARCH_PATH")
+done
+
+if [ -f "$LIB_PATH" ]; then
+    # shellcheck disable=SC1090
+    . "$LIB_PATH"
+else
+    echo "[ERROR] Lib not found"
+    exit 1
+fi
+
+TESTNAME="Kvm-Reboot"
+RES_FILE="${TESTNAME}.res"
+rm -f "$RES_FILE"
+
+# Clean up old stdout logs from previous runs
+rm -f *_stdout_*.log
+
+log_info "----------- KVM Reboot -----------"
+
+if virsh list --all | grep -q -w "$VM_NAME"; then
+    log_info "Existing VM instance found. Cleaning up..."
+    vm_clean
+fi
+
+vm_define && vm_start
+if [ $? -ne 0 ]; then echo "$TESTNAME FAIL" > "$RES_FILE"; exit 1; fi
+
+# Test: Reboot
+log_info "Rebooting $VM_NAME"
+virsh reboot "$VM_NAME"
+sleep 5
+
+# Verify Running
+check_vm_state "$VM_NAME" "running"
+if [ $? -eq 0 ]; then
+    log_pass "VM rebooted successfully."
+    echo "$TESTNAME PASS" > "$RES_FILE"
+else
+    log_fail "VM not running after reboot."
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+fi
+
+# Cleanup
+vm_clean

--- a/Runner/suites/Kernel/Virtualization/Kvm-Reboot/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Reboot/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/Runner/suites/Kernel/Virtualization/Kvm-Resume/Kvm-Resume.yaml
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Resume/Kvm-Resume.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: kvm-resume
+  format: "Lava-Test Test Definition 1.0"
+  description: "Resume a paused Gunyah KVM Virtual Machine"
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Kernel/Virtualization/Kvm-Resume
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Kvm-Resume.res || true

--- a/Runner/suites/Kernel/Virtualization/Kvm-Resume/README.md
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Resume/README.md
@@ -1,0 +1,23 @@
+# Kvm-Resume Test
+© Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+This test validates that a suspended VM can be resumed to active execution.
+
+### The test checks for:
+- Successful execution of `virsh resume`.
+- VM state transition back to **"running"**.
+
+## Usage
+### Quick Example
+```bash
+cd /var/Runner/suites/Kernel/Virtualization/Kvm-Resume
+./run.sh
+```
+
+### Result Format
+Test result will be saved in Kvm-Reboot.res.
+
+### Output
+Kvm-Reboot PASS OR Kvm-Reboot FAIL

--- a/Runner/suites/Kernel/Virtualization/Kvm-Resume/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Resume/run.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SEARCH_PATH="$SCRIPT_DIR"
+LIB_PATH=""
+while [ "$SEARCH_PATH" != "/" ]; do
+    if [ -f "$SEARCH_PATH/utils/kvm_common.sh" ]; then
+        LIB_PATH="$SEARCH_PATH/utils/kvm_common.sh"
+        break
+    fi
+    SEARCH_PATH=$(dirname "$SEARCH_PATH")
+done
+
+if [ -f "$LIB_PATH" ]; then
+    # shellcheck disable=SC1090
+    . "$LIB_PATH"
+else
+    echo "[ERROR] Lib not found"
+    exit 1
+fi
+
+TESTNAME="Kvm-Resume"
+RES_FILE="${TESTNAME}.res"
+rm -f "$RES_FILE"
+
+# Clean up old stdout logs from previous runs
+rm -f *_stdout_*.log
+
+log_info "----------- KVM Resume -----------"
+
+if virsh list --all | grep -q -w "$VM_NAME"; then
+    log_info "Existing VM instance found. Cleaning up..."
+    vm_clean
+fi
+
+vm_define && vm_start
+if [ $? -ne 0 ]; then echo "$TESTNAME FAIL" > "$RES_FILE"; exit 1; fi
+
+# Pre-req: Must be suspended first
+log_info "Suspending VM for resume test..."
+virsh suspend "$VM_NAME"
+sleep 2
+
+# Test: Resume
+log_info "Resuming $VM_NAME"
+virsh resume "$VM_NAME"
+
+# Verify Running
+check_vm_state "$VM_NAME" "running"
+if [ $? -eq 0 ]; then
+    log_pass "VM resumed successfully."
+    echo "$TESTNAME PASS" > "$RES_FILE"
+else
+    log_fail "VM failed to resume."
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+fi
+
+# Cleanup
+vm_clean

--- a/Runner/suites/Kernel/Virtualization/Kvm-Resume/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Resume/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/Runner/suites/Kernel/Virtualization/Kvm-Setup/Kvm-Setup.yaml
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Setup/Kvm-Setup.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: kvm-setup
+  format: "Lava-Test Test Definition 1.0"
+  description: "Setup and Start Gunyah KVM Virtual Machine"
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Kernel/Virtualization/Kvm-Setup
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Kvm-Setup.res || true

--- a/Runner/suites/Kernel/Virtualization/Kvm-Setup/README.md
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Setup/README.md
@@ -1,0 +1,34 @@
+# Kvm-Setup Test
+© Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+This test case initializes the KVM environment by defining the Virtual Machine using an XML configuration and starting the domain. It verifies that the VM transitions to the `running` state.
+
+### The test checks for:
+- Successful **definition** of the VM from `vm.xml`.
+- Successful **start** command execution.
+- Verification that the VM state is **"running"**.
+
+## Usage
+### Instructions:
+1. Ensure the `vm.xml` and guest image files are present in `/var/gunyah/`.
+2. Navigate to the test directory.
+3. Run the script.
+
+### Quick Example
+```bash
+cd /var/Runner/suites/Kernel/Virtualization/Kvm-Setup
+./run.sh
+```
+
+### Prerequisites
+1. virsh tool must be installed.
+2. Gunyah hypervisor must be enabled.
+3. Root access is required.
+
+### Result Format
+Test result will be saved in Kvm-Setup.res.
+
+### Output
+Kvm-Setup PASS OR Kvm-Setup FAIL

--- a/Runner/suites/Kernel/Virtualization/Kvm-Setup/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Setup/run.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SEARCH_PATH="$SCRIPT_DIR"
+LIB_PATH=""
+while [ "$SEARCH_PATH" != "/" ]; do
+    if [ -f "$SEARCH_PATH/utils/kvm_common.sh" ]; then
+        LIB_PATH="$SEARCH_PATH/utils/kvm_common.sh"
+        break
+    fi
+    SEARCH_PATH=$(dirname "$SEARCH_PATH")
+done
+
+if [ -f "$LIB_PATH" ]; then
+    # shellcheck disable=SC1090
+    . "$LIB_PATH"
+else
+    echo "[ERROR] Lib not found"
+    exit 1
+fi
+
+# Define Test Metadata
+TESTNAME="Kvm-Setup"
+RES_FILE="${TESTNAME}.res"
+
+# Clean up old stdout logs from previous runs
+rm -f *_stdout_*.log
+
+# Execution
+log_info "----------- KVM Setup: Define and Start -----------"
+
+# Clean up any existing result file
+rm -f "$RES_FILE"
+
+# Define VM
+if virsh list --all | grep -q -w "$VM_NAME"; then
+    log_info "Existing VM instance found. Cleaning up..."
+    vm_clean
+fi
+
+# 2. Define
+vm_define
+if [ $? -ne 0 ]; then echo "$TESTNAME FAIL" > "$RES_FILE"; exit 1; fi
+
+# 3. Start
+vm_start
+if [ $? -ne 0 ]; then echo "$TESTNAME FAIL" > "$RES_FILE"; exit 1; fi
+
+# 4. Verify
+check_vm_state "$VM_NAME" "running"
+if [ $? -eq 0 ]; then
+    log_pass "VM is running."
+    echo "$TESTNAME PASS" > "$RES_FILE"
+else
+    log_fail "VM failed to reach 'running' state."
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 1
+fi

--- a/Runner/suites/Kernel/Virtualization/Kvm-Setup/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Setup/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/Runner/suites/Kernel/Virtualization/Kvm-Suspend/Kvm-Suspend.yaml
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Suspend/Kvm-Suspend.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: kvm-suspend
+  format: "Lava-Test Test Definition 1.0"
+  description: "Suspend a running Gunyah KVM Virtual Machine"
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Kernel/Virtualization/Kvm-Suspend
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Kvm-Suspend.res || true

--- a/Runner/suites/Kernel/Virtualization/Kvm-Suspend/README.md
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Suspend/README.md
@@ -1,0 +1,23 @@
+# Kvm-Suspend Test
+© Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+This test checks the ability to suspend (pause) the execution of the Guest VM.
+
+### The test checks for:
+- Successful execution of `virsh suspend`.
+- VM state transition to **"paused"**.
+
+## Usage
+### Quick Example
+```bash
+cd /var/Runner/suites/Kernel/Virtualization/Kvm-Suspend
+./run.sh
+```
+
+### Result Format
+Test result will be saved in Kvm-Suspend.res.
+
+### Output
+Kvm-Suspend PASS OR Kvm-Suspend FAIL

--- a/Runner/suites/Kernel/Virtualization/Kvm-Suspend/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Suspend/run.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SEARCH_PATH="$SCRIPT_DIR"
+LIB_PATH=""
+while [ "$SEARCH_PATH" != "/" ]; do
+    if [ -f "$SEARCH_PATH/utils/kvm_common.sh" ]; then
+        LIB_PATH="$SEARCH_PATH/utils/kvm_common.sh"
+        break
+    fi
+    SEARCH_PATH=$(dirname "$SEARCH_PATH")
+done
+
+if [ -f "$LIB_PATH" ]; then
+    # shellcheck disable=SC1090
+    . "$LIB_PATH"
+else
+    echo "[ERROR] Lib not found"
+    exit 1
+fi
+
+TESTNAME="Kvm-Suspend"
+RES_FILE="${TESTNAME}.res"
+rm -f "$RES_FILE"
+
+# Clean up old stdout logs from previous runs
+rm -f *_stdout_*.log
+
+log_info "----------- KVM Suspend -----------"
+
+if virsh list --all | grep -q -w "$VM_NAME"; then
+    log_info "Existing VM instance found. Cleaning up..."
+    vm_clean
+fi
+
+vm_define && vm_start
+if [ $? -ne 0 ]; then echo "$TESTNAME FAIL" > "$RES_FILE"; exit 1; fi
+
+log_info "Suspending VM: $VM"
+virsh suspend "$VM"
+if [ $? -ne 0 ]; then
+    log_fail "Failed to issue suspend command."
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 1
+fi
+
+check_vm_state "$VM" "paused"
+if [ $? -eq 0 ]; then
+    log_pass "VM successfully paused."
+    echo "$TESTNAME PASS" > "$RES_FILE"
+else
+    log_fail "VM failed to enter 'paused' state."
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 1
+fi
+
+vm_clean

--- a/Runner/suites/Kernel/Virtualization/Kvm-Suspend/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-Suspend/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/Runner/suites/Kernel/Virtualization/Kvm-UnDefine/Kvm-UnDefine.yaml
+++ b/Runner/suites/Kernel/Virtualization/Kvm-UnDefine/Kvm-UnDefine.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: kvm-teardown
+  format: "Lava-Test Test Definition 1.0"
+  description: "Stop and Remove Gunyah KVM Virtual Machine"
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Kernel/Virtualization/Kvm-Teardown
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Kvm-Teardown.res || true

--- a/Runner/suites/Kernel/Virtualization/Kvm-UnDefine/README.md
+++ b/Runner/suites/Kernel/Virtualization/Kvm-UnDefine/README.md
@@ -1,0 +1,24 @@
+# Kvm-Teardown Test
+© Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+## Overview
+This test cleans up the KVM environment by forcefully stopping (destroying) the VM and removing its configuration (undefining).
+
+### The test checks for:
+- Successful execution of `virsh destroy`.
+- Successful execution of `virsh undefine`.
+- Verification that the VM is no longer listed in `virsh list --all`.
+
+## Usage
+### Quick Example
+```bash
+cd /var/Runner/suites/Kernel/Virtualization/Kvm-Teardown
+./run.sh
+```
+
+### Result Format
+Test result will be saved in Kvm-Reboot.res.
+
+### Output
+Kvm-Reboot PASS OR Kvm-Reboot FAIL

--- a/Runner/suites/Kernel/Virtualization/Kvm-UnDefine/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-UnDefine/run.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Robustly find and source init_env
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SEARCH_PATH="$SCRIPT_DIR"
+LIB_PATH=""
+while [ "$SEARCH_PATH" != "/" ]; do
+    if [ -f "$SEARCH_PATH/utils/kvm_common.sh" ]; then
+        LIB_PATH="$SEARCH_PATH/utils/kvm_common.sh"
+        break
+    fi
+    SEARCH_PATH=$(dirname "$SEARCH_PATH")
+done
+
+if [ -f "$LIB_PATH" ]; then
+    # shellcheck disable=SC1090
+    . "$LIB_PATH"
+else
+    echo "[ERROR] Lib not found"
+    exit 1
+fi
+
+TESTNAME="Kvm-Teardown"
+RES_FILE="${TESTNAME}.res"
+rm -f "$RES_FILE"
+
+# Clean up old stdout logs from previous runs
+rm -f *_stdout_*.log
+
+log_info "----------- KVM Teardown: Destroy and Undefine -----------"
+
+if virsh list --all | grep -q -w "$VM_NAME"; then
+    log_info "Existing VM instance found. Cleaning up..."
+    vm_clean
+fi
+
+vm_define && vm_start
+if [ $? -ne 0 ]; then echo "$TESTNAME FAIL" > "$RES_FILE"; exit 1; fi
+
+log_info "Destroying VM $VM_NAME"
+virsh destroy "$VM_NAME"
+sleep 2
+
+if virsh list | grep -q "$VM_NAME"; then
+    log_fail "VM still listed as running."
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    vm_clean
+    exit 1
+fi
+
+log_info "Undefining VM $VM_NAME"
+virsh undefine "$VM_NAME"
+
+if virsh list --all | grep -q "$VM_NAME"; then
+    log_fail "VM configuration still exists."
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+else
+    log_pass "VM successfully torn down."
+    echo "$TESTNAME PASS" > "$RES_FILE"
+fi

--- a/Runner/suites/Kernel/Virtualization/Kvm-UnDefine/run.sh
+++ b/Runner/suites/Kernel/Virtualization/Kvm-UnDefine/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/Runner/utils/kvm_common.sh
+++ b/Runner/utils/kvm_common.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+ 
+UTILS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEARCH="$UTILS_DIR"
+INIT_ENV=""
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] kvm_common.sh: Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+
+# shellcheck disable=SC1090
+. "$TOOLS/functestlib.sh"
+
+export VM="hk-vm"
+export VM_NAME="$VM"
+export XML_FILE="/var/gunyah/vm.xml"
+export NONRT_IMAGE_DIR="$TOOLS/nonrt_Image"
+
+vm_clean() {
+    log_info "Cleaning up existing VM state for: $VM_NAME"
+    
+    if virsh list --all | grep -q "$VM_NAME"; then
+        virsh destroy "$VM_NAME" > /dev/null 2>&1
+        sleep 2
+    fi
+    
+    if virsh list --all | grep -q "$VM_NAME"; then
+        virsh undefine "$VM_NAME" > /dev/null 2>&1
+    fi
+}
+
+vm_define() {
+    log_info "Defining VM from XML: $XML_FILE"
+    if [ ! -f "$XML_FILE" ]; then
+        log_fail "XML File not found at $XML_FILE"
+        return 1
+    fi
+
+    virsh define "$XML_FILE"
+    if [ $? -ne 0 ]; then
+        log_fail "Failed to define VM."
+        return 1
+    fi
+    return 0
+}
+
+vm_start() {
+    log_info "Starting VM: $VM_NAME"
+    virsh start "$VM_NAME"
+    if [ $? -ne 0 ]; then
+        log_fail "Failed to start VM."
+        return 1
+    fi
+    
+    sleep 5
+    return 0
+}
+
+check_vm_state() {
+ 
+    local vm_name=$1
+    local expected_state=$2
+    local current_state
+    
+    log_info "Verifying VM state for '$vm_name'... Expecting: $expected_state"
+    
+    current_state=$(virsh domstate "$vm_name" 2>/dev/null | xargs)
+    
+    if [ "$current_state" == "$expected_state" ]; then
+        log_info "SUCCESS: VM is in '$current_state' state."
+        return 0
+    else
+        log_fail "FAIL: VM state mismatch. Expected '$expected_state', found '$current_state'."
+        return 1
+    fi
+}


### PR DESCRIPTION
This PR refactors the Virsh Commands into a modular suite of independent KVM test cases.

Key Changes:

1. Modular Architecture: Split the original script into 5 standalone test cases:
2. Kvm-Setup: Defines and starts the VM.
3. Kvm-Reboot: Verifies reboot functionality.
4. Kvm-Suspend: Verifies suspend/pause functionality.
5. Kvm-Resume: Verifies resume functionality.
6. Kvm-UnDefine: Verifies destroy and undefine functionality.

Created kvm_common.sh to handle shared logic (define, start, clean, state checks) and reduce code duplication.

Robust State Verification: Replaced simple exit code checks with a check_vm_state function that parses virsh domstate output to ensure the VM is actually in the expected state (e.g., "running", "paused", "shut off").

Independence: Each test script now manages its own lifecycle (Setup -> Test -> Undefine), allowing them to be run individually or in any order.

Reporting: Added .res file generation (PASS/FAIL) and LAVA-compatible .yaml metadata for automation integration.