### PR TITLE
Added single sink reset scripts

### DIFF
--- a/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/README.md
+++ b/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/README.md
@@ -1,0 +1,93 @@
+# Single-Sink-Reset-Base
+
+## Overview
+
+Thie `Single-Sink-Reset-Base` test validates CoreSight sink reset behavior while STM/ETM sources are actively generating trace data. It ensures all sinks properly reset and trace capture remains functional after repeated reset operations.
+
+## Test Goals
+
+- Ensure CoreSight sinks can be safely reset while STM or ETM sources are actively generating trace data.
+- Repeatedly perform sink enable, source enable, and reset operations across numerous iterations to expose timing or stability issues.
+- Verify through sysfs that no CoreSight sink remains enabled after a reset, even when the reset occurs during active tracing.
+- Validate that trace data can still be captured and read from an ETF sink after extensive sink reset operations.
+
+## Prerequisites
+
+- Kernel must be built with Coresight support.
+- sysfs access to `/sys/bus/coresight/devices/stm0/`.
+- Multiple Coresight sink devices (`tmc_et*`).
+- Coresight STM and ETM device nodes for post-test data generation.
+- Root privileges.
+
+## Script Location
+
+```
+`Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/run.sh`
+```
+
+## Files
+
+- `run.sh` - Main test script
+- `Single-Sink-Reset-Base.res` - Summary result file with PASS/FAIL
+- `Single-Sink-Reset-Base.log` - Full execution log (generated if logging is enabled)
+
+## How It Works
+
+1. Initialize the CoreSight hardware by disabling all sources and sinks globally.
+2. **Stress Loop (default 250 iterations)**:
+   - For every available CoreSight sink (excluding `tmc_etf1`):
+     - Enable the target sink.
+     - Enable the active source (STM).
+     - Trigger `reset_source_sink` while data is flowing.
+     - Assert that the sink registers correctly as disabled (`enable_sink` == 0).
+3. **Validation Phase**:
+   - Re-enable `tmc_etf0` (sink) and `etm0` (source).
+   - Dump standard character data directly from the ETF devnode.
+   - Fail if the dump yields less than 64 bytes of output, indicating a damaged trace path.
+
+## Usage
+
+Run the script directly. An optional numeric argument specifies loop iterations (default 250):
+
+```bash
+./run.sh 
+
+./run.sh [no. of iterations]
+```
+
+## Example Output
+```
+[INFO] 2026-04-06 09:29:06 - ------------------------Single-Sink-Reset-Base Starting------------------------
+[INFO] 2026-04-06 09:29:07 - Starting sink reset test for 250 iterations...
+[INFO] 2026-04-06 09:29:07 - Stress test running loop: 0
+[INFO] 2026-04-06 09:29:10 - Stress test running loop: 1
+[INFO] 2026-04-06 09:29:13 - Stress test running loop: 2
+[INFO] 2026-04-06 09:29:16 - Stress test running loop: 3
+..............
+[INFO] 2026-04-06 09:41:47 - Stress test running loop: 247
+[INFO] 2026-04-06 09:41:50 - Stress test running loop: 248
+[INFO] 2026-04-06 09:41:53 - Stress test running loop: 249
+[INFO] 2026-04-06 09:41:57 - Starting reset_sink functionality check by reading from tmc_etf0 using source etm0.
+[PASS] 2026-04-06 09:42:02 - PASS: sink reset during active source
+[INFO] 2026-04-06 09:42:02 - ------------------------Single-Sink-Reset-Base Finished------------------------
+```
+
+## Return Code
+
+- `0` — All the sinks were enabled and reset successfully.
+- `1` — One or more sink reset failed.
+
+## Integration in CI
+
+- Can be run standalone or via LAVA
+- Result file `Single-Sink-Reset-Base.res` will be parsed by `result_parse.sh`
+
+## Notes
+
+- Each sink is tested individually while the trace source is active to isolate reset behavior per sink.
+- A final ETF read check confirms that reset stress testing does not corrupt or disable normal trace data output.
+
+## License
+
+SPDX-License-Identifier: BSD-3-Clause
+(c) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/Single-Sink-Reset-Base.yaml
+++ b/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/Single-Sink-Reset-Base.yaml
@@ -1,0 +1,16 @@
+metadata:
+  name: STM-HWEvent-Port-Enable-Disable
+  format: "Lava-Test Test Definition 1.0"
+  description: "This test validates CoreSight sink reset behavior while STM/ETM sources are actively generating trace data."
+  os:
+    - linux
+  scope:
+    - coresight
+    - kernel
+
+run:
+  steps:
+    - REPO_PATH=$PWD || true
+    - cd Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base || true
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Single-Sink-Reset-Base.res || true

--- a/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/run.sh
+++ b/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/run.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/coresight_helper.sh"
+
+TESTNAME="Single-Sink-Reset-Base"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+log_info "------------------------$TESTNAME Starting------------------------"
+
+cs_base="/sys/bus/coresight/devices"
+debugfs="/sys/kernel/debug"
+[ ! -d "$debugfs/tracing" ] && debugfs="/debug"
+
+fail=0
+
+if [ ! -d "$cs_base" ]; then
+    log_warn "Coresight directory $cs_base not found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+trap cleanup EXIT HUP INT TERM
+
+reset_coresight
+[ -f "$debugfs/tracing/events/enable" ] && echo 0 > "$debugfs/tracing/events/enable" 2>/dev/null
+
+
+sink_list=""
+for sink_node in "$cs_base"/*; do
+    [ ! -d "$sink_node" ] && continue
+    [ "$(basename "$sink_node")" = "tmc_etf1" ] && continue
+    
+    if [ -f "$sink_node/enable_sink" ]; then
+        sink_list="$sink_list $sink_node"
+    fi
+done
+sink_list=${sink_list# }
+
+if [ -z "$sink_list" ]; then
+    log_warn "No Coresight sinks found. Cannot run test. Skipping."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+source=""
+for node in "$cs_base"/stm*; do
+    if [ -d "$node" ] && [ -f "$node/enable_source" ]; then
+        source="$node"
+        break
+    fi
+done
+
+verify_source=""
+for node in "$cs_base"/etm*; do
+    if [ -d "$node" ] && [ -f "$node/enable_source" ]; then
+        verify_source="$node"
+        break
+    fi
+done
+
+[ -z "$source" ] && source="$verify_source"
+[ -z "$verify_source" ] && verify_source="$source"
+
+if [ -z "$source" ]; then
+    log_warn "No Coresight sources (STM/ETM) found. Cannot run active-source stress test. Skipping."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+runs=${1:-250}
+case "$1" in
+    ''|*[!0-9]*) ;;
+    *) runs=$1 ;;
+esac
+
+log_info "Starting sink reset test for $runs iterations..."
+
+i=0
+while [ "$i" -lt "$runs" ] && [ "$fail" -eq 0 ]; do
+    [ $((i % 25)) -eq 0 ] && log_info "Stress test running loop: $i"
+    
+    for sink in $sink_list; do
+        reset_coresight
+        
+        [ -f "$sink/enable_sink" ] && echo 1 > "$sink/enable_sink" 2>/dev/null
+        [ -f "$source/enable_source" ] && echo 1 > "$source/enable_source" 2>/dev/null
+        
+        sleep 1
+        
+        reset_coresight
+        
+        if ! check_sink_status; then
+            log_fail "FAIL: reset_coresight failed to disable sink during active source at loop $i"
+            fail=1
+            break
+        fi
+    done
+    i=$((i + 1))
+done
+
+verify_sink=""
+for sink in $sink_list; do
+    sink_name=$(basename "$sink")
+    if [ -c "/dev/$sink_name" ]; then
+        verify_sink="$sink"
+        break
+    fi
+done
+
+if [ -z "$verify_sink" ]; then
+    log_info "No valid character device found in /dev/ for verification. Skipping read check."
+else
+    sink_name=$(basename "$verify_sink")
+    log_info "Starting reset_sink functionality check by reading from $sink_name using source $(basename "$verify_source")."
+    
+    reset_coresight
+    [ -f "$verify_sink/enable_sink" ] && echo 1 > "$verify_sink/enable_sink" 2>/dev/null
+    [ -f "$verify_source/enable_source" ] && echo 1 > "$verify_source/enable_source" 2>/dev/null
+    
+    sleep 5
+    
+    [ -f "$verify_source/enable_source" ] && echo 0 > "$verify_source/enable_source" 2>/dev/null
+    
+    rm -f "/tmp/${sink_name}.bin"
+    cat "/dev/$sink_name" > "/tmp/${sink_name}.bin" 2>/dev/null
+    
+    if [ ! -f "/tmp/${sink_name}.bin" ]; then
+        log_fail "Sink read FAIL after stress test (file missing)"
+        fail=1
+    else
+        size=$(wc -c < "/tmp/${sink_name}.bin" 2>/dev/null || echo 0)
+        size=$(echo "$size" | tr -d ' ')
+        
+        if [ "$size" -lt 64 ]; then
+            log_fail "Sink read FAIL after stress test (size $size < 64 bytes)"
+            fail=1
+        fi
+    fi
+fi
+
+reset_coresight
+
+if [ "$fail" -eq 0 ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+fi
+
+log_info "------------------------$TESTNAME Finished------------------------"

--- a/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/run.sh
+++ b/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Base/run.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/coresight_helper.sh"
+
+TESTNAME="Single-Sink-Reset-Base"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+log_info "------------------------$TESTNAME Starting------------------------"
+
+cs_base="/sys/bus/coresight/devices"
+debugfs="/sys/kernel/debug"
+[ ! -d "$debugfs/tracing" ] && debugfs="/debug"
+
+fail=0
+
+if [ ! -d "$cs_base" ]; then
+    log_warn "Coresight directory $cs_base not found. Skipping test."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+trap cleanup EXIT HUP INT TERM
+
+reset_coresight
+[ -f "$debugfs/tracing/events/enable" ] && echo 0 > "$debugfs/tracing/events/enable" 2>/dev/null
+
+
+sink_list=""
+for sink_node in "$cs_base"/*; do
+    [ ! -d "$sink_node" ] && continue
+    [ "$(basename "$sink_node")" = "tmc_etf1" ] && continue
+    
+    if [ -f "$sink_node/enable_sink" ]; then
+        sink_list="$sink_list $sink_node"
+    fi
+done
+sink_list=${sink_list# }
+
+if [ -z "$sink_list" ]; then
+    log_warn "No Coresight sinks found. Cannot run test. Skipping."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+source=""
+for node in "$cs_base"/stm*; do
+    if [ -d "$node" ] && [ -f "$node/enable_source" ]; then
+        source="$node"
+        break
+    fi
+done
+
+verify_source=""
+for node in "$cs_base"/etm*; do
+    if [ -d "$node" ] && [ -f "$node/enable_source" ]; then
+        verify_source="$node"
+        break
+    fi
+done
+
+[ -z "$source" ] && source="$verify_source"
+[ -z "$verify_source" ] && verify_source="$source"
+
+if [ -z "$source" ]; then
+    log_warn "No Coresight sources (STM/ETM) found. Cannot run active-source stress test. Skipping."
+    echo "$TESTNAME SKIP" > "$res_file"
+    exit 0
+fi
+
+runs=${1:-250}
+case "$1" in
+    ''|*[!0-9]*) ;;
+    *) runs=$1 ;;
+esac
+
+log_info "Starting sink reset test for $runs iterations..."
+
+i=0
+while [ "$i" -lt "$runs" ] && [ "$fail" -eq 0 ]; do
+    [ $((i % 25)) -eq 0 ] && log_info "Stress test running loop: $i"
+    
+    for sink in $sink_list; do
+        reset_coresight
+        
+        [ -f "$sink/enable_sink" ] && echo 1 > "$sink/enable_sink" 2>/dev/null
+        [ -f "$source/enable_source" ] && echo 1 > "$source/enable_source" 2>/dev/null
+        
+        sleep 1
+        
+        reset_coresight
+        
+        if ! check_sink_status; then
+            log_fail "FAIL: reset_coresight failed to disable sink during active source at loop $i"
+            fail=1
+            break
+        fi
+    done
+    i=$((i + 1))
+done
+
+verify_sink=""
+for sink in $sink_list; do
+    sink_name=$(basename "$sink")
+    if [ -c "/dev/$sink_name" ]; then
+        verify_sink="$sink"
+        break
+    fi
+done
+
+if [ -z "$verify_sink" ]; then
+    log_info "No valid character device found in /dev/ for verification. Skipping read check."
+else
+    sink_name=$(basename "$verify_sink")
+    log_info "Starting reset_sink functionality check by reading from $sink_name using source $(basename "$verify_source")."
+    
+    reset_coresight
+    [ -f "$verify_sink/enable_sink" ] && echo 1 > "$verify_sink/enable_sink" 2>/dev/null
+    [ -f "$verify_source/enable_source" ] && echo 1 > "$verify_source/enable_source" 2>/dev/null
+    
+    sleep 5
+    
+    [ -f "$verify_source/enable_source" ] && echo 0 > "$verify_source/enable_source" 2>/dev/null
+    
+    rm -f "/tmp/${sink_name}.bin"
+    cat "/dev/$sink_name" > "/tmp/${sink_name}.bin" 2>/dev/null
+    
+    if [ ! -f "/tmp/${sink_name}.bin" ]; then
+        log_fail "Sink read FAIL after stress test (file missing)"
+        fail=1
+    else
+        size=$(wc -c < "/tmp/${sink_name}.bin" 2>/dev/null || echo 0)
+        size=$(echo "$size" | tr -d ' ')
+        
+        if [ "$size" -lt 64 ]; then
+            log_fail "Sink read FAIL after stress test (size $size < 64 bytes)"
+            fail=1
+        fi
+    fi
+fi
+
+reset_coresight
+
+if [ "$fail" -eq 0 ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+fi
+
+log_info "------------------------$TESTNAME Finished------------------------" 

--- a/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/README.md
+++ b/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/README.md
@@ -1,0 +1,86 @@
+# Single Sink Reset Connected Base Test
+
+## Overview
+The `Single-Sink-Reset-Connected-Base` test case validates the robustness of CoreSight sinks when a reset occurs while trace sources are actively streaming data, specifically targeting STM/ETM writing into TMC sinks (ETR/ETF).
+
+## Test Goals
+
+- Validate correct sink reset behavior during active tracing.
+- Ensure stress‑test sink and source reset stability under repeated cycles.
+- Verify post‑reset sink functionality and data integrity.
+
+## Prerequisites
+
+- Coresight drivers must be loaded.
+- STM and TMC devices must be present in `/sys/bus/coresight/devices`.
+- Debugfs must be mounted to access tracing events if necessary.
+
+## Script Location
+
+```
+Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/run.sh
+```
+
+## Files
+
+- `run.sh` - Main test script
+- `Single-Sink-Reset-Connected-Base.res` - Summary result file with PASS/FAIL
+- `Single-Sink-Reset-Connected-Base.log` - Full execution log.
+
+## How it works
+1. Initialize the environment and disable any existing hardware events or tracing.
+2. Loop for a specified number of iterations (default 250):
+    - Iterate through all available TMC sinks (excluding `tmc_etf1`).
+    - Enable the sink and the STM source.
+    - Wait for 1 second of active trace generation.
+    - Trigger a global `reset_source_sink`.
+    - Verify that the sink's `enable_sink` node successfully returned to 0.
+3. After the loop, perform a functional check by enabling a sink and source for 5 seconds.
+4. Read data from `/dev/tmc_etf0`.
+
+## Usage
+
+Run the script directly. No iterations or special arguments are required for this basic test.
+
+```bash
+./run.sh
+```
+
+## Example Output
+
+```
+[INFO] 2026-03-26 06:57:16 - --------------------------------------------------
+[INFO] 2026-03-26 06:57:16 - -----Single Sink Reset Connected Base-----
+[INFO] 2026-03-26 06:57:17 - Running sink reset stress test for 250 iterations...
+[INFO] 2026-03-26 06:57:17 - Sink reset running loop: 0 / 250
+[INFO] 2026-03-26 06:57:18 - PASS: reset_source_sink successful for /sys/bus/coresight/devices/tmc_etf0
+[INFO] 2026-03-26 06:57:19 - PASS: reset_source_sink successful for /sys/bus/coresight/devices/tmc_etr0
+[INFO] 2026-03-26 06:57:20 - PASS: reset_source_sink successful for /sys/bus/coresight/devices/tmc_etr1
+.........
+[INFO] 2026-03-26 07:10:06 - Sink reset running loop: 249 / 250
+[INFO] 2026-03-26 07:10:07 - PASS: reset_source_sink successful for /sys/bus/coresight/devices/tmc_etf0
+[INFO] 2026-03-26 07:10:08 - PASS: reset_source_sink successful for /sys/bus/coresight/devices/tmc_etr0
+[INFO] 2026-03-26 07:10:09 - PASS: reset_source_sink successful for /sys/bus/coresight/devices/tmc_etr1
+[PASS] 2026-03-26 07:10:14 - Single-Sink-Reset-Connected-Base Passed
+[INFO] 2026-03-26 07:10:14 - -------------------Single-Sink-Reset-Connected-Base Finished----------------------------
+```
+
+## Return Code
+
+- `0` — The sink behaviour was correct
+- `1` — One or more sinks failed to trace data
+
+## Integration in CI
+
+- Can be run standalone or via LAVA
+- Result file `Single-Sink-Reset-Connected-Base.res` will be parsed by `result_parse.sh`
+
+## Notes
+
+- The test iterates multiple times (default 250 iterations) across all CoreSight ETR sinks.
+- After stress testing it will perform a functional validation by enabling an ETF sink generating trace data and reading from the ETF node, and checking that meaningful data was captured.
+
+## License
+
+SPDX-License-Identifier: BSD-3-Clause.
+(c) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/Single-Sink-Reset-Connected-Base.yaml
+++ b/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/Single-Sink-Reset-Connected-Base.yaml
@@ -1,0 +1,16 @@
+metadata:
+  name: Single-Sink-Reset-Connected-Base
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validates the robustness of CoreSight sinks when a reset occurs while trace sources are actively streaming data, specifically targeting STM/ETM writing into TMC sinks (ETR/ETF)."
+  os:
+    - linux
+  scope:
+    - coresight
+    - kernel
+
+run:
+  steps:
+    - REPO_PATH=$PWD || true
+    - cd Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base || true
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Single-Sink-Reset-Connected-Base.res || true

--- a/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/run.sh
+++ b/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/run.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/coresight_helper.sh"
+
+TESTNAME="Single-Sink-Reset-Connected-Base"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+log_info "------------------------$TESTNAME Starting------------------------"
+
+cs_base="/sys/bus/coresight/devices"
+
+if [ ! -d "$cs_base" ]; then
+    log_warn "Coresight directory $cs_base not found. Skipping test."
+    echo "0" > "$res_file"
+    exit 0
+fi
+
+stm=""
+for node in "$cs_base"/stm*; do
+    if [ -d "$node" ] && [ -f "$node/enable_source" ]; then
+        stm="$node"
+        brea
+    fi
+done
+
+sinks=""
+for node in "$cs_base"/*; do
+    [ -d "$node" ] || continue
+    [ "$(basename "$node")" = "tmc_etf1" ] && continue
+    
+    if [ -f "$node/enable_sink" ]; then
+        sinks="$sinks $node"
+    fi
+done
+
+sinks="${sinks# }"
+
+if [ -z "$stm" ]; then
+    log_warn "No stm source found on this device. Skipping test."
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 0
+fi
+
+if [ -z "$sinks" ]; then
+    log_warn "No Coresight sinks found on this device. Skipping test."
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 0
+fi
+
+trap cleanup EXIT HUP INT TERM
+
+reset_coresight
+
+if [ -f "$stm/hwevent_enable" ]; then
+    echo 0 > "$stm/hwevent_enable" 2>/dev/null || true
+fi
+
+debugfs="/sys/kernel/debug"
+[ ! -d "$debugfs/tracing" ] && debugfs="/debug"
+if [ -f "$debugfs/tracing/events/enable" ]; then
+    echo 0 > "$debugfs/tracing/events/enable" 2>/dev/null || true
+fi
+
+testRes=""
+runs=${1:-250}
+log_info "Running sink reset stress test for $runs iterations..."
+
+i=0
+while [ "$i" -lt "$runs" ]; do
+    log_info "Sink reset running loop: $i / $runs"
+    
+    for sink in $sinks; do
+        reset_coresight
+        
+        echo 1 > "$sink/enable_sink" 2>/dev/null || true
+        echo 1 > "$stm/enable_source" 2>/dev/null || true
+        
+        sleep 1
+        reset_coresight
+        
+        if ! check_sink_status; then
+            log_fail "FAIL: reset_source_sink failed to disable sink during active source at loop $i"
+            testRes="FAIL"
+        else
+            log_info "PASS: reset_source_sink successful for $sink"
+        fi
+    done
+    i=$((i+1))
+done
+
+reset_coresight
+
+verify_sink=""
+verify_dev=""
+for s in $sinks; do
+    dev_path="/dev/$(basename "$s")"
+    if [ -c "$dev_path" ]; then
+        verify_sink="$s"
+        verify_dev="$dev_path"
+        break
+    fi
+done
+
+if [ -z "$verify_sink" ]; then
+    log_warn "Could not find a valid /dev/ character node for any sink. Skipping read verification."
+else   
+    echo 1 > "$verify_sink/enable_sink" 2>/dev/null || true
+    echo 1 > "$stm/enable_source" 2>/dev/null || true
+    
+    sleep 5
+    
+    echo 0 > "$stm/enable_source" 2>/dev/null || true
+    echo 0 > "$verify_sink/enable_sink" 2>/dev/null || true
+    
+    rm -f /tmp/etf.bin
+    cat "$verify_dev" > /tmp/etf.bin 2>/dev/null
+    
+    if [ ! -f "/tmp/etf.bin" ]; then
+        log_fail "Trace read FAIL: File /tmp/etf.bin not created"
+        testRes="FAIL"
+    else
+        size=$(wc -c < /tmp/etf.bin)
+        if [ "$size" -lt 64 ]; then
+            testRes="FAIL"
+        fi
+    fi
+fi
+
+if [ -z "$testRes" ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+fi
+
+log_info "-------------------$TESTNAME Finished----------------------------"

--- a/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/run.sh
+++ b/Runner/suites/Kernel/DEBUG/Single-Sink-Reset-Connected-Base/run.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env" >&2
+    exit 1
+fi
+
+if [ -z "$__INIT_ENV_LOADED" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/coresight_helper.sh"
+
+TESTNAME="Single-Sink-Reset-Connected-Base"
+test_path=$(find_test_case_by_name "$TESTNAME")
+cd "$test_path" || exit 1
+res_file="./$TESTNAME.res"
+log_info "------------------------$TESTNAME Starting------------------------"
+
+cs_base="/sys/bus/coresight/devices"
+
+if [ ! -d "$cs_base" ]; then
+    log_warn "Coresight directory $cs_base not found. Skipping test."
+    echo "0" > "$res_file"
+    exit 0
+fi
+
+stm=""
+for node in "$cs_base"/stm*; do
+    if [ -d "$node" ] && [ -f "$node/enable_source" ]; then
+        stm="$node"
+        brea
+    fi
+done
+
+sinks=""
+for node in "$cs_base"/*; do
+    [ -d "$node" ] || continue
+    [ "$(basename "$node")" = "tmc_etf1" ] && continue
+    
+    if [ -f "$node/enable_sink" ]; then
+        sinks="$sinks $node"
+    fi
+done
+
+sinks="${sinks# }"
+
+if [ -z "$stm" ]; then
+    log_warn "No stm source found on this device. Skipping test."
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 0
+fi
+
+if [ -z "$sinks" ]; then
+    log_warn "No Coresight sinks found on this device. Skipping test."
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 0
+fi
+
+trap cleanup EXIT HUP INT TERM
+
+reset_coresight
+
+if [ -f "$stm/hwevent_enable" ]; then
+    echo 0 > "$stm/hwevent_enable" 2>/dev/null || true
+fi
+
+debugfs="/sys/kernel/debug"
+[ ! -d "$debugfs/tracing" ] && debugfs="/debug"
+if [ -f "$debugfs/tracing/events/enable" ]; then
+    echo 0 > "$debugfs/tracing/events/enable" 2>/dev/null || true
+fi
+
+testRes=""
+runs=${1:-250}
+log_info "Running sink reset stress test for $runs iterations..."
+
+i=0
+while [ "$i" -lt "$runs" ]; do
+    log_info "Sink reset running loop: $i / $runs"
+    
+    for sink in $sinks; do
+        reset_coresight
+        
+        echo 1 > "$sink/enable_sink" 2>/dev/null || true
+        echo 1 > "$stm/enable_source" 2>/dev/null || true
+        
+        sleep 1
+        reset_coresight
+        
+        if ! check_sink_status; then
+            log_fail "FAIL: reset_source_sink failed to disable sink during active source at loop $i"
+            testRes="FAIL"
+        else
+            log_info "PASS: reset_source_sink successful for $sink"
+        fi
+    done
+    i=$((i+1))
+done
+
+reset_coresight
+
+verify_sink=""
+verify_dev=""
+for s in $sinks; do
+    dev_path="/dev/$(basename "$s")"
+    if [ -c "$dev_path" ]; then
+        verify_sink="$s"
+        verify_dev="$dev_path"
+        break
+    fi
+done
+
+if [ -z "$verify_sink" ]; then
+    log_warn "Could not find a valid /dev/ character node for any sink. Skipping read verification."
+else   
+    echo 1 > "$verify_sink/enable_sink" 2>/dev/null || true
+    echo 1 > "$stm/enable_source" 2>/dev/null || true
+    
+    sleep 5
+    
+    echo 0 > "$stm/enable_source" 2>/dev/null || true
+    echo 0 > "$verify_sink/enable_sink" 2>/dev/null || true
+    
+    rm -f /tmp/etf.bin
+    cat "$verify_dev" > /tmp/etf.bin 2>/dev/null
+    
+    if [ ! -f "/tmp/etf.bin" ]; then
+        log_fail "Trace read FAIL: File /tmp/etf.bin not created"
+        testRes="FAIL"
+    else
+        size=$(wc -c < /tmp/etf.bin)
+        if [ "$size" -lt 64 ]; then
+            testRes="FAIL"
+        fi
+    fi
+fi
+
+if [ -z "$testRes" ]; then
+    log_pass "$TESTNAME : Test Passed"
+    echo "$TESTNAME PASS" > "$res_file"
+else
+    log_fail "$TESTNAME : Test Failed"
+    echo "$TESTNAME FAIL" > "$res_file"
+fi
+
+log_info "-------------------$TESTNAME Finished----------------------------" 


### PR DESCRIPTION
- Single-Sink-Reset-Base: Repeatedly enable an active source and a single sink, reset CoreSight, and verify the sink consistently disables under load.

- Single-Sink-Reset-Connected-Base: Stress test sink reset behavior with an actively connected STM source and verify recovery via successful trace read.

Dependency PR: This PR depends on PR #389 and should be merged after it.