### PR TITLE
CI: Switch workflow trigger from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,6 +1,6 @@
 name: Qualcomm Preflight Checks
 on:
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
   push:
     branches: [ "main" ]


### PR DESCRIPTION
### What changed
This PR updates the GitHub Actions workflow to use the `pull_request` event instead of `pull_request_target`.

### Why
- Ensures checks run against the actual PR code rather than the base branch
- Avoids skipped or misleading CI results
- Aligns with expected PR validation behavior

### Impact
- No functional code changes
- CI now accurately reflects PR modifications