### PR TITLE
added coresight helper(utils) and sink-source-test

### DIFF
--- a/Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/Coresight-Sink-Source-Test.yaml
+++ b/Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/Coresight-Sink-Source-Test.yaml
@@ -1,0 +1,16 @@
+metadata:
+  name: Coresight-Sink-Source-Test
+  format: "Lava-Test Test Definition 1.0"
+  description: "This test iterates through all CoreSight sources and sinks to validate end‑to‑end trace path accessibility. It ensures trace data capture works correctly and that all sources are cleanly disabled after execution."
+  os:
+    - linux
+  scope:
+    - coresight
+    - kernel
+
+run:
+  steps:
+    - REPO_PATH=$PWD || true
+    - cd Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test || true
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Coresight-Sink-Source-Test.res || true

--- a/Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/README.md
+++ b/Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/README.md
@@ -1,0 +1,82 @@
+# Coresight-Sink-Source-Test
+
+## Overview
+The `Coresight-Sink-Source-Test` test iterates through all CoreSight sources and sinks to validate end‑to‑end trace path accessibility. It ensures trace data capture works correctly and that all sources are cleanly disabled after execution.
+
+## Test Goals
+
+- Verify that the CoreSight sink correctly switches to ETF mode.
+- Validate STM trace data routing to ETF via Ftrace integration.
+- Ensure sched_switch events are captured and stored in the ETF buffer.
+- Confirm valid trace data generation by checking ETF output size.
+
+## Prerequisites
+
+- Coresight framework enabled in the kernel with `sysfs` and `debugfs` accessible
+- Multiple Coresight sink and source devices should be present
+- Coresight STM, ETM, ETF devices must be included
+- Root priviledges
+
+## Script Location
+
+```
+Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/run.sh
+```
+
+## Files
+
+- `run.sh` - Main test script
+- `Coresight-Sink-Source-Test.res` - Summary result file with PASS/FAIL
+- `Coresight-Sink-Source-Test.log` - Full execution log.
+
+## How it works
+1. Parses input parameters, sources common utilities, gathers all CoreSight devices, and configures the ETR sink to memory output mode.
+2. Loops over all valid CoreSight sinks and sources, optionally skipping remote ETMs and unsupported TPDM sources.
+3. Resets all sources and sinks, enables one sink at a time, then enables each applicable source to form a complete trace path.
+4. Reads trace data from each sink device and verifies successful data capture based on output file size.
+5. Resets the system again and checks that all sources are properly disabled before reporting pass or fail status.
+
+## Usage
+
+Run the script directly. No iterations or special arguments are required for this basic test.
+
+```bash
+./run.sh
+```
+
+## Example Output
+
+```
+[INFO] 2026-04-06 05:17:08 - ---------------------------Coresight-Sink-Source-Test Starting---------------------------
+[INFO] 2026-04-06 05:17:08 - Starting iteration: 1
+[INFO] 2026-04-06 05:17:08 - Sink Active:- tmc_etf0
+[INFO] 2026-04-06 05:17:09 - Source: etm0 with trace captured of size 65536 bytes
+[INFO] 2026-04-06 05:17:10 - Source: etm1 with trace captured of size 65536 bytes
+[INFO] 2026-04-06 05:17:11 - Source: etm2 with trace captured of size 65536 bytes
+.........
+[INFO] 2026-04-06 05:20:15 - Source: tpdm7 with trace captured of size 96 bytes
+[INFO] 2026-04-06 05:20:16 - Source: tpdm8 with trace captured of size 96 bytes
+[INFO] 2026-04-06 05:20:17 - Source: tpdm9 with trace captured of size 80 bytes
+[INFO] 2026-04-06 05:20:17 - PASS: coresight source/sink path test
+[INFO] 2026-04-06 05:20:17 - ---------------------------Coresight-Sink-Source-Test Finished---------------------------
+```
+
+## Return Code
+
+- `0` — All test cases passed
+- `1` — One or more test cases failed
+
+## Integration in CI
+
+- Can be run standalone or via LAVA
+- Result file `Coresight-Sink-Source-Test.res` will be parsed by `result_parse.sh`
+
+## Notes
+
+- Remote ETM sources and unsupported TPDM sources are conditionally skipped during testing.
+- Trace validity is confirmed by checking a minimum output file size from each sink.
+
+## License
+
+SPDX-License-Identifier: BSD-3-Clause.
+(c) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/run.sh
+++ b/Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/run.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/coresight_helper.sh"
+
+TESTNAME="Coresight-Sink-Source-Test"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+log_info "---------------------------$TESTNAME Starting---------------------------"
+no_remote_etm=0
+if [ "$#" -eq 1 ]; then
+    no_remote_etm=1
+fi
+cs_base="/sys/bus/coresight/devices"
+fail=0
+
+if [ ! -d "$cs_base" ]; then
+    log_warn "Coresight directory $cs_base not found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+cleanup() {
+    reset_coresight
+}
+trap cleanup EXIT HUP INT TERM
+
+reset_coresight
+sinks=""
+sources=""
+for node in "$cs_base"/*; do
+    [ ! -d "$node" ] && continue
+    node_name=$(basename "$node")
+    
+    if [ -f "$node/enable_sink" ]; then
+        [ "$node_name" = "tmc_etf1" ] && continue
+        sinks="$sinks $node"
+        
+        if [ -f "$node/out_mode" ]; then
+            echo mem > "$node/out_mode" 2>/dev/null || true
+        fi
+    fi
+    
+    if [ -f "$node/enable_source" ]; then
+        sources="$sources $node"
+    fi
+done
+
+sinks=${sinks# }
+sources=${sources# }
+if [ -z "$sinks" ]; then
+    log_warn "No Coresight sinks found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+if [ -z "$sources" ]; then
+    log_warn "No Coresight sources found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+i=0
+while [ "$i" -le 2 ]; do
+    log_info "Starting iteration: $((i+1))" 
+    for sink_node in $sinks; do
+        sink_dev=$(basename "$sink_node")
+        log_info "Sink Active:- $sink_dev"
+        
+        for source_node in $sources; do
+            dev_name=$(basename "$source_node")
+            
+            case "$dev_name" in
+                *etm*)
+                    if [ "$no_remote_etm" -eq 1 ]; then
+                        continue
+                    fi
+                    ;;
+                *tpdm-vsense* | *tpdm-qm*)
+                    continue
+                    ;;
+            esac      
+            reset_coresight
+            
+            [ -f "$sink_node/enable_sink" ] && echo 1 > "$sink_node/enable_sink" 2>/dev/null
+            if [ -f "$source_node/enable_source" ]; then
+                echo 1 > "$source_node/enable_source" 2>/dev/null
+                ret=$(tr -d ' ' < "$source_node/enable_source")
+                if [ "$ret" = "0" ]; then
+                    log_fail "FAIL: enable source in $dev_name"
+                    fail=1
+                    continue
+                fi
+            fi          
+            sleep 1
+            reset_coresight
+            
+            rm -f "/tmp/$sink_dev.bin"
+            if [ -c "/dev/$sink_dev" ]; then
+                cat "/dev/$sink_dev" > "/tmp/$sink_dev.bin" 2>/dev/null
+                outfilesize=$(wc -c < "/tmp/$sink_dev.bin" 2>/dev/null | tr -d ' ')
+            else
+                log_warn "Character device /dev/$sink_dev not found! Skipping read."
+                outfilesize=0
+            fi
+            
+            if [ -n "$outfilesize" ] && [ "$outfilesize" -ge 64 ]; then
+                log_info "Source: $dev_name with trace captured of size $outfilesize bytes"
+            else
+                log_fail "Source: $dev_name with no traces captured of size ${outfilesize:-0}"
+                fail=1
+            fi
+        done
+    done
+    i=$((i + 1))
+done
+reset_coresight
+
+for source_node in $sources; do
+    dev_name=$(basename "$source_node")
+    if [ -f "$source_node/enable_source" ]; then
+        ret=$(tr -d ' ' < "$source_node/enable_source")
+        if [ "$ret" = "1" ]; then
+            log_fail "fail to disable source in $dev_name during final verification"
+            fail=1
+        fi
+    fi
+done
+
+if [ "$fail" -eq 0 ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+fi
+
+log_info "---------------------------$TESTNAME Finished---------------------------"

--- a/Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/run.sh
+++ b/Runner/suites/Kernel/DEBUG/Coresight-Sink-Source-Test/run.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/coresight_helper.sh"
+
+TESTNAME="Coresight-Sink-Source-Test"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+log_info "---------------------------$TESTNAME Starting---------------------------"
+no_remote_etm=0
+if [ "$#" -eq 1 ]; then
+    no_remote_etm=1
+fi
+cs_base="/sys/bus/coresight/devices"
+fail=0
+
+if [ ! -d "$cs_base" ]; then
+    log_warn "Coresight directory $cs_base not found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+cleanup() {
+    reset_coresight
+}
+trap cleanup EXIT HUP INT TERM
+
+reset_coresight
+sinks=""
+sources=""
+for node in "$cs_base"/*; do
+    [ ! -d "$node" ] && continue
+    node_name=$(basename "$node")
+    
+    if [ -f "$node/enable_sink" ]; then
+        [ "$node_name" = "tmc_etf1" ] && continue
+        sinks="$sinks $node"
+        
+        if [ -f "$node/out_mode" ]; then
+            echo mem > "$node/out_mode" 2>/dev/null || true
+        fi
+    fi
+    
+    if [ -f "$node/enable_source" ]; then
+        sources="$sources $node"
+    fi
+done
+
+sinks=${sinks# }
+sources=${sources# }
+if [ -z "$sinks" ]; then
+    log_warn "No Coresight sinks found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+if [ -z "$sources" ]; then
+    log_warn "No Coresight sources found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+i=0
+while [ "$i" -le 2 ]; do
+    log_info "Starting iteration: $((i+1))" 
+    for sink_node in $sinks; do
+        sink_dev=$(basename "$sink_node")
+        log_info "Sink Active:- $sink_dev"
+        
+        for source_node in $sources; do
+            dev_name=$(basename "$source_node")
+            
+            case "$dev_name" in
+                *etm*)
+                    if [ "$no_remote_etm" -eq 1 ]; then
+                        continue
+                    fi
+                    ;;
+                *tpdm-vsense* | *tpdm-qm*)
+                    continue
+                    ;;
+            esac      
+            reset_coresight
+            
+            [ -f "$sink_node/enable_sink" ] && echo 1 > "$sink_node/enable_sink" 2>/dev/null
+            if [ -f "$source_node/enable_source" ]; then
+                echo 1 > "$source_node/enable_source" 2>/dev/null
+                ret=$(tr -d ' ' < "$source_node/enable_source")
+                if [ "$ret" = "0" ]; then
+                    log_fail "FAIL: enable source in $dev_name"
+                    fail=1
+                    continue
+                fi
+            fi          
+            sleep 1
+            reset_coresight
+            
+            rm -f "/tmp/$sink_dev.bin"
+            if [ -c "/dev/$sink_dev" ]; then
+                cat "/dev/$sink_dev" > "/tmp/$sink_dev.bin" 2>/dev/null
+                outfilesize=$(wc -c < "/tmp/$sink_dev.bin" 2>/dev/null | tr -d ' ')
+            else
+                log_warn "Character device /dev/$sink_dev not found! Skipping read."
+                outfilesize=0
+            fi
+            
+            if [ -n "$outfilesize" ] && [ "$outfilesize" -ge 64 ]; then
+                log_info "Source: $dev_name with trace captured of size $outfilesize bytes"
+            else
+                log_fail "Source: $dev_name with no traces captured of size ${outfilesize:-0}"
+                fail=1
+            fi
+        done
+    done
+    i=$((i + 1))
+done
+reset_coresight
+
+for source_node in $sources; do
+    dev_name=$(basename "$source_node")
+    if [ -f "$source_node/enable_source" ]; then
+        ret=$(tr -d ' ' < "$source_node/enable_source")
+        if [ "$ret" = "1" ]; then
+            log_fail "fail to disable source in $dev_name during final verification"
+            fail=1
+        fi
+    fi
+done
+
+if [ "$fail" -eq 0 ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+fi
+
+log_info "---------------------------$TESTNAME Finished---------------------------" 

--- a/Runner/utils/coresight_helper.sh
+++ b/Runner/utils/coresight_helper.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+cs_base="${cs_base:-/sys/bus/coresight/devices}"
+
+reset_coresight() {
+    [ ! -d "$cs_base" ] && return 0
+
+    for node in "$cs_base"/*; do
+        [ ! -d "$node" ] && continue
+
+        if [ -f "$node/enable_source" ]; then
+            echo 0 > "$node/enable_source" 2>/dev/null || true
+        fi
+
+        if [ -f "$node/enable_sink" ]; then
+            echo 0 > "$node/enable_sink" 2>/dev/null || true
+        fi
+    done
+}
+
+check_sink_status() {
+    _fail=0
+
+    for _sink in "$@"; do
+        [ ! -f "$_sink/enable_sink" ] && continue
+
+        status=$(tr -d ' \n' < "$_sink/enable_sink" 2>/dev/null)
+
+        if [ "$status" = "1" ]; then
+            echo "[ERROR] Sink still enabled after reset: $(basename "$_sink")" >&2
+            _fail=1
+        fi
+    done
+
+    return $_fail
+}

--- a/Runner/utils/coresight_helper.sh
+++ b/Runner/utils/coresight_helper.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+export CS_BASE="/sys/bus/coresight/devices"
+cs_base="${cs_base:-/sys/bus/coresight/devices}"
+
+find_path() {
+    for _dir_name in "$@"; do
+        if [ -d "$CS_BASE/$_dir_name" ]; then
+            echo "$CS_BASE/$_dir_name"
+            return 0
+        fi
+    done
+    echo ""
+}
+
+reset_coresight() {
+    [ ! -d "$cs_base" ] && return 0
+
+    for node in "$cs_base"/*; do
+        [ ! -d "$node" ] && continue
+
+        if [ -f "$node/enable_source" ]; then
+            echo 0 > "$node/enable_source" 2>/dev/null || true
+        fi
+
+        if [ -f "$node/enable_sink" ]; then
+            echo 0 > "$node/enable_sink" 2>/dev/null || true
+        fi
+    done
+}
+
+# Alias to support scripts from PR 370 that use reset_devices
+reset_devices() {
+    reset_coresight
+}
+
+check_sink_status() {
+    _fail=0
+
+    for _sink in "$@"; do
+        [ ! -f "$_sink/enable_sink" ] && continue
+
+        status=$(tr -d ' \n' < "$_sink/enable_sink" 2>/dev/null)
+
+        if [ "$status" = "1" ]; then
+            echo "[ERROR] Sink still enabled after reset: $(basename "$_sink")" >&2
+            _fail=1
+        fi
+    done
+
+    return $_fail
+}
+
+enable_npu_clocks() {
+    if [ -f "/sys/kernel/debug/npu/ctrl" ]; then
+        echo on > "/sys/kernel/debug/npu/ctrl" 2>/dev/null
+    elif [ -f "/d/npu/ctrl" ]; then
+        echo on > "/d/npu/ctrl" 2>/dev/null
+    fi
+}
+
+disable_npu_clocks() {
+    if [ -f "/sys/kernel/debug/npu/ctrl" ]; then
+        echo off > "/sys/kernel/debug/npu/ctrl" 2>/dev/null
+    elif [ -f "/d/npu/ctrl" ]; then
+        echo off > "/d/npu/ctrl" 2>/dev/null
+    fi
+}


### PR DESCRIPTION
- Coresight-Sink-Source-Test: Validate trace capture across all CoreSight source and sink combinations by enabling sources, routing to sinks, and verifying collected trace data.

Also a common library helper function coresight_helper.sh is added to prevent duplication of code blocks.