### PR TITLE
Added coresight reset all and random sinks scripts

### DIFF
--- a/Runner/suites/Kernel/DEBUG/Reset-All-Sinks-Base/README.md
+++ b/Runner/suites/Kernel/DEBUG/Reset-All-Sinks-Base/README.md
@@ -1,0 +1,87 @@
+# Reset-All-Sinks-Base Test
+
+## Overview
+The `Reset-All-Sinks-Base` test case validates the correctness and robustness of CoreSight reset logic when multiple trace sinks are enabled simultaneously.
+
+## Test Goals
+
+- Validate correct reset behavior with multiple active sinks.
+- Ensure stress‑test reset robustness across multiple sink combinations.
+- Verify post‑reset trace functionality.
+
+## Prerequisites
+
+- Coresight framework enabled in the kernel
+- Multiple Coresight sink devices should be present
+- Coresight STM and ETM device nodes for post-test data generation
+
+## Script Location
+
+```
+Runner/suites/Kernel/DEBUG/Reset-All-Sinks-Base/run.sh
+```
+
+## Files
+
+- `run.sh` - Main test script
+- `Reset-All-Sinks-Base.res` - Summary result file with PASS/FAIL
+- `Reset-All-Sinks-Base.log` - Full execution log.
+
+## How it works
+1. Discovers standard coresight sink devices (excluding tmc_etf1)
+2. Loops for a configured number of iterations (default 1000)
+3. Iterates through all paired combinations of available sinks
+4. Enables both sinks simultaneously, issues a global reset, and validates that neither remains active
+5. Performs a final read verification of an active source via tmc_etf0/tmc_etf to confirm system trace flow functionality
+
+## Usage
+
+Run the script directly. No iterations or special arguments are required for this basic test.
+
+```bash
+./run.sh
+
+./run.sh [no. of iterations]
+```
+
+## Example Output
+
+```
+[INFO] 2026-03-26 09:44:07 - ----------------------------------------------------
+[INFO] 2026-03-26 09:44:07 - -----Reset All Sinks Base Starting-----
+[INFO] 2026-03-26 09:44:08 - Discovered Sinks (3): tmc_etf0 tmc_etr0 tmc_etr1
+[INFO] 2026-03-26 09:44:08 - Discovered STM: stm0
+[INFO] 2026-03-26 09:44:08 - Discovered ETM: etm0
+[INFO] 2026-03-26 09:44:08 - starting reset sinks stress test for 1000 iterations...
+[INFO] 2026-03-26 09:44:08 - stress test running loop: 0
+[INFO] 2026-03-26 09:44:08 - stress test running loop: 1
+[INFO] 2026-03-26 09:44:08 - stress test running loop: 2
+.........
+[INFO] 2026-03-26 09:44:57 - stress test running loop: 998
+[INFO] 2026-03-26 09:44:57 - stress test running loop: 999
+[INFO] 2026-03-26 09:44:57 - Starting post-stress trace capture verification...
+[INFO] 2026-03-26 09:44:57 - enabled dynamic STM source
+[INFO] 2026-03-26 09:44:57 - enabled dynamic ETM source
+[PASS] 2026-03-26 09:44:58 - -----Reset All Sinks Base PASS-----
+[INFO] 2026-03-26 09:44:58 - -------------------Reset-All-Sinks-Base Testcase Finished----------------------------
+```
+
+## Return Code
+
+- `0` — All stress test cases passed
+- `1` — One or more stress test cases failed
+
+## Integration in CI
+
+- Can be run standalone or via LAVA
+- Result file `Reset-All-Sinks-Base.res` will be parsed by `result_parse.sh`
+
+## Notes
+
+- the test with 1000 default iterations heavily exercises reset paths to catch intermittent or timing‑sensitive failures..
+- The test will stop and flag a failure as soon as any sink remains enabled after reset, ensuring strict correctness.
+
+## License
+
+SPDX-License-Identifier: BSD-3-Clause.
+(c) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/DEBUG/Reset-All-Sinks-Base/Reset_All_Sinks_Base.yaml
+++ b/Runner/suites/Kernel/DEBUG/Reset-All-Sinks-Base/Reset_All_Sinks_Base.yaml
@@ -1,0 +1,16 @@
+metadata:
+  name: Reset-All-Sinks-Base
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validates the correctness and robustness of CoreSight reset logic when multiple trace sinks are enabled simultaneously. "
+  os:
+    - linux
+  scope:
+    - coresight
+    - kernel
+
+run:
+  steps:
+    - REPO_PATH=$PWD || true
+    - cd Runner/suites/Kernel/DEBUG/Reset-All-Sinks-Base || true
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Reset-All-Sinks-Base.res || true

--- a/Runner/suites/Kernel/DEBUG/Reset-All-Sinks-Base/run.sh
+++ b/Runner/suites/Kernel/DEBUG/Reset-All-Sinks-Base/run.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/coresight_helper.sh"
+
+TESTNAME="Reset-All-Sinks-Base"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+log_info "---------------------------$TESTNAME Starting---------------------------"
+
+cs_base="/sys/bus/coresight/devices"
+debugfs="/sys/kernel/debug"
+[ ! -d "$debugfs/tracing" ] && debugfs="/debug"
+
+if [ ! -d "$cs_base" ]; then
+    log_warn "Coresight directory not found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+trap cleanup EXIT HUP INT TERM
+
+reset_coresight
+
+runs=${1:-1000}
+
+sinks=""
+sink_count=0
+for node in "$cs_base"/*; do
+    [ ! -d "$node" ] && continue
+    [ "$(basename "$node")" = "tmc_etf1" ] && continue
+
+    if [ -f "$node/enable_sink" ]; then
+        sinks="$sinks $node"
+        sink_count=$((sink_count + 1))
+    fi
+done
+sinks="${sinks# }"
+
+if [ "$sink_count" -lt 2 ]; then
+    log_warn "Need at least 2 Coresight sinks for multiple sink reset test. Found $sink_count. Skipping."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+stm=""
+for node in "$cs_base"/stm*; do
+    if [ -d "$node" ] && [ -f "$node/enable_source" ]; then
+        stm="$node"
+        break
+    fi
+done
+
+etm=""
+for node in "$cs_base"/etm*; do
+    if [ -d "$node" ] && [ -f "$node/enable_source" ]; then
+        etm="$node"
+        break
+    fi
+done
+
+if [ -z "$stm" ] && [ -z "$etm" ]; then
+    log_warn "No STM or ETM sources found. Cannot generate trace data. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+log_info "Discovered Sinks ($sink_count): $(for s in $sinks; do basename "$s"; done | tr '\n' ' ')"
+[ -n "$stm" ] && log_info "Discovered STM: $(basename "$stm")"
+[ -n "$etm" ] && log_info "Discovered ETM: $(basename "$etm")"
+
+# shellcheck disable=SC2086
+set -- $sinks
+
+fail=0
+case "$1" in
+    ''|*[!0-9]*) ;;
+    *) runs=$1 ;;
+esac
+log_info "starting reset sinks stress test for $runs iterations..."
+
+i=0
+while [ "$i" -lt "$runs" ] && [ "$fail" -eq 0 ]; do
+    log_info "stress test running loop: $i"
+    
+    while [ "$#" -gt 1 ] && [ "$fail" -eq 0 ]; do
+        sink1="$1"
+        shift
+
+        for sink2 in "$@"; do
+            if [ "$fail" -ne 0 ]; then
+                break
+            fi
+
+            if [ -f "$sink1/enable_sink" ]; then
+                echo 1 > "$sink1/enable_sink" 2>/dev/null
+            fi
+
+            if [ -f "$sink2/enable_sink" ]; then
+                echo 1 > "$sink2/enable_sink" 2>/dev/null
+            fi
+
+            reset_coresight
+            
+# shellcheck disable=SC2086
+            if ! check_sink_status $sinks; then
+                log_fail "FAIL: reset multiple sinks at loop $i (failed on sinks: $(basename "$sink1"), $(basename "$sink2"))"
+                fail=1
+                break
+            fi
+        done
+    done
+
+    i=$((i + 1))
+done
+
+if [ "$fail" -eq 0 ]; then
+    log_info "Starting post-stress trace capture verification..."
+    
+    verify_sink=""
+    verify_dev=""
+    for s in $sinks; do
+        s_name=$(basename "$s")
+        if [ -c "/dev/$s_name" ]; then
+            verify_sink="$s"
+            verify_dev="/dev/$s_name"
+            break
+        fi
+    done
+
+    if [ -z "$verify_sink" ]; then
+        log_warn "No valid /dev node found for any sink. Cannot verify read, but reset test passed."
+    else      
+        reset_coresight
+
+        [ -f "$verify_sink/enable_sink" ] && echo 1 > "$verify_sink/enable_sink" 2>/dev/null
+        [ -f "$debugfs/tracing/events/enable" ] && echo 0 > "$debugfs/tracing/events/enable" 2>/dev/null
+
+        if [ -n "$stm" ]; then
+            echo 1 > "$stm/enable_source" 2>/dev/null
+            log_info "enabled STM source"
+        fi
+
+        if [ -n "$etm" ]; then
+            echo 1 > "$etm/enable_source" 2>/dev/null
+            log_info "enabled ETM source"
+        fi
+
+        sleep 1
+
+        rm -f "/tmp/verify_sink.bin"
+        if [ -c "$verify_dev" ]; then
+            cat "$verify_dev" > "/tmp/verify_sink.bin" 2>/dev/null
+        fi
+
+        if [ -f "/tmp/verify_sink.bin" ]; then
+            size=$(wc -c < "/tmp/verify_sink.bin" 2>/dev/null || echo 0)
+            size=$(echo "$size" | tr -d ' ')
+            if [ "$size" -lt 64 ]; then
+                fail=1
+            fi
+        else
+            log_fail "verification read FAIL: /tmp/verify_sink.bin missing"
+            fail=1
+        fi
+    fi
+fi
+
+if [ "$fail" -eq 0 ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+fi
+
+log_info "-------------------$TESTNAME Testcase Finished----------------------------"

--- a/Runner/suites/Kernel/DEBUG/Reset-Random-Sinks-Base/README.md
+++ b/Runner/suites/Kernel/DEBUG/Reset-Random-Sinks-Base/README.md
@@ -1,0 +1,88 @@
+# Reset-Random-Sinks-Base
+
+## Overview
+
+This script tests multiple Coresight sinks during a continuous loop. It discovers all available sinks, pairs them up, enables them simultaneously, and ensures that a reset operation safely and completely disables both sinks. A post-stress validation runs a live trace through the STM and ETM nodes to confirm the hardware sink is still functional and returns trace data.
+
+## Test Goals
+
+- Ensure that when two sinks are enabled simultaneously and a reset is triggered, all sinks transition back to a disabled state.
+- Repeatedly perform sink enable and reset operations over multiple iterations to identify stability or intermittent reset issues.
+- Confirm through sysfs that no sink remains enabled after a reset operation, indicating a successful reset.
+- Verify that after extensive reset testing, trace data can still be successfully captured and read from a selected sink. 
+
+## Prerequisites
+
+- Kernel must be built with Coresight support.
+- sysfs access to `/sys/bus/coresight/devices/stm0/`.
+- Multiple Coresight sink devices (`tmc_et*`).
+- Coresight STM and ETM device nodes for post-test data generation.
+- Root privileges.
+
+## Script Location
+
+```
+`Runner/suites/Kernel/DEBUG/Reset-Random-Sinks-Base/run.sh`
+```
+
+## Files
+
+- `run.sh` - Main test script
+- `Reset-Random-Sinks-Base.res` - Summary result file with PASS/FAIL
+- `Reset-Random-Sinks-Base.log` - Full execution log (generated if logging is enabled)
+
+## How It Works
+
+1. Discovers standard coresight sink devices (excluding tmc_etf1)
+2. Loops for a configured number of iterations (default 1000)
+3. Iterates through all paired combinations of available sinks
+4. Enables both sinks simultaneously, issues a global reset, and validates that neither remains active
+5. Performs a final read verification of an active source via tmc_etf0/tmc_etf to confirm system trace flow functionality
+
+## Usage
+
+Run the script directly. No iterations or special arguments are required for this basic test.
+
+```bash
+./run.sh
+
+./run.sh [no. of iterations]
+```
+
+## Example Output
+```
+[INFO] 2026-04-06 07:27:48 - ---------------------------Reset-Random-Sinks-Base Starting---------------------------
+[INFO] 2026-04-06 07:27:48 - Start run reset sinks for 1000 iterations with 3 available sinks
+[INFO] 2026-04-06 07:27:48 - start run reset sinks in loop: 0
+[INFO] 2026-04-06 07:27:48 - start run reset sinks in loop: 1
+[INFO] 2026-04-06 07:27:48 - start run reset sinks in loop: 2
+[INFO] 2026-04-06 07:27:48 - start run reset sinks in loop: 3
+................
+[INFO] 2026-04-06 07:28:28 - start run reset sinks in loop: 997
+[INFO] 2026-04-06 07:28:28 - start run reset sinks in loop: 998
+[INFO] 2026-04-06 07:28:28 - start run reset sinks in loop: 999
+[INFO] 2026-04-06 07:28:28 - Starting post-stress validation...
+[INFO] 2026-04-06 07:28:28 - Using sink: tmc_etf0 and source: etm0 for verification.
+[INFO] 2026-04-06 07:28:29 - Post-stress read successful (size 65536 bytes).
+[INFO] 2026-04-06 07:28:29 - -------------------Reset-Random-Sinks-Base Testcase Finished----------------------------
+```
+
+## Return Code
+
+- `0` — All the sinks were enabled and reset successfully.
+- `1` — One or more sink reset failed.
+
+## Integration in CI
+
+- Can be run standalone or via LAVA
+- Result file `Reset-Random-Sinks-Base.res` will be parsed by `result_parse.sh`
+
+## Notes
+
+- The test enables sink pairs in nested loops to ensure wide range of coverage of sink combinations during reset testing.
+- A final functional check reads trace output from a CoreSight Sink to ensure reset operations have not affected normal trace behavior.
+
+## License
+
+SPDX-License-Identifier: BSD-3-Clause
+(c) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/DEBUG/Reset-Random-Sinks-Base/Reset_Random_Sinks_Base.yaml
+++ b/Runner/suites/Kernel/DEBUG/Reset-Random-Sinks-Base/Reset_Random_Sinks_Base.yaml
@@ -1,0 +1,16 @@
+metadata:
+  name: STM-HWEvent-Port-Enable-Disable
+  format: "Lava-Test Test Definition 1.0"
+  description: "This script validates multiple coresight sinks reset by simultaneously enabling pairs of sinks and verifying reset robustness."
+  os:
+    - linux
+  scope:
+    - coresight
+    - kernel
+
+run:
+  steps:
+    - REPO_PATH=$PWD || true
+    - cd Runner/suites/Kernel/DEBUG/Reset-Random-Sinks-Base || true
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Reset-Random-Sinks-Base.res || true

--- a/Runner/suites/Kernel/DEBUG/Reset-Random-Sinks-Base/run.sh
+++ b/Runner/suites/Kernel/DEBUG/Reset-Random-Sinks-Base/run.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/coresight_helper.sh"
+
+TESTNAME="Reset-Random-Sinks-Base"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+log_info "---------------------------$TESTNAME Starting---------------------------"
+
+cs_base="/sys/bus/coresight/devices"
+debugfs="/sys/kernel/debug"
+[ ! -d "$debugfs/tracing" ] && debugfs="/debug"
+
+fail=0
+
+if [ ! -d "$cs_base" ]; then
+    log_warn "Coresight directory $cs_base not found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+trap cleanup EXIT HUP INT TERM
+
+reset_source_sink
+
+sink_list=""
+sink_cnt=0
+
+for sink in "$cs_base"/*; do
+    [ ! -d "$sink" ] && continue
+    [ "$(basename "$sink")" = "tmc_etf1" ] && continue
+    
+    if [ -f "$sink/enable_sink" ]; then
+        sink_list="$sink_list $sink"
+        sink_cnt=$((sink_cnt + 1))
+    fi
+done
+
+sink_list=${sink_list# }
+
+if [ "$sink_cnt" -lt 2 ]; then
+    log_warn "Found less than 2 valid sinks ($sink_cnt). Cannot run multiple sink reset test. Skipping."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+runs=${1:-1000}
+case "$1" in
+    ''|*[!0-9]*) ;;
+    *) runs=$1 ;;
+esac
+log_info "Start run reset sinks for $runs iterations with $sink_cnt available sinks"
+i=0
+while [ "$i" -lt "$runs" ] && [ "$fail" -eq 0 ]; do
+    
+    log_info "start run reset sinks in loop: $i"
+    
+    for sink1 in $sink_list; do
+        [ "$fail" -eq 1 ] && break
+        
+        found_sink1=0
+        for sink2 in $sink_list; do
+            [ "$fail" -eq 1 ] && break
+            
+            if [ "$sink1" = "$sink2" ]; then
+                found_sink1=1
+                continue
+            fi
+            [ "$found_sink1" -eq 0 ] && continue
+            
+            echo 1 > "$sink1/enable_sink" 2>/dev/null
+            echo 1 > "$sink2/enable_sink" 2>/dev/null
+            
+            reset_source_sink
+            
+            if ! check_sink_status; then
+                log_fail "FAIL: reset multiple sinks (failed on loop $i for $(basename "$sink1") & $(basename "$sink2"))"
+                fail=1
+                break
+            fi
+        done
+    done
+    i=$((i+1))
+done
+
+log_info "Starting post-stress validation..."
+
+sink_path=""
+sink_base=""
+for sink in $sink_list; do
+    base_sink=$(basename "$sink")
+    if [ -c "/dev/$base_sink" ]; then
+        sink_path="$sink"
+        sink_base="$base_sink"
+        break
+    fi
+done
+
+src_path=""
+for src in "$cs_base"/*; do
+    [ ! -d "$src" ] && continue
+    if [ -f "$src/enable_source" ]; then
+        src_path="$src"
+        break
+    fi
+done
+
+if [ -z "$sink_path" ]; then
+    log_warn "No valid sink with a /dev/ node found for post-stress verification. Skipping verification."
+elif [ -z "$src_path" ]; then
+    log_warn "No valid source found for post-stress verification. Skipping verification."
+elif [ "$fail" -eq 0 ]; then
+    log_info "Using sink: $sink_base and source: $(basename "$src_path") for verification."
+    
+    echo 1 > "$sink_path/enable_sink" 2>/dev/null
+    echo 1 > "$src_path/enable_source" 2>/dev/null
+    
+    sleep 1
+    
+    echo 0 > "$src_path/enable_source" 2>/dev/null
+    
+    trace_file="/tmp/${sink_base}_stress.bin"
+    rm -f "$trace_file"
+    
+    cat "/dev/$sink_base" > "$trace_file" 2>/dev/null
+    
+    if [ -f "$trace_file" ]; then
+        size=$(wc -c < "$trace_file" 2>/dev/null || echo 0)
+        size=$(echo "$size" | tr -d ' ')
+        
+        if [ "$size" -lt 64 ]; then
+            log_fail "etr/etf read FAIL after sink reset stress test (size $size < 64)"
+            fail=1
+        else
+            log_info "Post-stress read successful (size $size bytes)."
+        fi
+    else
+        log_fail "etr/etf read FAIL: $trace_file missing"
+        fail=1
+    fi
+    
+    echo 0 > "$sink_path/enable_sink" 2>/dev/null
+fi
+
+if [ "$fail" -eq 0 ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+fi
+
+log_info "-------------------$TESTNAME Testcase Finished----------------------------"


### PR DESCRIPTION
- Reset-All-Sinks-Base: Stress test simultaneous reset of multiple CoreSight sinks and ensure all sinks reliably disable and recover for trace capture.

- Reset-Random-Sinks-Base: Randomly enable and reset multiple CoreSight sinks under stress and validate sink disable behavior and post-reset trace functionality.

Dependency PR: This PR depends on PR #389 and should be merged after it.