### PR TITLE
Removing Invalid secret, SEMGREP_APP_TOKEN is not defined in the reference of workflow

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -21,5 +21,3 @@ jobs:
       enable-copyright-license-check: true
       enable-commit-email-check: true
       enable-commit-msg-check: false
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
This secret is not used by the current Semgrep/preflight workflow and has been removed to avoid misconfiguration.