### PR TITLE
ci: align test inventory Pages workflow with Node 24 transition

### DIFF
--- a/.github/workflows/test-inventory-pages.yml
+++ b/.github/workflows/test-inventory-pages.yml
@@ -17,6 +17,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: "pages"
   cancel-in-progress: true
@@ -27,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
This PR updates the test inventory GitHub Pages workflow to reduce the
current GitHub Actions runtime deprecation warnings.
 
Why:
- the workflow is publishing correctly, but Actions shows warnings for
  Node.js 20-based actions
- GitHub has announced the transition to Node.js 24 on hosted runners
- we should proactively align the workflow with that transition
 
What changed:
- updated actions/checkout from v4 to v6
- enabled FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 at workflow level