### PR TITLE
audio: increase PipeWire restart timeout to 30s

### DIFF
--- a/Runner/utils/audio_common.sh
+++ b/Runner/utils/audio_common.sh
@@ -316,7 +316,7 @@ setup_overlay_audio_environment() {
     
     # Restart PipeWire
     log_info "Restarting pipewire service..."
-    if ! audio_exec_with_timeout 15s systemctl restart pipewire 2>/dev/null; then
+    if ! audio_exec_with_timeout 30s systemctl restart pipewire 2>/dev/null; then
         log_fail "Failed to restart pipewire service"
         return 1
     fi


### PR DESCRIPTION
This PR increases the timeout used when restarting PipeWire via systemctl from 15s to 30s:
- Updates: audio_exec_with_timeout 15s systemctl restart pipewire -> audio_exec_with_timeout 30s systemctl restart pipewire
- Motivation:
- Some targets take longer to stop/start PipeWire, causing the restart command to time out even though PipeWire would recover successfully.