### PR TITLE
Added lava test name support to handle failure due to test case name

### DIFF
--- a/Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/README.md
+++ b/Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/README.md
@@ -211,6 +211,13 @@ Help:
     - `9` MEMDUMP
   - Default: `2`
 
+- `--lava-testcase-id <name>`
+  - Override the test case name reported to LAVA in the `.res` file
+  - Default: `Video_Encode_Decode`
+  - Used by LAVA to match expected test case names
+  - Example: `--lava-testcase-id "GStreamer_Video_Decode_h265_480p"`
+  - **Note:** This is typically set automatically by LAVA job definitions and should not be used for local testing
+
 ---
 
 ## Examples
@@ -585,8 +592,25 @@ The test supports these environment variables (can be set in LAVA job definition
 - `VIDEO_GST_DEBUG` - GStreamer debug level (default: 2)
 - `GST_DEBUG_LEVEL` - Alternative to VIDEO_GST_DEBUG
 - `VIDEO_CLIP_URL` - URL for VP9 clip download (default: GitHub releases)
+- `LAVA_TESTCASE_ID` - Override test case name for LAVA reporting (default: Video_Encode_Decode)
 
 **Priority order for duration**: `VIDEO_DURATION` > `RUNTIMESEC` > default (30)
+
+### LAVA Test Case Naming
+
+The test supports flexible test case naming for LAVA integration:
+
+- **Default behavior**: Reports results as `Video_Encode_Decode` in the `.res` file
+- **LAVA override**: Set `LAVA_TESTCASE_ID` parameter in the YAML definition to match LAVA's expected test case name
+- **Example YAML configuration**:
+  ```yaml
+  params:
+    VIDEO_TEST_MODE: decode
+    VIDEO_CODECS: h265
+    VIDEO_RESOLUTIONS: 480p
+    LAVA_TESTCASE_ID: "GStreamer_Video_Decode_h265_480p"  # Matches LAVA expected name
+  ```
+- This ensures LAVA correctly matches test results with expected test case names, avoiding "Unexpected test result" errors
 
 ### VP9-Specific Notes for CI/LAVA
 

--- a/Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/Video_Encode_Decode.yaml
+++ b/Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/Video_Encode_Decode.yaml
@@ -19,6 +19,7 @@ params:
   VIDEO_GST_DEBUG: "2"
   VIDEO_CLIP_URL: ""
   VIDEO_CLIP_PATH: ""   # dir/file/archive (tar/tar.gz/tar.xz/xz)
+  LAVA_TESTCASE_ID: "Video_Encode_Decode"
 
 run:
   steps:
@@ -27,5 +28,5 @@ run:
     - VIDEO_SHARED_ENCODE_DIR="${REPO_PATH%%/tests/*}/shared/video-encode-decode"
     - export VIDEO_TEST_MODE VIDEO_CODECS VIDEO_RESOLUTIONS VIDEO_DURATION VIDEO_FRAMERATE
     - export VIDEO_STACK VIDEO_GST_DEBUG VIDEO_CLIP_URL VIDEO_CLIP_PATH VIDEO_SHARED_ENCODE_DIR
-    - ./run.sh --mode "${VIDEO_TEST_MODE}" --codecs "${VIDEO_CODECS}" --resolutions "${VIDEO_RESOLUTIONS}" --duration "${VIDEO_DURATION}" --framerate "${VIDEO_FRAMERATE}" --stack "${VIDEO_STACK}" --gst-debug "${VIDEO_GST_DEBUG}" --clip-url "${VIDEO_CLIP_URL}" --clip-path "${VIDEO_CLIP_PATH}" || true
+    - ./run.sh --mode "${VIDEO_TEST_MODE}" --codecs "${VIDEO_CODECS}" --resolutions "${VIDEO_RESOLUTIONS}" --duration "${VIDEO_DURATION}" --framerate "${VIDEO_FRAMERATE}" --stack "${VIDEO_STACK}" --gst-debug "${VIDEO_GST_DEBUG}" --clip-url "${VIDEO_CLIP_URL}" --clip-path "${VIDEO_CLIP_PATH}" --lava-testcase-id "${LAVA_TESTCASE_ID}" || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh Video_Encode_Decode.res

--- a/Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/run.sh
+++ b/Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/run.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(
 )"
 
 TESTNAME="Video_Encode_Decode"
+RESULT_TESTNAME="$TESTNAME"
 RES_FILE="${SCRIPT_DIR}/${TESTNAME}.res"
 LOG_DIR="${SCRIPT_DIR}/logs"
 OUTDIR="$LOG_DIR/$TESTNAME"
@@ -31,7 +32,7 @@ done
  
 if [ -z "${INIT_ENV:-}" ]; then
   echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
-  echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+  echo "$RESULT_TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
   exit 0
 fi
  
@@ -62,7 +63,7 @@ if ! mkdir -p "$OUTDIR" "$DMESG_DIR" "$ENCODED_DIR"; then
   log_error "  OUTDIR=$OUTDIR"
   log_error "  DMESG_DIR=$DMESG_DIR"
   log_error "  ENCODED_DIR=$ENCODED_DIR"
-  echo "$TESTNAME FAIL" >"$RES_FILE" 2>/dev/null || true
+  echo "$RESULT_TESTNAME FAIL" >"$RES_FILE" 2>/dev/null || true
   exit 0
 fi
 
@@ -103,13 +104,13 @@ for param in VIDEO_DURATION RUNTIMESEC VIDEO_FRAMERATE VIDEO_GST_DEBUG GST_DEBUG
     case "$val" in
       ''|*[!0-9]*) 
         log_warn "$param must be numeric (got '$val')"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
         ;;
       *)
         if [ "$val" -le 0 ] 2>/dev/null; then
           log_warn "$param must be positive (got '$val')"
-          echo "$TESTNAME SKIP" >"$RES_FILE"
+          echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
           exit 0
         fi
         ;;
@@ -132,7 +133,7 @@ while [ $# -gt 0 ]; do
     --mode)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --mode"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       # If empty, keep default; otherwise use provided value
@@ -143,7 +144,7 @@ while [ $# -gt 0 ]; do
     --codecs)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --codecs"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       # If empty, keep default; otherwise use provided value
@@ -154,7 +155,7 @@ while [ $# -gt 0 ]; do
     --resolutions)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --resolutions"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       # If empty, keep default; otherwise use provided value
@@ -165,7 +166,7 @@ while [ $# -gt 0 ]; do
     --duration)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --duration"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       # If empty or non-numeric, keep default; otherwise use provided value
@@ -173,7 +174,7 @@ while [ $# -gt 0 ]; do
         case "$2" in
           ''|*[!0-9]*)
             log_warn "Invalid --duration '$2' (must be numeric)"
-            echo "$TESTNAME SKIP" >"$RES_FILE"
+            echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
             exit 0
             ;;
           *)
@@ -187,20 +188,20 @@ while [ $# -gt 0 ]; do
     --framerate)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --framerate"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       if [ -n "$2" ]; then
         case "$2" in
           ''|*[!0-9]*) 
             log_warn "Invalid --framerate '$2' (must be numeric)"
-            echo "$TESTNAME SKIP" >"$RES_FILE"
+            echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
             exit 0
             ;;
           *)
             if [ "$2" -le 0 ] 2>/dev/null; then
               log_warn "Framerate must be positive (got '$2')"
-              echo "$TESTNAME SKIP" >"$RES_FILE"
+              echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
               exit 0
             fi
             ;;
@@ -214,7 +215,7 @@ while [ $# -gt 0 ]; do
     --stack)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --stack"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       # If empty, keep default; otherwise use provided value
@@ -225,7 +226,7 @@ while [ $# -gt 0 ]; do
     --gst-debug)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --gst-debug"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       # If empty, keep default; otherwise use provided value
@@ -236,7 +237,7 @@ while [ $# -gt 0 ]; do
     --clip-url)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --clip-url"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       # If empty, keep default; otherwise use provided value
@@ -246,10 +247,19 @@ while [ $# -gt 0 ]; do
     --clip-path)
       if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
         log_warn "Missing/invalid value for --clip-path"
-        echo "$TESTNAME SKIP" >"$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
         exit 0
       fi
       [ -n "$2" ] && clipPath="$2"
+      shift 2
+      ;;
+    --lava-testcase-id)
+      if [ $# -lt 2 ] || [ "${2#--}" != "$2" ]; then
+        log_warn "Missing/invalid value for --lava-testcase-id"
+        echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+      fi
+      [ -n "$2" ] && RESULT_TESTNAME="$2"
       shift 2
       ;;
     -h|--help)
@@ -294,6 +304,11 @@ OPTIONS:
   --clip-path <path>    Local path to test video files
                         (overrides --clip-url if files exist)
 
+  --lava-testcase-id <name>
+                        Override the test case name reported to LAVA
+                        (default: Video_Encode_Decode)
+                        Used by LAVA to match expected test case names
+
   -h, --help            Display this help message
 
 ENVIRONMENT VARIABLES:
@@ -332,7 +347,7 @@ EOF
       ;;
     *)
       log_warn "Unknown argument: $1"
-      echo "$TESTNAME SKIP" >"$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
       exit 0
       ;;
   esac
@@ -341,14 +356,14 @@ done
 # -------------------- Validate parsed values --------------------
 case "$testMode" in all|encode|decode) : ;; *)
   log_warn "Invalid --mode '$testMode'"
-  echo "$TESTNAME SKIP" >"$RES_FILE"
+  echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
   exit 0
   ;;
 esac
 
 case "$gstDebugLevel" in 1|2|3|4|5|6|7|8|9) : ;; *)
   log_warn "Invalid --gst-debug '$gstDebugLevel' (allowed: 1-9)"
-  echo "$TESTNAME SKIP" >"$RES_FILE"
+  echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
   exit 0
   ;;
 esac
@@ -356,13 +371,13 @@ esac
 case "$duration" in
   ''|*[!0-9]*) 
     log_warn "Invalid duration '$duration' (must be numeric)"
-    echo "$TESTNAME SKIP" >"$RES_FILE"
+    echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
     exit 0
     ;;
   *)
     if [ "$duration" -le 0 ] 2>/dev/null; then
       log_warn "Duration must be positive (got '$duration')"
-      echo "$TESTNAME SKIP" >"$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
       exit 0
     fi
     ;;
@@ -371,13 +386,13 @@ esac
 case "$framerate" in
   ''|*[!0-9]*) 
     log_warn "Invalid framerate '$framerate' (must be numeric)"
-    echo "$TESTNAME SKIP" >"$RES_FILE"
+    echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
     exit 0
     ;;
   *)
     if [ "$framerate" -le 0 ] 2>/dev/null; then
       log_warn "Framerate must be positive (got '$framerate')"
-      echo "$TESTNAME SKIP" >"$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
       exit 0
     fi
     ;;
@@ -386,7 +401,7 @@ esac
 # -------------------- Pre-checks --------------------
 check_dependencies "gst-launch-1.0 gst-inspect-1.0 awk grep head sed tr stat find curl tar" >/dev/null 2>&1 || {
   log_skip "Missing required tools (gst-launch-1.0, gst-inspect-1.0, awk, grep, head, sed, tr, stat, find, curl, tar)"
-  echo "$TESTNAME SKIP" >"$RES_FILE"
+  echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
   exit 0
 }
 
@@ -737,15 +752,15 @@ fi
 case "$result" in
   PASS)
     log_pass "$TESTNAME $result: $reason"
-    echo "$TESTNAME PASS" >"$RES_FILE"
+    echo "$RESULT_TESTNAME PASS" >"$RES_FILE"
     ;;
   FAIL)
     log_fail "$TESTNAME $result: $reason"
-    echo "$TESTNAME FAIL" >"$RES_FILE"
+    echo "$RESULT_TESTNAME FAIL" >"$RES_FILE"
     ;;
   *)
     log_warn "$TESTNAME $result: $reason"
-    echo "$TESTNAME SKIP" >"$RES_FILE"
+    echo "$RESULT_TESTNAME SKIP" >"$RES_FILE"
     ;;
 esac
 


### PR DESCRIPTION
Summary:
Applied test name fix as suggested, updated readme doc based on changes done.

Files changed:
Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/run.sh
Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/Video_Encode_Decode.yaml
Runner/suites/Multimedia/GSTreamer/Video/Video_Encode_Decode/README.md

Validation:
LAVA level verified: https://lava.infra.foundries.io/scheduler/job/168726