### PR TITLE
Fix AudioRecord testcase ID collision for LAVA CI

### DIFF
--- a/Runner/suites/Multimedia/Audio/AudioRecord/AudioRecord.yaml
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/AudioRecord.yaml
@@ -20,10 +20,11 @@ params:
   DMESG_SCAN: 1  # Scan dmesg for errors after recording, default: 1
   VERBOSE: 0  # Enable verbose logging, default: 0
   RES_SUFFIX: ""  # Suffix for unique result file and log directory (e.g., "Config1" generates AudioRecord_Config1.res and results/AudioRecord_Config1/), default: unset
+  LAVA_TESTCASE_ID: "AudioRecord"  # Unique testcase ID written into the .res file for LAVA, default: AudioRecord
 
 run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/Audio/AudioRecord/
-    - ./run.sh --backend "${AUDIO_BACKEND}" --source "${SOURCE_CHOICE}" --config-name "${CONFIG_NAMES}" --config-filter "${CONFIG_FILTER}" --record-seconds "${RECORD_SECONDS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --res-suffix "${RES_SUFFIX}" || true
+    - ./run.sh --backend "${AUDIO_BACKEND}" --source "${SOURCE_CHOICE}" --config-name "${CONFIG_NAMES}" --config-filter "${CONFIG_FILTER}" --record-seconds "${RECORD_SECONDS}" --loops "${LOOPS}" --timeout "${TIMEOUT}" --strict "${STRICT}" --res-suffix "${RES_SUFFIX}" --lava-testcase-id "${LAVA_TESTCASE_ID}" || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh AudioRecord${RES_SUFFIX:+_${RES_SUFFIX}}.res

--- a/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/Read_me.md
@@ -13,6 +13,10 @@ This suite automates the validation of audio recording capabilities on Qualcomm 
   - Use descriptive names (e.g., record_48KHz_2ch) for specific formats
   - Auto-discovery mode tests all available configs
 - **Config filtering**: Filter tests by sample rate or channel configuration
+- **CI/LAVA integration**: 
+  - Unique result file suffixes prevent file collisions in parallel test runs
+  - Unique testcase IDs prevent LAVA testcase ID collisions
+  - Enables running multiple AudioRecord configurations simultaneously in CI
 - Records audio with configurable duration and loop count
 - Automatically detects and routes to appropriate source (e.g., mic, null)
 - Validates recording using multiple evidence sources:
@@ -185,6 +189,7 @@ DMESG_SCAN	      Scan dmesg for errors after recording	                         
 VERBOSE	          Enable verbose logging	                                      0
 JUNIT_OUT	      Path to write JUnit XML output	                              unset
 RES_SUFFIX        Suffix for unique result file and log directory                 unset
+LAVA_TESTCASE_ID  Unique testcase ID written into the .res file for LAVA         AudioRecord
 
 
 CLI Options:
@@ -200,6 +205,7 @@ Option	                      Description
 --strict [0|1]                Enable strict mode (0=disabled, 1=enabled)
 --no-dmesg	                  Disable dmesg scan
 --res-suffix <suffix>         Suffix for unique result file and log directory (e.g., "Config01" generates AudioRecord_Config01.res and results/AudioRecord_Config01/)
+--lava-testcase-id <id>       Unique testcase ID written into the .res file for LAVA (e.g., "AudioRecord_Config01")
 --junit <file.xml>            Write JUnit XML output
 --verbose	                  Enable verbose logging
 --help	                      Show usage instructions
@@ -310,7 +316,32 @@ AudioRecord_Config01.res
 AudioRecord_Config07.res
 ```
 
-**Example 7: Testing all 10 configs with short duration**
+**Example 7: CI/LAVA workflow with unique testcase IDs (prevents LAVA collisions)**
+```
+# Using --lava-testcase-id ensures unique testcase IDs in LAVA results
+# This prevents testcase ID collisions when running multiple AudioRecord configs in parallel
+
+sh-5.3# ./run.sh --config-name "record_config1" --res-suffix "Config01" --lava-testcase-id "AudioRecord_Config01" --record-seconds 10s
+[INFO] 2026-01-12 07:20:15 - Using unique result file: ./AudioRecord_Config01.res
+[PASS] 2026-01-12 07:20:25 - AudioRecord PASS
+
+sh-5.3# cat AudioRecord_Config01.res
+AudioRecord_Config01 PASS
+
+sh-5.3# ./run.sh --config-name "record_config7" --res-suffix "Config07" --lava-testcase-id "AudioRecord_Config07" --record-seconds 10s
+[INFO] 2026-01-12 07:21:30 - Using unique result file: ./AudioRecord_Config07.res
+[PASS] 2026-01-12 07:21:40 - AudioRecord PASS
+
+sh-5.3# cat AudioRecord_Config07.res
+AudioRecord_Config07 PASS
+
+# LAVA will receive unique testcase IDs:
+# - AudioRecord_Config01 PASS
+# - AudioRecord_Config07 PASS
+# No testcase ID collisions!
+```
+
+**Example 8: Testing all 10 configs with short duration**
 ```
 sh-5.3# ./run.sh --record-seconds 3s
 [INFO] 2026-01-02 12:05:26 - Auto-detected config discovery mode (testing all 10 record configs)

--- a/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
@@ -39,17 +39,20 @@ if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
 fi
 
 TESTNAME="AudioRecord"
+RESULT_TESTNAME="$TESTNAME"
 RES_SUFFIX="" # Optional suffix for unique result files (e.g., "Config1")
 # RES_FILE will be set after parsing command-line arguments
 
-# Pre-parse --res-suffix for early failure handling
-# This ensures unique result files even if setup fails in parallel CI runs
+# Pre-parse --res-suffix and --lava-testcase-id for early failure handling
+# This ensures unique result files and unique testcase IDs even if setup fails in parallel CI runs
 prev_arg=""
 for arg in "$@"; do
   case "$prev_arg" in
     --res-suffix)
       RES_SUFFIX="$arg"
-      break
+      ;;
+    --lava-testcase-id)
+      RESULT_TESTNAME="$arg"
       ;;
   esac
   prev_arg="$arg"
@@ -143,6 +146,10 @@ while [ $# -gt 0 ]; do
       ;;
     --res-suffix)
       RES_SUFFIX="$2"
+      shift 2
+      ;;
+    --lava-testcase-id)
+      RESULT_TESTNAME="$2"
       shift 2
       ;;
     --durations)
@@ -254,7 +261,7 @@ trap 'audio_cleanup_started_daemons' EXIT HUP INT TERM
 test_path="$(find_test_case_by_name "$TESTNAME" 2>/dev/null || echo "$SCRIPT_DIR")"
 if ! cd "$test_path"; then
   log_error "cd failed: $test_path"
-  echo "$TESTNAME FAIL" > "$RES_FILE"
+  echo "$RESULT_TESTNAME FAIL" > "$RES_FILE"
   exit 1
 fi
 
@@ -273,7 +280,7 @@ fi
 if { [ -n "$CONFIG_NAMES" ] || [ -n "$CONFIG_FILTER" ]; } && [ -n "$DURATIONS" ]; then
   log_error "Cannot mix config discovery parameters (--config-name, --config-filter) with legacy matrix parameters (--durations)"
   log_error "Please use either config discovery mode OR legacy matrix mode, not both"
-  echo "$TESTNAME SKIP" > "$RES_FILE"
+  echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
   exit 0
 fi
 
@@ -335,7 +342,7 @@ if [ -z "$AUDIO_BACKEND" ]; then
       log_warn "$TESTNAME: no managed audio backend running - using direct ALSA capture path"
     else
       log_skip "$TESTNAME SKIP - no audio backend running and ALSA capture probe failed: ${AUDIO_ALSA_CAPTURE_REASON:-capture path unavailable}"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
   fi
@@ -403,7 +410,7 @@ if [ "$backend_ok" -ne 1 ]; then
   else
     log_skip "$TESTNAME SKIP - backend not available: $AUDIO_BACKEND"
   fi
-  echo "$TESTNAME SKIP" > "$RES_FILE"
+  echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
   exit 0
 fi
 
@@ -412,27 +419,27 @@ case "$AUDIO_BACKEND" in
   pipewire)
     if ! check_dependencies wpctl pw-record; then
       log_skip "$TESTNAME SKIP - missing PipeWire utils"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
     ;;
   pulseaudio)
     if ! check_dependencies pactl parecord; then
       log_skip "$TESTNAME SKIP - missing PulseAudio utils"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
     ;;
   alsa)
     if ! check_dependencies arecord; then
       log_skip "$TESTNAME SKIP - missing arecord"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
     ;;
   *)
     log_skip "$TESTNAME SKIP - unsupported backend: $AUDIO_BACKEND"
-    echo "$TESTNAME SKIP" > "$RES_FILE"
+    echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
     exit 0
     ;;
 esac
@@ -452,7 +459,7 @@ if [ "$AUDIO_BACKEND" = "pipewire" ]; then
     fi
     if ! audio_pw_ctl_ok 2>/dev/null; then
       log_skip "$TESTNAME SKIP - PipeWire control-plane not responsive"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
   fi
@@ -470,7 +477,7 @@ elif [ "$AUDIO_BACKEND" = "pulseaudio" ]; then
     fi
     if ! audio_pa_ctl_ok 2>/dev/null; then
       log_skip "$TESTNAME SKIP - PulseAudio control-plane not responsive"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
   fi
@@ -543,7 +550,7 @@ fi
 # Only skip if no source AND not on PipeWire.
 if [ -z "$SRC_ID" ] && [ "$AUDIO_BACKEND" != "pipewire" ]; then
   log_skip "$TESTNAME SKIP - requested source '$SRC_CHOICE' not available on any backend (${BACKENDS_TO_TRY:-unknown})"
-  echo "$TESTNAME SKIP" > "$RES_FILE"
+  echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
   exit 0
 fi
 
@@ -574,7 +581,7 @@ if [ "$AUDIO_BACKEND" = "alsa" ]; then
         log_info "ALSA auto-pick: using $SRC_ID"
       else
         log_skip "$TESTNAME SKIP - no valid ALSA capture device found"
-        echo "$TESTNAME SKIP" > "$RES_FILE"
+        echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
         exit 0
       fi
       ;;
@@ -606,21 +613,21 @@ case "$AUDIO_BACKEND" in
   pipewire)
     if ! check_dependencies wpctl pw-record; then
       log_skip "$TESTNAME SKIP - missing PipeWire utils"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
     ;;
   pulseaudio)
     if ! check_dependencies pactl parecord; then
       log_skip "$TESTNAME SKIP - missing PulseAudio utils"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
     ;;
   alsa)
     if ! check_dependencies arecord; then
       log_skip "$TESTNAME SKIP - missing arecord"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     fi
     ;;
@@ -696,20 +703,20 @@ if [ "$USE_CONFIG_DISCOVERY" = "true" ]; then
   if [ -n "$CONFIG_NAMES" ] || [ -n "$CONFIG_FILTER" ]; then
     CONFIGS_TO_TEST="$(discover_and_filter_record_configs "$CONFIG_NAMES" "$CONFIG_FILTER")" || {
       log_skip "$TESTNAME SKIP - Invalid config name(s) provided"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     }
   else
     CONFIGS_TO_TEST="$(discover_record_configs)" || {
       log_skip "$TESTNAME SKIP - No record configs found"
-      echo "$TESTNAME SKIP" > "$RES_FILE"
+      echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
       exit 0
     }
   fi
 
   if [ -z "$CONFIGS_TO_TEST" ]; then
     log_skip "$TESTNAME SKIP - No valid record configs found"
-    echo "$TESTNAME SKIP" > "$RES_FILE"
+    echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
     exit 0
   fi
 
@@ -1334,22 +1341,22 @@ log_info "Summary: total=$total pass=$pass fail=$fail skip=$skip"
 # --- Proper exit codes: PASS=0, FAIL=1, SKIP-only=0 ---
 if [ "$total" -eq 0 ] && [ "$pass" -eq 0 ] && [ "$fail" -eq 0 ]; then
   log_skip "$TESTNAME SKIP - no runnable record testcases"
-  echo "$TESTNAME SKIP" > "$RES_FILE"
+  echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
   exit 0
 fi
 
 if [ "$pass" -eq 0 ] && [ "$fail" -eq 0 ] && [ "$skip" -gt 0 ]; then
   log_skip "$TESTNAME SKIP"
-  echo "$TESTNAME SKIP" > "$RES_FILE"
+  echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
   exit 0
 fi
 
 if [ "$suite_rc" -eq 0 ]; then
   log_pass "$TESTNAME PASS"
-  echo "$TESTNAME PASS" > "$RES_FILE"
+  echo "$RESULT_TESTNAME PASS" > "$RES_FILE"
   exit 0
 fi
 
 log_fail "$TESTNAME FAIL"
-echo "$TESTNAME FAIL" > "$RES_FILE"
+echo "$RESULT_TESTNAME FAIL" > "$RES_FILE"
 exit 1


### PR DESCRIPTION
## Description

This PR fixes the testcase ID collision issue in LAVA by implementing flexible testcase naming for the AudioRecord test suite, enabling parallel execution of multiple AudioRecord configurations in CI.

## Problem

LAVA was experiencing testcase ID collisions because:

- The AudioRecord script was hardcoding the testcase name as `AudioRecord` in the .res file
- When running multiple AudioRecord configurations in parallel (e.g., Config01, Config03, Config05), all tests reported the same testcase ID
- LAVA expected unique testcase IDs like `AudioRecord_Config01`, `AudioRecord_Config03`, etc. based on the job definition
- This collision caused LAVA to overwrite test results and prevented proper CI enablement
- __Blocked issue__: #378 

## Solution

Implemented a flexible testcase naming mechanism that allows LAVA to specify unique testcase IDs:

- __Added `RESULT_TESTNAME` variable__ - Defaults to `AudioRecord` but can be overridden via CLI parameter
- __Added `--lava-testcase-id` parameter__ - Allows LAVA to specify unique testcase names for each configuration
- __Added `LAVA_TESTCASE_ID` YAML parameter__ - Passes the testcase ID from LAVA job definition to the script
- __Updated all result handling__ - Changed all 22 .res file writes to use `$RESULT_TESTNAME` instead of `$TESTNAME`
- __Pre-parse support__ - Early parsing of `--lava-testcase-id` ensures unique result files even if setup fails
