### PR TITLE
Legal: update SPDX license from BSD-3-Clause-Clear to BSD-3-Clause

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,5 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # 🛠️ Contributing to qcom-linux-testkit
 
 Thank you for considering contributing to the **qcom-linux-testkit** project! Your contributions help improve the quality and functionality of our test suite. Please follow the guidelines below to ensure a smooth contribution process.
@@ -78,8 +77,7 @@ Runner/
 
 ```sh
 #!/bin/sh
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 #Source init_env and functestlib.sh
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
@@ -160,8 +158,7 @@ Ensure that all new files include the appropriate license header:
 
 ```sh
 #!/bin/sh
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-```
+# SPDX-License-Identifier: BSD-3-Clause```
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,3 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
 
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -111,5 +111,4 @@ These tests can be used as CI jobs in:
 
 ```
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
-SPDX-License-Identifier: BSD-3-Clause-Clear
-```
+SPDX-License-Identifier: BSD-3-Clause```

--- a/Runner/init_env
+++ b/Runner/init_env
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Idempotency guard: only initialize ONCE per shell session
 [ -n "$__INIT_ENV_LOADED" ] && return
 __INIT_ENV_LOADED=1

--- a/Runner/run-test.sh
+++ b/Runner/run-test.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Resolve the real path of this script
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/Runner/suites/Connectivity/Bluetooth/BT_FW_KMD_Service/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/BT_FW_KMD_Service/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # BT_FW_KMD_Service - Bluetooth FW + KMD + service + controller infra validation
 # Non-expect version, using lib_bluetooth.sh helpers.
 

--- a/Runner/suites/Connectivity/Bluetooth/BT_ON_OFF/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/BT_ON_OFF/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# BT_ON_OFF - Basic Bluetooth power toggle validation (non-expect version)
+# SPDX-License-Identifier: BSD-3-Clause# BT_ON_OFF - Basic Bluetooth power toggle validation (non-expect version)
 
 # Robustly find and source init_env
 SCRIPT_DIR="$(

--- a/Runner/suites/Connectivity/Bluetooth/BT_SCAN/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/BT_SCAN/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# BT_SCAN – Bluetooth scanning validation (non-expect version)
+# SPDX-License-Identifier: BSD-3-Clause# BT_SCAN – Bluetooth scanning validation (non-expect version)
 # ---------- Repo env + helpers ----------
 SCRIPT_DIR="$(
   cd "$(dirname "$0")" || exit 1

--- a/Runner/suites/Connectivity/Bluetooth/BT_SCAN_PAIR/BT_SCAN_PAIR_README.md
+++ b/Runner/suites/Connectivity/Bluetooth/BT_SCAN_PAIR/BT_SCAN_PAIR_README.md
@@ -121,5 +121,4 @@ When a whitelist is specified (CLI or `BT_WHITELIST_ENV`), only devices whose MA
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-© Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause© Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Connectivity/Bluetooth/BT_SCAN_PAIR/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/BT_SCAN_PAIR/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Connectivity/Ethernet/README.md
+++ b/Runner/suites/Connectivity/Ethernet/README.md
@@ -1,6 +1,5 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 # Ethernet Validation Test
 
 ## Overview

--- a/Runner/suites/Connectivity/Ethernet/run.sh
+++ b/Runner/suites/Connectivity/Ethernet/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Connectivity/WiFi/WiFi_Dynamic_IP/README_WiFi_Connectivity.md
+++ b/Runner/suites/Connectivity/WiFi/WiFi_Dynamic_IP/README_WiFi_Connectivity.md
@@ -1,6 +1,5 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 # WiFi Connectivity Validation
 
 ## 📋 Overview

--- a/Runner/suites/Connectivity/WiFi/WiFi_Dynamic_IP/run.sh
+++ b/Runner/suites/Connectivity/WiFi/WiFi_Dynamic_IP/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Connectivity/WiFi/WiFi_Firmware_Driver/run.sh
+++ b/Runner/suites/Connectivity/WiFi/WiFi_Firmware_Driver/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Connectivity/WiFi/WiFi_Manual_IP/run.sh
+++ b/Runner/suites/Connectivity/WiFi/WiFi_Manual_IP/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Connectivity/WiFi/WiFi_OnOff/run.sh
+++ b/Runner/suites/Connectivity/WiFi/WiFi_OnOff/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/BWMON/run.sh
+++ b/Runner/suites/Kernel/Baseport/BWMON/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/Buses/run.sh
+++ b/Runner/suites/Kernel/Baseport/Buses/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Robustly find and source init_env
+# SPDX-License-Identifier: BSD-3-Clause# Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
 SEARCH="$SCRIPT_DIR"

--- a/Runner/suites/Kernel/Baseport/CPUFreq_Validation/README_CPUFreq_Validation.md
+++ b/Runner/suites/Kernel/Baseport/CPUFreq_Validation/README_CPUFreq_Validation.md
@@ -67,6 +67,5 @@ Runner/suites/Kernel/FunctionalArea/baseport/CPUFreq_Validation/run.sh
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-(c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause(c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 

--- a/Runner/suites/Kernel/Baseport/CPUFreq_Validation/run.sh
+++ b/Runner/suites/Kernel/Baseport/CPUFreq_Validation/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/GIC/run.sh
+++ b/Runner/suites/Kernel/Baseport/GIC/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/IPA/run.sh
+++ b/Runner/suites/Kernel/Baseport/IPA/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Test for IPA driver: skip if CONFIG_QCOM_IPA not enabled, then
 # builtin vs module, verify /dev/ipa, functional sysfs & dmesg checks.
 

--- a/Runner/suites/Kernel/Baseport/IPCC/run.sh
+++ b/Runner/suites/Kernel/Baseport/IPCC/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/Interrupts/run.sh
+++ b/Runner/suites/Kernel/Baseport/Interrupts/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/Kernel_Selftests/README.md
+++ b/Runner/suites/Kernel/Baseport/Kernel_Selftests/README.md
@@ -90,5 +90,4 @@ or from a higher-level testkit runner:
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-ClauseCopyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/Baseport/Kernel_Selftests/run.sh
+++ b/Runner/suites/Kernel/Baseport/Kernel_Selftests/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/MEMLAT/run.sh
+++ b/Runner/suites/Kernel/Baseport/MEMLAT/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/PCIe/README.md
+++ b/Runner/suites/Kernel/Baseport/PCIe/README.md
@@ -1,7 +1,6 @@
 # PCIe Validation Test
 © Qualcomm Technologies, Inc. and/or its subsidiaries.  
-SPDX-License-Identifier: BSD-3-Clause-Clear
-## Overview
+SPDX-License-Identifier: BSD-3-Clause## Overview
 This test case validates the PCIe interface on the target device by checking for the presence of key PCIe attributes using the `lspci -vvv` command. It ensures that the PCIe subsystem is correctly enumerated and functional
 ### The test checks for:
 - Presence of **Device Tree Node**

--- a/Runner/suites/Kernel/Baseport/PCIe/run.sh
+++ b/Runner/suites/Kernel/Baseport/PCIe/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/Probe_Failure_Check/Probe_Failure_Check_README.md
+++ b/Runner/suites/Kernel/Baseport/Probe_Failure_Check/Probe_Failure_Check_README.md
@@ -55,4 +55,4 @@ The script is tested with `shellcheck` and disables SC2039 and SC1091 where sour
 ## License
 
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause

--- a/Runner/suites/Kernel/Baseport/Probe_Failure_Check/run.sh
+++ b/Runner/suites/Kernel/Baseport/Probe_Failure_Check/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Probe failure / deferred probe detector using kernel logs + devices_deferred
+# SPDX-License-Identifier: BSD-3-Clause# Probe failure / deferred probe detector using kernel logs + devices_deferred
 
 # ---------- Repo env + helpers ----------
 SCRIPT_DIR="$(

--- a/Runner/suites/Kernel/Baseport/RMNET/run.sh
+++ b/Runner/suites/Kernel/Baseport/RMNET/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Test for RMNET driver: skip if CONFIG_RMNET not enabled, then
 # builtin vs module, verify /dev/rmnet, functional sysfs & dmesg checks.
 

--- a/Runner/suites/Kernel/Baseport/Reboot_health_check/run.sh
+++ b/Runner/suites/Kernel/Baseport/Reboot_health_check/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/Reboot_health_check/setup_systemd.sh
+++ b/Runner/suites/Kernel/Baseport/Reboot_health_check/setup_systemd.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Import test suite definitions
 set -x
 chmod 777 -R /var/common/*

--- a/Runner/suites/Kernel/Baseport/Storage/UFS_Validation/run.sh
+++ b/Runner/suites/Kernel/Baseport/Storage/UFS_Validation/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/Storage/eMMC_Validation/run.sh
+++ b/Runner/suites/Kernel/Baseport/Storage/eMMC_Validation/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/Timer/run.sh
+++ b/Runner/suites/Kernel/Baseport/Timer/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/USBHost/README.md
+++ b/Runner/suites/Kernel/Baseport/USBHost/README.md
@@ -1,7 +1,6 @@
 ```
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-```
+SPDX-License-Identifier: BSD-3-Clause```
 
 # USB Host Mode Validation
 
@@ -23,5 +22,4 @@ This shell script executes on the DUT (Device-Under-Test) and verifies enumerati
 
 ```
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
-SPDX-License-Identifier: BSD-3-Clause-Clear
-```
+SPDX-License-Identifier: BSD-3-Clause```

--- a/Runner/suites/Kernel/Baseport/USBHost/run.sh
+++ b/Runner/suites/Kernel/Baseport/USBHost/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 #Setup requires at least one USB peripheral connected to USB port that supports Host mode function
 
 # Robustly find and source init_env

--- a/Runner/suites/Kernel/Baseport/UserDataEncryption/README_UserDataEncryption.md
+++ b/Runner/suites/Kernel/Baseport/UserDataEncryption/README_UserDataEncryption.md
@@ -1,6 +1,5 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 # Qualcomm UserDataEncryption Functionality Test Script
 ## Overview
 

--- a/Runner/suites/Kernel/Baseport/UserDataEncryption/run.sh
+++ b/Runner/suites/Kernel/Baseport/UserDataEncryption/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Robustly find and source init_env
+# SPDX-License-Identifier: BSD-3-Clause# Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
 SEARCH="$SCRIPT_DIR"

--- a/Runner/suites/Kernel/Baseport/adsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/Baseport/adsp_remoteproc/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Robustly find and source init_env
+# SPDX-License-Identifier: BSD-3-Clause# Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
 SEARCH="$SCRIPT_DIR"

--- a/Runner/suites/Kernel/Baseport/cdsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/Baseport/cdsp_remoteproc/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/etm_trace/README.md
+++ b/Runner/suites/Kernel/Baseport/etm_trace/README.md
@@ -1,7 +1,6 @@
 # ETM_Trace  Validation test
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 ## Overview
 This test case validates the CoreSight Embedded Trace Macrocell (ETM) trace capture functionality on the target device. It ensures that the ETM source and TMC sink are properly enabled and that trace data can be successfully captured and validated.
 

--- a/Runner/suites/Kernel/Baseport/etm_trace/run.sh
+++ b/Runner/suites/Kernel/Baseport/etm_trace/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/gpdsp_remoteproc/run.sh
+++ b/Runner/suites/Kernel/Baseport/gpdsp_remoteproc/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/hotplug/run.sh
+++ b/Runner/suites/Kernel/Baseport/hotplug/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/iommu/README.md
+++ b/Runner/suites/Kernel/Baseport/iommu/README.md
@@ -39,5 +39,4 @@ Test result will be saved in `IOMMU.res` as:
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-(C) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause(C) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/Baseport/iommu/run.sh
+++ b/Runner/suites/Kernel/Baseport/iommu/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/irq/run.sh
+++ b/Runner/suites/Kernel/Baseport/irq/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/kaslr/run.sh
+++ b/Runner/suites/Kernel/Baseport/kaslr/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/pinctrl/run.sh
+++ b/Runner/suites/Kernel/Baseport/pinctrl/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/qcom_crypto/README_qcom_crypto.md
+++ b/Runner/suites/Kernel/Baseport/qcom_crypto/README_qcom_crypto.md
@@ -1,6 +1,5 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 # Qualcomm Crypto (qcom_crypto) Functionality Test Script
 # Overview
 

--- a/Runner/suites/Kernel/Baseport/qcom_crypto/run.sh
+++ b/Runner/suites/Kernel/Baseport/qcom_crypto/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/qcom_hwrng/README_qcom_hwrng.md
+++ b/Runner/suites/Kernel/Baseport/qcom_hwrng/README_qcom_hwrng.md
@@ -1,6 +1,5 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 # Qualcomm Hardware Random Number Generator (QRNG) Script
 # Overview
 

--- a/Runner/suites/Kernel/Baseport/qcom_hwrng/run.sh
+++ b/Runner/suites/Kernel/Baseport/qcom_hwrng/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/qcrypto/run.sh
+++ b/Runner/suites/Kernel/Baseport/qcrypto/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/remoteproc/run.sh
+++ b/Runner/suites/Kernel/Baseport/remoteproc/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/rngtest/run.sh
+++ b/Runner/suites/Kernel/Baseport/rngtest/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/shmbridge/README.md
+++ b/Runner/suites/Kernel/Baseport/shmbridge/README.md
@@ -1,6 +1,5 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 # shmbridge Validation test
 
 ## Overview

--- a/Runner/suites/Kernel/Baseport/shmbridge/run.sh
+++ b/Runner/suites/Kernel/Baseport/shmbridge/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
  
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
- 
+# SPDX-License-Identifier: BSD-3-Clause 
 # Locate and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/smmu/run.sh
+++ b/Runner/suites/Kernel/Baseport/smmu/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/stm_cpu/README.md
+++ b/Runner/suites/Kernel/Baseport/stm_cpu/README.md
@@ -1,7 +1,6 @@
 # STM CPU Trace  Validation test
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 ## Overview
 This test case validates the System Trace Macrocell (STM) functionality on the target device by configuring the STM source, enabling tracing, and capturing trace data. It ensures that the STM infrastructure is correctly initialized and capable of generating trace output.
 

--- a/Runner/suites/Kernel/Baseport/stm_cpu/run.sh
+++ b/Runner/suites/Kernel/Baseport/stm_cpu/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
  
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
- 
+# SPDX-License-Identifier: BSD-3-Clause 
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/usb_hid/README.md
+++ b/Runner/suites/Kernel/Baseport/usb_hid/README.md
@@ -1,6 +1,5 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 # USB HID Validation
 
 ## Overview

--- a/Runner/suites/Kernel/Baseport/usb_hid/run.sh
+++ b/Runner/suites/Kernel/Baseport/usb_hid/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Validate USB HID device detection
 # Requires at least one USB HID peripheral (keyboard/mouse, etc.) connected to a USB Host port.
 

--- a/Runner/suites/Kernel/Baseport/watchdog/run.sh
+++ b/Runner/suites/Kernel/Baseport/watchdog/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Baseport/wpss_remoteproc/run.sh
+++ b/Runner/suites/Kernel/Baseport/wpss_remoteproc/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/DCVS/Freq_Scaling/README.md
+++ b/Runner/suites/Kernel/DCVS/Freq_Scaling/README.md
@@ -33,5 +33,4 @@ Test result will be saved in `Freq_Scaling.res` as:
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-(C) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause(C) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/DCVS/Freq_Scaling/run.sh
+++ b/Runner/suites/Kernel/DCVS/Freq_Scaling/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Scheduler/CPU_affinity/README.md
+++ b/Runner/suites/Kernel/Scheduler/CPU_affinity/README.md
@@ -33,5 +33,4 @@ Test result will be saved in `CPU_affinity.res` as:
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-(C) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause(C) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/Scheduler/CPU_affinity/run.sh
+++ b/Runner/suites/Kernel/Scheduler/CPU_affinity/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Kernel/Stress/Stress-ng/README.md
+++ b/Runner/suites/Kernel/Stress/Stress-ng/README.md
@@ -287,7 +287,7 @@ Still, run on development hardware or staging boards when possible.
 
 License
 
-The test runner: BSD-3-Clause-Clear (Qualcomm Technologies, Inc. and/or its subsidiaries).
+The test runner: BSD-3-Clause (Qualcomm Technologies, Inc. and/or its subsidiaries).
 
 stress-ng is licensed upstream by its author; see its repository for details.
 

--- a/Runner/suites/Kernel/Stress/Stress-ng/run.sh
+++ b/Runner/suites/Kernel/Stress/Stress-ng/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # stress-ng validation runner:
 # - Default: auto-sized CPU + VM/HDD sets with strict FAIL criteria
 # - Custom: pass any stress-ng CLI via --stressng-args "…" or after "--"

--- a/Runner/suites/Kernel/Stress/Stressapptest/README.md
+++ b/Runner/suites/Kernel/Stress/Stressapptest/README.md
@@ -223,5 +223,5 @@ Auto network starts a local listen thread and chooses a primary IP (falling back
 
 License
 
-The test runner: BSD-3-Clause-Clear (Qualcomm Technologies, Inc. and/or its subsidiaries).
+The test runner: BSD-3-Clause (Qualcomm Technologies, Inc. and/or its subsidiaries).
 stressapptest is licensed by its upstream author; see its repository for details.

--- a/Runner/suites/Kernel/Stress/Stressapptest/run.sh
+++ b/Runner/suites/Kernel/Stress/Stressapptest/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # stressapptest/run.sh
 # Safe wrapper around stressapptest for embedded/CI use.
 # Memory-safety features: --mem-pct, --mem-cap-mb, --mem-headroom-mb,

--- a/Runner/suites/Multimedia/Audio/AudioPlayback/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/Read_me.md
@@ -383,5 +383,4 @@ Results:
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-(C) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause(C) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Multimedia/Audio/AudioPlayback/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioPlayback/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # ---- Source init_env & tools ----

--- a/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
@@ -360,5 +360,4 @@ Results:
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-(C) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause(C) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # ---- Source init_env & tools ----

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test_README.md
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test_README.md
@@ -155,5 +155,4 @@ FASTRPC_DOMAIN=2 FASTRPC_USER_PD=1 ./run.sh
 
 ## License
 
-SPDX-License-Identifier: BSD-3-Clause-Clear  
-Copyright (c) Qualcomm Technologies, Inc.
+SPDX-License-Identifier: BSD-3-ClauseCopyright (c) Qualcomm Technologies, Inc.

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # --------- Robustly source init_env and functestlib.sh ----------
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Multimedia/Camera/Camera_NHX/run.sh
+++ b/Runner/suites/Multimedia/Camera/Camera_NHX/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Camera NHX validation
 
 TESTNAME="Camera_NHX"

--- a/Runner/suites/Multimedia/Camera/Camera_RDI_FrameCapture/run.sh
+++ b/Runner/suites/Multimedia/Camera/Camera_RDI_FrameCapture/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# --- Robustly find and source init_env ---------------------------
+# SPDX-License-Identifier: BSD-3-Clause# --- Robustly find and source init_env ---------------------------
 # ---------- Repo env + helpers ----------
 SCRIPT_DIR="$(
   cd "$(dirname "$0")" || exit 1

--- a/Runner/suites/Multimedia/Camera/Libcamera_cam/run.sh
+++ b/Runner/suites/Multimedia/Camera/Libcamera_cam/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# libcamera 'cam' runner with strong post-capture validation (CLI-config only)
+# SPDX-License-Identifier: BSD-3-Clause# libcamera 'cam' runner with strong post-capture validation (CLI-config only)
 # ---------- Repo env + helpers (single-pass) ----------
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 SEARCH="$SCRIPT_DIR"

--- a/Runner/suites/Multimedia/DSP_AudioPD/run.sh
+++ b/Runner/suites/Multimedia/DSP_AudioPD/run.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Robustly find and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""

--- a/Runner/suites/Multimedia/Display/igt-gpu-tools/core_auth/Display_IGT_Core_Auth_TestValidation_Readme.md
+++ b/Runner/suites/Multimedia/Display/igt-gpu-tools/core_auth/Display_IGT_Core_Auth_TestValidation_Readme.md
@@ -1,7 +1,6 @@
 # License
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
-
+SPDX-License-Identifier: BSD-3-Clause
 # IGT Core Auth Test Script
 
 ## Overview

--- a/Runner/suites/Multimedia/Display/igt-gpu-tools/core_auth/run.sh
+++ b/Runner/suites/Multimedia/Display/igt-gpu-tools/core_auth/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # ---- Source init_env & tools ----

--- a/Runner/suites/Multimedia/Display/weston-clickdot/run.sh
+++ b/Runner/suites/Multimedia/Display/weston-clickdot/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Validate weston-clickdot runs under a working Wayland session.
 # - Wayland env resolution (adopts socket & fixes XDG_RUNTIME_DIR perms)
 # - CI-friendly logs and PASS/FAIL/SKIP semantics (LAVA-friendly: exits 0)

--- a/Runner/suites/Multimedia/Display/weston-cliptest/run.sh
+++ b/Runner/suites/Multimedia/Display/weston-cliptest/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Validate weston-cliptest runs under a working Wayland session.
 # - Wayland env resolution (adopts socket & fixes XDG_RUNTIME_DIR perms)
 # - CI-friendly logs and PASS/FAIL/SKIP semantics (LAVA-friendly: exits 0)

--- a/Runner/suites/Multimedia/Display/weston-editor/run.sh
+++ b/Runner/suites/Multimedia/Display/weston-editor/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Validate weston-editor runs under a working Wayland session.
 # - Uses lib_display.sh to adopt Wayland env (socket + XDG_RUNTIME_DIR)
 # - CI-friendly logs and PASS/FAIL/SKIP semantics (LAVA-friendly: exits 0)

--- a/Runner/suites/Multimedia/Display/weston-flower/run.sh
+++ b/Runner/suites/Multimedia/Display/weston-flower/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Validate weston-flower runs under a working Wayland session.
 # - Wayland env resolution (adopts socket & fixes XDG_RUNTIME_DIR perms)
 # - Optional Wayland protocol validation via WAYLAND_DEBUG capture

--- a/Runner/suites/Multimedia/Display/weston-resizor/run.sh
+++ b/Runner/suites/Multimedia/Display/weston-resizor/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Validate weston-resizor runs under a working Wayland session.
 # - Wayland env resolution (adopts socket & fixes XDG_RUNTIME_DIR perms)
 # - CI-friendly logs and PASS/FAIL/SKIP semantics (LAVA-friendly: exits 0)

--- a/Runner/suites/Multimedia/Display/weston-scaler/run.sh
+++ b/Runner/suites/Multimedia/Display/weston-scaler/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Validate weston-scaler runs under a working Wayland session.
 # - Uses lib_display.sh to adopt Wayland env (socket + XDG_RUNTIME_DIR)
 # - CI-friendly logs and PASS/FAIL/SKIP semantics (LAVA-friendly: exits 0)

--- a/Runner/suites/Multimedia/Display/weston-smoke/run.sh
+++ b/Runner/suites/Multimedia/Display/weston-smoke/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Validate weston-smoke runs under a working Wayland session.
 # - Wayland env resolution (adopts socket & fixes XDG_RUNTIME_DIR perms)
 # - Optional Wayland protocol validation via WAYLAND_DEBUG capture

--- a/Runner/suites/Multimedia/GSTreamer/Audio/Audio_Playback/run.sh
+++ b/Runner/suites/Multimedia/GSTreamer/Audio/Audio_Playback/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Audio Playback validation using GStreamer (auto backend: PipeWire/Pulse/ALSA)
+# SPDX-License-Identifier: BSD-3-Clause# Audio Playback validation using GStreamer (auto backend: PipeWire/Pulse/ALSA)
 # Logs everything to console and also to local log files.
 # PASS/FAIL/SKIP is emitted to .res. Always exits 0 (LAVA-friendly).
 

--- a/Runner/suites/Multimedia/Graphics/KMSCube/README_KMSCube.md
+++ b/Runner/suites/Multimedia/Graphics/KMSCube/README_KMSCube.md
@@ -1,7 +1,6 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
-SPDX-License-Identifier: BSD-3-Clause-Clear
-# KMSCube GraphicsTest Scripts for Qualcomm Linux based platform (Yocto)
+SPDX-License-Identifier: BSD-3-Clause# KMSCube GraphicsTest Scripts for Qualcomm Linux based platform (Yocto)
 # Overview
 
 Graphics scripts automates the validation of Graphics OpenGL ES 2.0 capabilities on the Qualcomm RB3 Gen2 platform running a Yocto-based Linux system. It utilizes kmscube test app which is publicly available at https://gitlab.freedesktop.org/mesa/kmscube

--- a/Runner/suites/Multimedia/Graphics/KMSCube/run.sh
+++ b/Runner/suites/Multimedia/Graphics/KMSCube/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # KMSCube Validator Script (Yocto-Compatible, POSIX sh)
 
 # --- Robustly find and source init_env ---------------------------------------

--- a/Runner/suites/Multimedia/Graphics/weston-simple-egl/README_weston-simple-egl.md
+++ b/Runner/suites/Multimedia/Graphics/weston-simple-egl/README_weston-simple-egl.md
@@ -1,7 +1,6 @@
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
-SPDX-License-Identifier: BSD-3-Clause-Clear
-# weston-simple-egl GraphicsTest Scripts for Qualcomm Linux based platform (Yocto)
+SPDX-License-Identifier: BSD-3-Clause# weston-simple-egl GraphicsTest Scripts for Qualcomm Linux based platform (Yocto)
 # Overview
 
 Graphics scripts automates the validation of Graphics OpenGL ES 2.0 capabilities on the Qualcomm RB3 Gen2 platform running a Yocto-based Linux system. It utilizes Weston-Simple-EGL test app which is publicly available at https://github.com/krh/weston

--- a/Runner/suites/Multimedia/Graphics/weston-simple-egl/run.sh
+++ b/Runner/suites/Multimedia/Graphics/weston-simple-egl/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Validate weston-simple-egl runs under a working Wayland session.
 # - Wayland env resolution (adopts socket & fixes XDG_RUNTIME_DIR perms)
 # - CI-friendly logs and PASS/FAIL/SKIP semantics

--- a/Runner/suites/Multimedia/OpenCV/opencv_suite_README.md
+++ b/Runner/suites/Multimedia/OpenCV/opencv_suite_README.md
@@ -332,5 +332,5 @@ Run one binary with extra args:
 
 ## License
 
-BSD-3-Clause-Clear (same as the script).
+BSD-3-Clause (same as the script).
 

--- a/Runner/suites/Multimedia/OpenCV/run.sh
+++ b/Runner/suites/Multimedia/OpenCV/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # OpenCV test/perf suite runner (auto-discovery; per-binary skip; summary; proper exit codes)
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # ----- locate and source init_env -----
 SCRIPT_DIR="$(
   cd "$(dirname "$0")" || exit 1

--- a/Runner/suites/Multimedia/Video/Video_V4L2_Runner/README_Video.md
+++ b/Runner/suites/Multimedia/Video/Video_V4L2_Runner/README_Video.md
@@ -1,7 +1,7 @@
 # Iris V4L2 Video Test Scripts for Qualcomm Linux (Yocto)
 
 **Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.**  
-**SPDX-License-Identifier: BSD-3-Clause-Clear**
+**SPDX-License-Identifier: BSD-3-Clause**
 
 ---
 

--- a/Runner/suites/Multimedia/Video/Video_V4L2_Runner/run.sh
+++ b/Runner/suites/Multimedia/Video/Video_V4L2_Runner/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# IRIS Video V4L2 runner with stack selection via utils/lib_video.sh
+# SPDX-License-Identifier: BSD-3-Clause# IRIS Video V4L2 runner with stack selection via utils/lib_video.sh
 
 # ---------- Repo env + helpers ----------
 SCRIPT_DIR="$(

--- a/Runner/suites/Performance/Boot_Systemd_KPI_Loop/run.sh
+++ b/Runner/suites/Performance/Boot_Systemd_KPI_Loop/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Boot KPI multi-boot aggregator / auto-reboot wrapper around Boot_Systemd_Validate.
+# SPDX-License-Identifier: BSD-3-Clause# Boot KPI multi-boot aggregator / auto-reboot wrapper around Boot_Systemd_Validate.
 
 SCRIPT_DIR="$(
   cd "$(dirname "$0")" || exit 1

--- a/Runner/suites/Performance/Boot_Systemd_Validate/run.sh
+++ b/Runner/suites/Performance/Boot_Systemd_Validate/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Systemd boot KPI + validation (single run).
+# SPDX-License-Identifier: BSD-3-Clause# Systemd boot KPI + validation (single run).
 
 SCRIPT_DIR="$(
   cd "$(dirname "$0")" || exit 1

--- a/Runner/suites/Performance/Geekbench/run.sh
+++ b/Runner/suites/Performance/Geekbench/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Geekbench runner with live console progress + CSV dump (summary + workloads)
+# SPDX-License-Identifier: BSD-3-Clause# Geekbench runner with live console progress + CSV dump (summary + workloads)
 # POSIX + LAVA-friendly, always exits 0, writes PASS/FAIL/SKIP to .res
 
 TESTNAME="Geekbench"

--- a/Runner/suites/Performance/Sysbench_Performance/README_sysbench.md
+++ b/Runner/suites/Performance/Sysbench_Performance/README_sysbench.md
@@ -224,4 +224,4 @@ Keep `CSV_FILE` empty by default (to avoid extra artifacts) and enable only when
 ## License
 
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.  
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause

--- a/Runner/suites/Performance/Sysbench_Performance/run.sh
+++ b/Runner/suites/Performance/Sysbench_Performance/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 SCRIPT_DIR="$(
   cd "$(dirname "$0")" || exit 1
   pwd

--- a/Runner/suites/Performance/Tiotest/run.sh
+++ b/Runner/suites/Performance/Tiotest/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 SCRIPT_DIR="$(
   cd "$(dirname "$0")" || exit 1
   pwd

--- a/Runner/suites/Performance/resource-tuner/README.md
+++ b/Runner/suites/Performance/resource-tuner/README.md
@@ -161,5 +161,5 @@ The script writes the overall result to `resource-tuner.res`. The **process exit
 - **Very long runs** → a `run_with_timeout` helper (if available in your repo toolchain) will be used automatically.
 
 ## License
-- SPDX-License-Identifier: BSD-3-Clause-Clear
+- SPDX-License-Identifier: BSD-3-Clause
 - (C) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Performance/resource-tuner/run.sh
+++ b/Runner/suites/Performance/resource-tuner/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# resource-tuner test runner (pinned whitelist)
+# SPDX-License-Identifier: BSD-3-Clause# resource-tuner test runner (pinned whitelist)
 
 # ---------- Repo env + helpers ----------
 SCRIPT_DIR="$(

--- a/Runner/utils/audio_common.sh
+++ b/Runner/utils/audio_common.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Common audio helpers for PipeWire / PulseAudio runners.
+# SPDX-License-Identifier: BSD-3-Clause# Common audio helpers for PipeWire / PulseAudio runners.
 # Requires: functestlib.sh (log_* helpers, extract_tar_from_url, scan_dmesg_errors)
 
 # ---------- Backend detection & daemon checks ----------

--- a/Runner/utils/basics.sh
+++ b/Runner/utils/basics.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Import test suite definitions
 . "${PWD}"/init_env
 

--- a/Runner/utils/camera/lib_camera.sh
+++ b/Runner/utils/camera/lib_camera.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Shared libcamera helpers
+# SPDX-License-Identifier: BSD-3-Clause# Shared libcamera helpers
 # ---------- Sensor & index helpers ----------
 
 # Return the number of sensors visible in `cam -l`

--- a/Runner/utils/camera/parse_media_topology.py
+++ b/Runner/utils/camera/parse_media_topology.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 import sys
 import re
 import subprocess

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # --- Logging helpers ---
 log() {
     level=$1

--- a/Runner/utils/lib_bluetooth.sh
+++ b/Runner/utils/lib_bluetooth.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 # lib_bluetooth.sh - Bluetooth-specific helpers split out from functestlib.sh
 # Copyright (c) Qualcomm Technologies, Inc.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # This file is meant to be sourced *after* init_env and functestlib.sh:
 # . "$TOOLS/functestlib.sh"
 # . "$TOOLS/lib_bluetooth.sh"

--- a/Runner/utils/lib_display.sh
+++ b/Runner/utils/lib_display.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-###############################################################################
+# SPDX-License-Identifier: BSD-3-Clause###############################################################################
 # DRM display + Weston + Wayland helpers
 # (assumes log_info/log_warn/log_error and run_with_timeout from functestlib.sh)
 ###############################################################################

--- a/Runner/utils/lib_gstreamer.sh
+++ b/Runner/utils/lib_gstreamer.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-#
+# SPDX-License-Identifier: BSD-3-Clause#
 # Runner/utils/lib_gstreamer.sh
 #
 # GStreamer helpers.

--- a/Runner/utils/lib_performance.sh
+++ b/Runner/utils/lib_performance.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Common performance-related helpers for KPI-style tests.
+# SPDX-License-Identifier: BSD-3-Clause# Common performance-related helpers for KPI-style tests.
 
 # ---------------------------------------------------------------------------
 # Logging fallback (avoid repeated command -v checks)

--- a/Runner/utils/lib_video.sh
+++ b/Runner/utils/lib_video.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-# Common, POSIX-compliant helpers for Qualcomm video stack selection and V4L2 testing.
+# SPDX-License-Identifier: BSD-3-Clause# Common, POSIX-compliant helpers for Qualcomm video stack selection and V4L2 testing.
 # Requires functestlib.sh: log_info/log_warn/log_pass/log_fail/log_skip,
 # check_dependencies, extract_tar_from_url, (optional) run_with_timeout, ensure_network_online.
 

--- a/Runner/utils/platform.sh
+++ b/Runner/utils/platform.sh
@@ -2,8 +2,7 @@
 # Intentionally not defining shell.
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
+# SPDX-License-Identifier: BSD-3-Clause
 # Detect Android userland
 ANDROID_PATH=/system/build.prop
 if [ -f $ANDROID_PATH ]; then

--- a/Runner/utils/result_parse.sh
+++ b/Runner/utils/result_parse.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-echo "Current working directory is $PWD"
+# SPDX-License-Identifier: BSD-3-Clauseecho "Current working directory is $PWD"
 
 find . -type f -name "*.res" 2>/dev/null | while IFS= read res_file; do
     echo "$res_file"

--- a/Runner/utils/send-to-lava.sh
+++ b/Runner/utils/send-to-lava.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 #Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-#SPDX-License-Identifier: BSD-3-Clause-Clear
-
+#SPDX-License-Identifier: BSD-3-Clause
 RESULT_FILE="$1"
 SIGNAL_FILE="/tmp/lava_signals_$$.log"
 


### PR DESCRIPTION
- Summary
    - Updated repository SPDX license identifiers from BSD-3-Clause-Clear to BSD-3-Clause per legal request.
- Details
    - Replaced SPDX-License-Identifier: BSD-3-Clause-Clear with SPDX-License-Identifier: BSD-3-Clause across applicable files.
    - Updated any remaining documentation references to match the new SPDX identifier (where present).
- Why
    - Align repository licensing headers with legal guidance.
- Notes
    - No functional/runtime changes, header-only modification.