### PR TITLE
shellcheck: clean up quoting and sourcing warnings in basics.sh

### DIFF
--- a/Runner/utils/basics.sh
+++ b/Runner/utils/basics.sh
@@ -1,15 +1,17 @@
 #!/bin/sh
-
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 # Import test suite definitions
-. "${PWD}"/init_env
+# shellcheck disable=SC1091
+. "${PWD}/init_env"
 
 #import platform
-. "${TOOLS}"/platform.sh
+# shellcheck disable=SC1091
+. "${TOOLS}/platform.sh"
 
 #import test functions library
-. "${TOOLS}"/functestlib.sh
+# shellcheck disable=SC1091
+. "${TOOLS}/functestlib.sh"
 
 # CPU_FAST CPU_SLOW FTRACE_START_MARKER are used by the ftrace libraries
 
@@ -30,59 +32,57 @@ IMPLEMENTER=0x41
 #A7
 default_little_cpulist
 HMPSLOWCPUS=$__RET
-littlecore=$(echo "${HMPSLOWCPUS}"|busybox awk '{print $1}')
-CONFIG_TARGET_LITTLE_CPUPART=$( cpupart $littlecore )
-PART_SLOW=`echo $CONFIG_TARGET_LITTLE_CPUPART`
+littlecore=$(echo "${HMPSLOWCPUS}" | busybox awk '{print $1}')
+CONFIG_TARGET_LITTLE_CPUPART=$(cpupart "$littlecore")
+PART_SLOW=$CONFIG_TARGET_LITTLE_CPUPART
 #A15
 default_big_cpulist
 HMPFASTCPUS=$__RET
-bigcore=$(echo "${HMPFASTCPUS}"|busybox awk '{print $1}')
-CONFIG_TARGET_BIG_CPUPART=$( cpupart $bigcore )
-PART_FAST=`echo $CONFIG_TARGET_BIG_CPUPART`
+bigcore=$(echo "${HMPFASTCPUS}" | busybox awk '{print $1}')
+CONFIG_TARGET_BIG_CPUPART=$(cpupart "$bigcore")
+PART_FAST=$CONFIG_TARGET_BIG_CPUPART
 commaslow=
 commafast=
 for cpu in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 21 22 23 24 25 26 ; do
-    $TASKSET -part $cpu,$IMPLEMENTER,$PART_SLOW >/dev/null
-    if [ $? = 0 ] ; then
+    if "$TASKSET" -part "$cpu,$IMPLEMENTER,$PART_SLOW" >/dev/null; then
         CPU_SLOW=$CPU_SLOW$commaslow$cpu
         commaslow=,
     fi
-    $TASKSET -part $cpu,$IMPLEMENTER,$PART_FAST >/dev/null
-    if [ $? = 0 ] ; then
+    if "$TASKSET" -part "$cpu,$IMPLEMENTER,$PART_FAST" >/dev/null; then
         CPU_FAST=$CPU_FAST$commafast$cpu
         commafast=,
     fi
 done
 echo "Fast CPU $CPU_FAST Slow CPU $CPU_SLOW"
 
-if [  ! -e /proc/sys/kernel/sched_upmigrate ]  ||  [ ! -e /proc/sys/kernel/sched_downmigrate  ]; then 
+if [ ! -e /proc/sys/kernel/sched_upmigrate ] || [ ! -e /proc/sys/kernel/sched_downmigrate ]; then
     echo "up-upmigrate and down-downmigrate values not exported. Precondition failure"
     #non-zero exit signals test runner to declare this test as a failure
     exit 1
 fi
 
-UP_THRESHOLD_1024=$(cat '/proc/sys/kernel/sched_upmigrate' | cut -f 1)
-DOWN_THRESHOLD_1024=$(cat '/proc/sys/kernel/sched_downmigrate' | cut -f 1)
-UP_THRESHOLD=$((UP_THRESHOLD_1024*100/1024))
-DOWN_THRESHOLD=$((DOWN_THRESHOLD_1024*100/1024))
-UNDER_DOWN_THRESHOLD=$((DOWN_THRESHOLD_1024*50/1024))
+UP_THRESHOLD_1024=$(cut -f 1 /proc/sys/kernel/sched_upmigrate)
+DOWN_THRESHOLD_1024=$(cut -f 1 /proc/sys/kernel/sched_downmigrate)
+UP_THRESHOLD=$((UP_THRESHOLD_1024 * 100 / 1024))
+DOWN_THRESHOLD=$((DOWN_THRESHOLD_1024 * 100 / 1024))
+UNDER_DOWN_THRESHOLD=$((DOWN_THRESHOLD_1024 * 50 / 1024))
 export UNDER_DOWN_THRESHOLD
-LITTLE_THRESHOLD=$((DOWN_THRESHOLD*70/100))
+LITTLE_THRESHOLD=$((DOWN_THRESHOLD * 70 / 100))
 export LITTLE_THRESHOLD
-NOCHANGE_THRESHOLD=$((\($DOWN_THRESHOLD_1024+$UP_THRESHOLD_1024\)*100/1024/2))
-BIG_THRESHOLD=$((UP_THRESHOLD*130/100))
+NOCHANGE_THRESHOLD=$(((DOWN_THRESHOLD_1024 + UP_THRESHOLD_1024) * 100 / 1024 / 2))
+BIG_THRESHOLD=$((UP_THRESHOLD * 130 / 100))
 export BIG_THRESHOLD
 THRESHOLD_TOLERANCE=15
 # separate down threshold as test load is +/- 10% accurate at best
 NODOWN_THRESHOLD=$NOCHANGE_THRESHOLD
-if [ "$NODOWN_THRESHOLD" -lt "$(($DOWN_THRESHOLD+$THRESHOLD_TOLERANCE))" ] ; then
-  NODOWN_THRESHOLD=$(($DOWN_THRESHOLD+$THRESHOLD_TOLERANCE))
+if [ "$NODOWN_THRESHOLD" -lt "$((DOWN_THRESHOLD + THRESHOLD_TOLERANCE))" ] ; then
+  NODOWN_THRESHOLD=$((DOWN_THRESHOLD + THRESHOLD_TOLERANCE))
   echo "Setting NODOWN_THRESHOLD to $NODOWN_THRESHOLD"
 fi
 # separate up threshold as test load is +/- 10% accurate at best
 NOUP_THRESHOLD=$NOCHANGE_THRESHOLD
-if [ "$NOUP_THRESHOLD" -gt "$(($UP_THRESHOLD-$THRESHOLD_TOLERANCE))" ] ; then
-  NOUP_THRESHOLD=$(($UP_THRESHOLD-$THRESHOLD_TOLERANCE))
+if [ "$NOUP_THRESHOLD" -gt "$((UP_THRESHOLD - THRESHOLD_TOLERANCE))" ] ; then
+  NOUP_THRESHOLD=$((UP_THRESHOLD - THRESHOLD_TOLERANCE))
   echo "Setting NOUP_THRESHOLD to $NOUP_THRESHOLD"
 fi
 CUTOFF_PRIORITY_GT=-5
@@ -95,39 +95,39 @@ HOG_PID=
 
 copy_trace_events()
 {
-    if [ -f $FTRACE_EVENTS/header_page ] ; then
+    if [ -f "$FTRACE_EVENTS/header_page" ] ; then
         echo "Trace events already copied"
         TRACE_EVENTS_PATH=$FTRACE_EVENTS
         return
     fi
 
     echo "Copying trace events..."
-    odir=`pwd`
+    odir=$(pwd)
     cd /sys/kernel/debug/tracing/events || exit 1
-    mkdir $FTRACE_EVENTS
+    mkdir "$FTRACE_EVENTS"
     for i in * ; do
-        if [ -f $i ] ; then
-            cat $i > $FTRACE_EVENTS/$i
+        if [ -f "$i" ] ; then
+            cat "$i" > "$FTRACE_EVENTS/$i"
         else
-            old=`pwd`
-            cd $i || exit 1
-            mkdir $FTRACE_EVENTS/$i/
+            old=$(pwd)
+            cd "$i" || exit 1
+            mkdir "$FTRACE_EVENTS/$i/"
             for j in * ; do
-                if [ -f $j/format ] ; then
-                    mkdir $FTRACE_EVENTS/$i/$j
-                    cat $j/format > $FTRACE_EVENTS/$i/$j/format
+                if [ -f "$j/format" ] ; then
+                    mkdir "$FTRACE_EVENTS/$i/$j"
+                    cat "$j/format" > "$FTRACE_EVENTS/$i/$j/format"
                 fi
             done
-            cd $old || exit 1
+            cd "$old" || exit 1
         fi
     done
-    cd $odir || exit 1
+    cd "$odir" || exit 1
     TRACE_EVENTS_PATH=$FTRACE_EVENTS
 }
 
 get_uptime()
 {
-    _temp="`cat /proc/uptime`"
+    _temp=$(cat /proc/uptime)
 # RESULT is the second integer of /proc/uptime
     for _temp1 in $_temp ; do
         RESULT=$_temp1
@@ -149,34 +149,34 @@ hog_cpu_slow()
 unhog_cpu()
 {
     for i in $HOG_PID ; do
-        kill -10 $i
-        wait $i
+        kill -10 "$i"
+        wait "$i"
     done
     HOG_PID=
 }
 
 taskset_cpuslow()
 {
-    $TASKSET -pc $CPU_SLOW $1
+    "$TASKSET" -pc "$CPU_SLOW" "$1"
 }
 
 taskset_cpufast()
 {
-    $TASKSET -pc $CPU_FAST $1
+    "$TASKSET" -pc "$CPU_FAST" "$1"
 }
 
 taskset_cpuany()
 {
-    $TASKSET -pc $CPU_FAST,$CPU_SLOW $1
+    "$TASKSET" -pc "$CPU_FAST,$CPU_SLOW" "$1"
 }
 
 CALIBRATION=${CALIBRATION:-$BASEDIR/calib.txt}
 calibrate_tasklib()
 {
     # share between test suites if possible
-    if [ ! -f $CALIBRATION ] ; then
-        $LOAD_GENERATOR --calibrate
-        mv calib.txt $CALIBRATION
+    if [ ! -f "$CALIBRATION" ] ; then
+        "$LOAD_GENERATOR" --calibrate
+        mv calib.txt "$CALIBRATION"
     fi
 }
 
@@ -188,27 +188,27 @@ calibrate_tasklib
 taskset_sleep()
 {
     sleep 1
-    taskset_cpuany $RESULT
+    taskset_cpuany "$RESULT"
 }
 
 load_generator()
 {
     echo "Using tasklibrary calibdation file: $CALIBRATION"
-    $LOAD_GENERATOR --calibfile=$CALIBRATION --loadseq=$1 &
+    "$LOAD_GENERATOR" --calibfile="$CALIBRATION" --loadseq="$1" &
     RESULT=$!
     if [ "$2" = "START_SLOW" ] ; then
-        taskset_cpuslow $RESULT
-		taskset_sleep &
+        taskset_cpuslow "$RESULT"
+        taskset_sleep &
     fi
     if [ "$2" = "START_FAST" ] ; then
-        taskset_cpufast $RESULT
-		taskset_sleep &
+        taskset_cpufast "$RESULT"
+        taskset_sleep &
     fi
     if [ "$2" = "STARTSTOP_SLOW" ] ; then
-        taskset_cpuslow $RESULT
+        taskset_cpuslow "$RESULT"
     fi
     if [ "$2" = "STARTSTOP_FAST" ] ; then
-        taskset_cpufast $RESULT
+        taskset_cpufast "$RESULT"
     fi
     echo "#load_generator PID=$RESULT COMMAND=$1"
 }
@@ -217,34 +217,34 @@ ftrace_start()
 {
     BOOST_GOVERNOR=${1:-1}
 
-    if [ $ANDROID -eq 1 ]; then
+    if [ "$ANDROID" -eq 1 ]; then
         echo "Stop all android services"
         stop
     fi
 
-    if [ $BOOST_GOVERNOR -eq 1 ]; then
+    if [ "$BOOST_GOVERNOR" -eq 1 ]; then
         echo "Save current CPUFreq governors configuration"
         i=0
-        FTRACE_OLD_GOV=""
-        while [ $i != 9999 ] ; do
-            temp="` cat /sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor 2>/dev/null`"
+        FTRACE_OLD_GOV=
+        while [ "$i" != 9999 ] ; do
+            temp=$(cat "/sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor" 2>/dev/null)
             if [ "$temp" = "" ] ; then
                 i=9999
             else
-				i=$(($i+1))
+                i=$((i + 1))
                 FTRACE_OLD_GOV="$FTRACE_OLD_GOV $temp"
             fi
         done
 
         echo "Set CPUFreq governor to [performance]"
         i=0
-        while [ $i != 9999 ] ; do
-            temp="` cat /sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor 2>/dev/null`"
+        while [ "$i" != 9999 ] ; do
+            temp=$(cat "/sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor" 2>/dev/null)
             if [ "$temp" = "" ] ; then
                 i=9999
             else
-                echo performance > /sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor
-				i=$(($i+1))
+                echo performance > "/sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor"
+                i=$((i + 1))
             fi
         done
     fi
@@ -254,9 +254,10 @@ ftrace_start()
     FTRACE_START_MARKER=$RESULT
 
     echo "Start FTrace..."
-    $TRACE_CMD_EXE reset
-    $TRACE_CMD_EXE start -b $CONFIG_FTRACE_BUFFER_SIZE $CONFIG_FTRACE_EVENTS
-    echo $FTRACE_START_MARKER > /sys/kernel/debug/tracing/trace_marker
+    "$TRACE_CMD_EXE" reset
+    # shellcheck disable=SC2086
+    "$TRACE_CMD_EXE" start -b "$CONFIG_FTRACE_BUFFER_SIZE" $CONFIG_FTRACE_EVENTS
+    echo "$FTRACE_START_MARKER" > /sys/kernel/debug/tracing/trace_marker
     echo "Tracing started @ $FTRACE_START_MARKER"
 }
 
@@ -264,30 +265,30 @@ ftrace_stop()
 {
     RESTORE_GOVERNOR=${1:-1}
 
-    $TRACE_CMD_EXE stop
+    "$TRACE_CMD_EXE" stop
 
     get_uptime
     ftrace_stop_start=$RESULT
     echo "Tracing stopped"
 
-    rm $FTRACE_FILE 2>/dev/null
+    rm "$FTRACE_FILE" 2>/dev/null
     if [ "$CONFIG_FTRACE_BINARY" = "n" ] ; then
         echo "Extracting ASCII trace buffer..."
-        $TRACE_CMD_EXE show > $FTRACE_FILE 2>/dev/null
+        "$TRACE_CMD_EXE" show > "$FTRACE_FILE" 2>/dev/null
     else
         echo "Extracting BINARY trace buffer..."
-        $TRACE_CMD_EXE extract -o $FTRACE_FILE 2>/dev/null
+        "$TRACE_CMD_EXE" extract -o "$FTRACE_FILE" 2>/dev/null
     fi
     get_uptime
     ftrace_extract_done=$RESULT
     echo "Trace analysis from $ftrace_stop_start to $ftrace_extract_done"
 
-    if [ $RESTORE_GOVERNOR -eq 1 ]; then
+    if [ "$RESTORE_GOVERNOR" -eq 1 ]; then
         echo "Restore CPUFreq governors..."
         i=0
-        for value  in $FTRACE_OLD_GOV ; do
-            echo $value > /sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor
-			i=$(($i+1))
+        for value in $FTRACE_OLD_GOV ; do
+            echo "$value" > "/sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor"
+            i=$((i + 1))
         done
     fi
 
@@ -334,12 +335,12 @@ ftrace_check()
     commandline="$commandline $FTRACE_ANALYZER_EXE -l $1 -t $FTRACE_FILE"
     echo "# $commandline"
     if [ "$CONFIG_FTRACE_BINARY" = "y" ] ; then
-        $TRACE_CMD_EXE report -i $FTRACE_FILE > trace.txt 2>/dev/null
-        $FTRACE_ANALYZER_EXE -l $1 -t trace.txt
+        "$TRACE_CMD_EXE" report -i "$FTRACE_FILE" > trace.txt 2>/dev/null
+        "$FTRACE_ANALYZER_EXE" -l "$1" -t trace.txt
         RESULT0=$?
         rm trace.txt
     else
-        $FTRACE_ANALYZER_EXE -l $1 -t $FTRACE_FILE
+        "$FTRACE_ANALYZER_EXE" -l "$1" -t "$FTRACE_FILE"
         RESULT0=$?
     fi
     get_uptime
@@ -348,10 +349,10 @@ ftrace_check()
 
     # remove ftrace files if it was a success to limit
     # space used on sdcard.
-    if [ "x$CONFIG_FTRACE_CLEANUP" = "xy" ] && [ "$RESULT0" = "0" ] ; then
-        rm $FTRACE_FILE
+    if [ "$CONFIG_FTRACE_CLEANUP" = "y" ] && [ "$RESULT0" = "0" ] ; then
+        rm "$FTRACE_FILE"
     else
-        gzip $FTRACE_FILE
+        gzip "$FTRACE_FILE"
     fi
     RESULT=$RESULT0
 }
@@ -360,8 +361,8 @@ get_task_pid() {
     TRACE=$1
     TASK_NAME=$2
 
-	TASK=$(awk -v PATTERN="$TASK_NAME-([0-9]+)" '$1 ~ PATTERN {print $1; exit 0;}' $TRACE)
-	TASK_PID=$(echo "${TASK}" | sed "s/${TASK_NAME}-//")
+    TASK=$(awk -v PATTERN="$TASK_NAME-([0-9]+)" '$1 ~ PATTERN {print $1; exit 0;}' "$TRACE")
+    TASK_PID=$(echo "${TASK}" | sed "s/${TASK_NAME}-//")
 
     echo "Found task [$TASK_NAME] PID: $TASK_PID"
     RESULT=$TASK_PID
@@ -374,20 +375,20 @@ ftrace_check_tasks()
 
     # Generate TXT file required for analysis
     if [ "$CONFIG_FTRACE_BINARY" = "y" ] ; then
-        $TRACE_CMD_EXE report -i $FTRACE_FILE > trace.txt 2>/dev/null
-        mv $FTRACE_FILE $FTRACE_FILE.bin
-        mv trace.txt $FTRACE_FILE
+        "$TRACE_CMD_EXE" report -i "$FTRACE_FILE" > trace.txt 2>/dev/null
+        mv "$FTRACE_FILE" "$FTRACE_FILE.bin"
+        mv trace.txt "$FTRACE_FILE"
     fi
 
     echo "Extracting tasks PIDs..."
     for TASK in $TRACE_TASKS; do
-      get_task_pid $FTRACE_FILE $TASK
+      get_task_pid "$FTRACE_FILE" "$TASK"
       TASK_PID=$RESULT
       PIDS="${PIDS},$TASK_PID"
     done
 
     echo "Computing CPUs usages for PIDs: $PIDS"
-    export PID=$PIDS
+    export PID="$PIDS"
     commandline="PID=$PID"
     export CPUS_MASK
     commandline="$commandline CPUS_MASK=$CPUS_MASK"
@@ -400,24 +401,23 @@ ftrace_check_tasks()
     export TIME_MAX
     commandline="$commandline TIME_MAX=$TIME_MAX"
     echo "# $commandline"
-    $FTRACE_ANALYZER_EXE -l libprocess_matrix.so.1.0.0 -t $FTRACE_FILE
+    "$FTRACE_ANALYZER_EXE" -l libprocess_matrix.so.1.0.0 -t "$FTRACE_FILE"
     RESULT0=$?
 
     # Recover original binary file
     if [ "$CONFIG_FTRACE_BINARY" = "y" ] ; then
-        rm $FTRACE_FILE
-        mv $FTRACE_FILE.bin $FTRACE_FILE
+        rm "$FTRACE_FILE"
+        mv "$FTRACE_FILE.bin" "$FTRACE_FILE"
     fi
 
     # remove ftrace files if it was a success to limit
     # space used on sdcard.
-    if [ "x$CONFIG_FTRACE_CLEANUP" = "xy" ] && [ "$RESULT0" = "0" ] ; then
-        rm $FTRACE_FILE
+    if [ "$CONFIG_FTRACE_CLEANUP" = "y" ] && [ "$RESULT0" = "0" ] ; then
+        rm "$FTRACE_FILE"
     else
-        gzip $FTRACE_FILE
+        gzip "$FTRACE_FILE"
     fi
 
     # Return test result to testrunner
     RESULT=$RESULT0
-
 }


### PR DESCRIPTION
Why this PR?
Address a batch of ShellCheck findings in Runner/utils/basics.sh by:
- adding targeted SC1091 annotations for runtime-sourced helper files
- quoting path and argument expansions where safe
- replacing legacy backticks with
- simplifying useless echo-based assignments
- converting indirect 127 checks to direct command tests
- cleaning up arithmetic expansions and x-prefixed comparisons

These changes are mechanical and do not alter the intended basics.sh runtime flow.