### PR TITLE
shellcheck: remove dead trailing completion logs in kernel run scripts

### DIFF
--- a/Runner/suites/Kernel/Baseport/BWMON/run.sh
+++ b/Runner/suites/Kernel/Baseport/BWMON/run.sh
@@ -43,7 +43,7 @@ check_dependencies bw_mem
 
 log_info "Fetching te interconnect summary"
 extract_votes() {
-  cat /sys/kernel/debug/interconnect/interconnect_summary | grep -i pmu | awk '{print $NF}'
+  grep -i pmu /sys/kernel/debug/interconnect/interconnect_summary | awk '{print $NF}'
 }
 log_info "Initial vote check:"
 sleep 5
@@ -88,4 +88,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/Buses/run.sh
+++ b/Runner/suites/Kernel/Baseport/Buses/run.sh
@@ -52,4 +52,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1 
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/CPUFreq_Validation/run.sh
+++ b/Runner/suites/Kernel/Baseport/CPUFreq_Validation/run.sh
@@ -108,12 +108,11 @@ log_info "=== Final Result ==="
 if [ "$overall_pass" -eq 0 ]; then
     log_pass "$TESTNAME: All policies passed"
     echo "$TESTNAME PASS" > "$res_file"
+    rm -rf "$status_dir"
     exit 0
 else
     log_fail "$TESTNAME: One or more policies failed"
     echo "$TESTNAME FAIL" > "$res_file"
+    rm -rf "$status_dir"
     exit 1
 fi
-
-rm -rf "$status_dir"
-exit "$overall_pass"

--- a/Runner/suites/Kernel/Baseport/GIC/run.sh
+++ b/Runner/suites/Kernel/Baseport/GIC/run.sh
@@ -40,7 +40,7 @@ log_info "=== Test Initialization ==="
 
 # Function to get the timer count
 get_timer_count() {
-    cat /proc/interrupts | grep arch_timer
+    grep arch_timer /proc/interrupts
 }
 
 # Get the initial timer count
@@ -58,20 +58,20 @@ echo "$final_count"
 
 # Compare the initial and final counts
 echo "Comparing timer counts:"
-echo "$initial_count" | while read -r line; do
-    cpu=$(echo "$line" | awk '{print $1}')
-    initial_values=$(echo "$line" | awk '{for(i=2;i<=9;i++) print $i}')
-    final_values=$(echo "$final_count" | grep "$cpu" | awk '{for(i=2;i<=9;i++) print $i}')
-    
+while IFS= read -r line; do
+    [ -n "$line" ] || continue
+
+    cpu=$(printf '%s\n' "$line" | awk '{print $1}')
+    initial_values=$(printf '%s\n' "$line" | awk '{for(i=2;i<=9;i++) print $i}')
+    final_values=$(printf '%s\n' "$final_count" | awk -v cpu="$cpu" '$1 == cpu {for(i=2;i<=9;i++) print $i}')
+
     fail_test=false
-    initial_values_list=$(echo "$initial_values" | tr ' ' '
-')
-    final_values_list=$(echo "$final_values" | tr ' ' '
-')
-    
     i=0
-    echo "$initial_values_list" | while read -r initial_value; do
-        final_value=$(echo "$final_values_list" | sed -n "$((i+1))p")
+
+    while IFS= read -r initial_value; do
+        [ -n "$initial_value" ] || continue
+
+        final_value=$(printf '%s\n' "$final_values" | sed -n "$((i + 1))p")
         if [ "$initial_value" -lt "$final_value" ]; then
             echo "CPU $i: Timer count has incremented. Test PASSED"
             log_pass "CPU $i: Timer count has incremented. Test PASSED"
@@ -80,9 +80,12 @@ echo "$initial_count" | while read -r line; do
             log_fail "CPU $i: Timer count has not incremented. Test FAILED"
             fail_test=true
         fi
-        i=$((i+1))
-    done
-    echo $fail_test
+        i=$((i + 1))
+    done <<EOF
+$initial_values
+EOF
+
+    echo "$fail_test"
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
         echo "$TESTNAME PASS" > "$res_file"
@@ -92,5 +95,6 @@ echo "$initial_count" | while read -r line; do
         echo "$TESTNAME FAIL" > "$res_file"
         exit 1
     fi
-done
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+done <<EOF
+$initial_count
+EOF

--- a/Runner/suites/Kernel/Baseport/IPCC/run.sh
+++ b/Runner/suites/Kernel/Baseport/IPCC/run.sh
@@ -42,7 +42,7 @@ output=$(cat /sys/class/remoteproc/remoteproc*/state)
 
 count=$(echo "$output" | grep -c "running")
 
-if [ $count -eq 4 ]; then
+if [ "$count" -eq 4 ]; then
     log_pass "$TESTNAME : Test Passed"
     log_info "Writing to file $res_file"
     echo "$TESTNAME PASS" > "$res_file"
@@ -53,4 +53,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/Interrupts/run.sh
+++ b/Runner/suites/Kernel/Baseport/Interrupts/run.sh
@@ -40,7 +40,7 @@ log_info "=== Test Initialization ==="
 
 # Function to get the timer count
 get_timer_count() {
-    cat /proc/interrupts | grep arch_timer
+    grep arch_timer /proc/interrupts
 }
 
 # Get the initial timer count
@@ -58,20 +58,20 @@ echo "$final_count"
 
 # Compare the initial and final counts
 echo "Comparing timer counts:"
-echo "$initial_count" | while read -r line; do
-    cpu=$(echo "$line" | awk '{print $1}')
-    initial_values=$(echo "$line" | awk '{for(i=2;i<=9;i++) print $i}')
-    final_values=$(echo "$final_count" | grep "$cpu" | awk '{for(i=2;i<=9;i++) print $i}')
-    
+while IFS= read -r line; do
+    [ -n "$line" ] || continue
+
+    cpu=$(printf '%s\n' "$line" | awk '{print $1}')
+    initial_values=$(printf '%s\n' "$line" | awk '{for(i=2;i<=9;i++) print $i}')
+    final_values=$(printf '%s\n' "$final_count" | awk -v cpu="$cpu" '$1 == cpu {for(i=2;i<=9;i++) print $i}')
+
     fail_test=false
-    initial_values_list=$(echo "$initial_values" | tr ' ' '
-')
-    final_values_list=$(echo "$final_values" | tr ' ' '
-')
-    
     i=0
-    echo "$initial_values_list" | while read -r initial_value; do
-        final_value=$(echo "$final_values_list" | sed -n "$((i+1))p")
+
+    while IFS= read -r initial_value; do
+        [ -n "$initial_value" ] || continue
+
+        final_value=$(printf '%s\n' "$final_values" | sed -n "$((i + 1))p")
         if [ "$initial_value" -lt "$final_value" ]; then
             echo "CPU $i: Timer count has incremented. Test PASSED"
             log_pass "CPU $i: Timer count has incremented. Test PASSED"
@@ -80,17 +80,21 @@ echo "$initial_count" | while read -r line; do
             log_fail "CPU $i: Timer count has not incremented. Test FAILED"
             fail_test=true
         fi
-        i=$((i+1))
-    done
-    echo $fail_test
+        i=$((i + 1))
+    done <<EOF
+$initial_values
+EOF
+
+    echo "$fail_test"
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
-	echo "$TESTNAME PASS" > "$res_file"
-    exit 0
+        echo "$TESTNAME PASS" > "$res_file"
+        exit 0
     else
         log_fail "$TESTNAME : Test Failed"
-	echo "$TESTNAME FAIL" > "$res_file"
-    exit 1
+        echo "$TESTNAME FAIL" > "$res_file"
+        exit 1
     fi
-done
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+done <<EOF
+$initial_count
+EOF

--- a/Runner/suites/Kernel/Baseport/Kernel_Selftests/run.sh
+++ b/Runner/suites/Kernel/Baseport/Kernel_Selftests/run.sh
@@ -228,6 +228,7 @@ while IFS= read -r test || [ -n "$test" ]; do
 
 done < "$whitelist"
 
+log_info "Per-test results written to $per_test_file"
 if [ "$fail" -eq 0 ] && [ "$pass" -gt 0 ]; then
     echo "$TESTNAME PASS" > "$res_file"
     log_pass "$TESTNAME: all tests passed"
@@ -237,6 +238,3 @@ else
     log_fail "$TESTNAME: one or more tests failed"
     exit 1
 fi
-
-log_info "Per-test results written to $per_test_file"
-log_info "------------------- Completed $TESTNAME Testcase -----------"

--- a/Runner/suites/Kernel/Baseport/MEMLAT/run.sh
+++ b/Runner/suites/Kernel/Baseport/MEMLAT/run.sh
@@ -43,7 +43,7 @@ log_info "Checking if dependency binary is available"
 check_dependencies lat_mem_rd
 
 extract_votes() {
-  cat /sys/kernel/debug/interconnect/interconnect_summary | grep -i cpu | awk '{print $NF}'
+  grep -i cpu /sys/kernel/debug/interconnect/interconnect_summary | awk '{print $NF}'
 }
 
 log_info "Initial vote check:"
@@ -90,4 +90,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/PCIe/run.sh
+++ b/Runner/suites/Kernel/Baseport/PCIe/run.sh
@@ -74,5 +74,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/Timer/run.sh
+++ b/Runner/suites/Kernel/Baseport/Timer/run.sh
@@ -79,16 +79,14 @@ else
 fi
 
 # --- Check if binary exists in PATH or at custom path ---
-check_dependencies "$BINARY"
-if [ $? -ne 0 ]; then
+if ! check_dependencies "$BINARY"; then
     log_skip "$TESTNAME : Binary '$BINARY' not found"
     echo "$TESTNAME SKIP" > "$res_file"
     exit 0
 fi
-
 # Run the binary and capture the output
 OUTPUT=$($BINARY)
-echo $OUTPUT
+echo "$OUTPUT"
 
 # Check if "pass:7" is in the output
 if echo "${OUTPUT}" | grep "pass:7"; then
@@ -100,4 +98,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/USBHost/run.sh
+++ b/Runner/suites/Kernel/Baseport/USBHost/run.sh
@@ -48,7 +48,7 @@ usb_output=$(lsusb)
 device_count=$(echo "$usb_output" | wc -l)
 
 # Filter out USB hubs
-non_hub_count=$(echo "$usb_output" | grep -vi "hub" | wc -l)
+non_hub_count=$(printf '%s\n' "$usb_output" | grep -ivc "hub")
 
 echo "Enumerated USB devices..."
 echo "$usb_output"
@@ -68,5 +68,3 @@ else
     echo "$TESTNAME PASS" > "$res_file"
     exit 0
 fi
-
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/hotplug/run.sh
+++ b/Runner/suites/Kernel/Baseport/hotplug/run.sh
@@ -69,7 +69,7 @@ for cpu in /sys/devices/system/cpu/cpu[0-7]*; do
     offline_cpu "$cpu_id"
     sleep 1
 
-    online_status=$(cat /sys/devices/system/cpu/$cpu_id/online)
+    online_status=$(cat /sys/devices/system/cpu/"$cpu_id"/online)
     if [ "$online_status" -ne 0 ]; then
         log_fail "Failed to offline $cpu_id"
         test_passed=false
@@ -79,7 +79,7 @@ for cpu in /sys/devices/system/cpu/cpu[0-7]*; do
     online_cpu "$cpu_id"
     sleep 1
 
-    online_status=$(cat /sys/devices/system/cpu/$cpu_id/online)
+    online_status=$(cat /sys/devices/system/cpu/"$cpu_id"/online)
     if [ "$online_status" -ne 1 ]; then
         log_fail "Failed to online $cpu_id"
         test_passed=false
@@ -99,4 +99,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/iommu/run.sh
+++ b/Runner/suites/Kernel/Baseport/iommu/run.sh
@@ -89,4 +89,3 @@ else
     exit 1
 fi
 
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/irq/run.sh
+++ b/Runner/suites/Kernel/Baseport/irq/run.sh
@@ -40,7 +40,7 @@ log_info "=== Test Initialization ==="
 
 # Function to get the timer count
 get_timer_count() {
-    cat /proc/interrupts | grep arch_timer
+    grep arch_timer /proc/interrupts
 }
 
 # Get the initial timer count
@@ -58,37 +58,40 @@ log_info "$final_count"
 
 # Compare the initial and final counts
 log_info "Comparing timer counts:"
-echo "$initial_count" | while read -r line; do
-    cpu=$(echo "$line" | awk '{print $1}')
-    initial_values=$(echo "$line" | awk '{for(i=2;i<=9;i++) print $i}')
-    final_values=$(echo "$final_count" | grep "$cpu" | awk '{for(i=2;i<=9;i++) print $i}')
-    
+while IFS= read -r line; do
+    [ -n "$line" ] || continue
+
+    cpu=$(printf '%s\n' "$line" | awk '{print $1}')
+    initial_values=$(printf '%s\n' "$line" | awk '{for(i=2;i<=9;i++) print $i}')
+    final_values=$(printf '%s\n' "$final_count" | awk -v cpu="$cpu" '$1 == cpu {for(i=2;i<=9;i++) print $i}')
+
     fail_test=false
-    initial_values_list=$(echo "$initial_values" | tr ' ' '
-')
-    final_values_list=$(echo "$final_values" | tr ' ' '
-')
-    
     i=0
-    echo "$initial_values_list" | while read -r initial_value; do
-        final_value=$(echo "$final_values_list" | sed -n "$((i+1))p")
+
+    while IFS= read -r initial_value; do
+        [ -n "$initial_value" ] || continue
+
+        final_value=$(printf '%s\n' "$final_values" | sed -n "$((i + 1))p")
         if [ "$initial_value" -lt "$final_value" ]; then
             log_pass "CPU $i: Timer count has incremented. Test PASSED"
         else
             log_fail "CPU $i: Timer count has not incremented. Test FAILED"
             fail_test=true
         fi
-        i=$((i+1))
-    done
+        i=$((i + 1))
+    done <<EOF
+$initial_values
+EOF
 
     if [ "$fail_test" = false ]; then
         log_pass "$TESTNAME : Test Passed"
-	echo "$TESTNAME PASS" > "$res_file"
-    exit 0
+        echo "$TESTNAME PASS" > "$res_file"
+        exit 0
     else
         log_fail "$TESTNAME : Test Failed"
-	echo "$TESTNAME FAIL" > "$res_file"
-    exit 1
+        echo "$TESTNAME FAIL" > "$res_file"
+        exit 1
     fi
-done
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"
+done <<EOF
+$initial_count
+EOF

--- a/Runner/suites/Kernel/Baseport/kaslr/run.sh
+++ b/Runner/suites/Kernel/Baseport/kaslr/run.sh
@@ -38,11 +38,11 @@ log_info "----------------------------------------------------------------------
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
 log_info "=== Test Initialization ==="
 
-output=$(cat /proc/kallsyms | grep stext)
+output=$(grep stext /proc/kallsyms)
 
-value=$(echo $output | awk '{print $1}')
+value=$(printf '%s\n' "$output" | awk '{print $1}')
 
-if [ $value != "0000000000000000" ]; then
+if [ "$value" != "0000000000000000" ]; then
     log_pass "$TESTNAME : Test Passed"
     log_info "Writing to file $res_file"
     echo "$TESTNAME PASS" > "$res_file"
@@ -53,4 +53,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/pinctrl/run.sh
+++ b/Runner/suites/Kernel/Baseport/pinctrl/run.sh
@@ -55,4 +55,3 @@ else
     echo "$TESTNAME PASS" > "$res_file"
     exit 0
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/qcom_crypto/run.sh
+++ b/Runner/suites/Kernel/Baseport/qcom_crypto/run.sh
@@ -109,7 +109,3 @@ else
     exit 1
 fi
 
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"
-
-
-

--- a/Runner/suites/Kernel/Baseport/qcrypto/run.sh
+++ b/Runner/suites/Kernel/Baseport/qcrypto/run.sh
@@ -55,4 +55,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 0
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/remoteproc/run.sh
+++ b/Runner/suites/Kernel/Baseport/remoteproc/run.sh
@@ -45,12 +45,11 @@ detect_platform
 available_rprocs=$(cat /sys/class/remoteproc/remoteproc*/firmware)
 
 # Check if any line contains "modem"
-echo "$available_rprocs" | grep -q "modem"
-if [ $? -eq 0 ] && [ ${PLATFORM_TARGET} = "Kodiak" ]; then
-    subsystem_count=$(echo "$available_rprocs" | grep -v "modem" | wc -l)
+if printf '%s\n' "$available_rprocs" | grep -q "modem" && [ "${PLATFORM_TARGET}" = "Kodiak" ]; then
+    subsystem_count=$(printf '%s\n' "$available_rprocs" | grep -vc "modem")
 else
     # "modem" not found, count all lines
-    subsystem_count=$(echo "$available_rprocs" | wc -l)
+    subsystem_count=$(printf '%s\n' "$available_rprocs" | wc -l)
 fi
 
 # Execute the command and get the output
@@ -62,7 +61,7 @@ count=$(echo "$output" | grep -c "running")
 log_info "rproc subsystems in running state : $count, expected subsystems : $subsystem_count"
 
 # Print overall test result
-if [ $count -eq $subsystem_count ]; then
+if [ "$count" -eq "$subsystem_count" ]; then
     log_pass "$TESTNAME : Test Passed"
     echo "$TESTNAME PASS" > "$res_file"
     exit 0
@@ -71,4 +70,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/shmbridge/run.sh
+++ b/Runner/suites/Kernel/Baseport/shmbridge/run.sh
@@ -38,7 +38,7 @@ log_info "Checking if required tools are available"
 
 if ! check_dependencies zcat grep dmesg; then
     log_skip "$TESTNAME SKIP - missing one or more of zcat grep dmesg utils"
-    echo "$TESTNAME SKIP" >"$RES_FILE"
+    echo "$TESTNAME SKIP" >"$res_file"
     exit 0
 fi
 

--- a/Runner/suites/Kernel/Baseport/smmu/run.sh
+++ b/Runner/suites/Kernel/Baseport/smmu/run.sh
@@ -53,4 +53,3 @@ else
     echo "$TESTNAME PASS" > "$res_file"
     exit 0
 fi
-log_info "-------------------Completed $TESTNAME Testcase----------------------------"

--- a/Runner/suites/Kernel/Baseport/watchdog/run.sh
+++ b/Runner/suites/Kernel/Baseport/watchdog/run.sh
@@ -49,4 +49,3 @@ else
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
-log_info "-------------------Completed $TESTNAME Testcase---------------------------"


### PR DESCRIPTION
This PR fixes the shellcheck reported issues by removing unreachable trailing completion log lines from kernel run.sh scripts where the final PASS/FAIL branches already exit unconditionally.

This is a lint-only cleanup for SC2317 and does not change runtime behavior.