### PR TITLE
Reduce false BT and shmbridge failures caused by kernel log flooding

### DIFF
--- a/Runner/suites/Connectivity/Bluetooth/BT_FW_KMD_Service/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/BT_FW_KMD_Service/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause#
+# SPDX-License-Identifier: BSD-3-Clause
 # BT_FW_KMD_Service - Bluetooth FW + KMD + service + controller infra validation
 # Non-expect version, using lib_bluetooth.sh helpers.
 
@@ -38,7 +38,7 @@ fi
 
 # ---------- CLI / env parameters ----------
 BT_ADAPTER="${BT_ADAPTER-}"
- 
+
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --adapter)
@@ -72,8 +72,8 @@ inc_warn() { WARN_COUNT=$((WARN_COUNT + 1)); }
 log_info "------------------------------------------------------------"
 log_info "Starting $TESTNAME"
 
-log_info "Checking dependencies: bluetoothctl hciconfig dmesg lsmod"
-if ! check_dependencies bluetoothctl hciconfig dmesg lsmod; then
+log_info "Checking dependencies: bluetoothctl hciconfig lsmod"
+if ! check_dependencies bluetoothctl hciconfig lsmod; then
     echo "$TESTNAME SKIP" > "$RES_FILE"
     exit 0
 fi
@@ -87,13 +87,13 @@ else
 fi
 
 # ---------- DT node / compatible ----------
-BT_COMPAT_LIST="
-qcom,wcn7850-bt
-qcom,wcn6855-bt
-qcom,bluetooth
-"
-
-if dt_confirm_node_or_compatible_all "BT" "$BT_COMPAT_LIST"; then
+# ---------- DT node / compatible ----------
+if dt_confirm_node_or_compatible_all \
+    "qcom,wcn7850-bt" \
+    "qcom,wcn6855-bt" \
+    "qcom,wcn6750-bt" \
+    "qcom,bluetooth"
+then
     log_pass "DT node/compatible for BT present (at least one entry matched)."
 else
     log_fail "DT node/compatible for BT NOT found."
@@ -108,26 +108,53 @@ else
     inc_warn
 fi
 
-# ---------- Firmware load dmesg ----------
+# ---------- Firmware load kernel log ----------
 if command -v btfwloaded >/dev/null 2>&1; then
     btfwloaded
     rc=$?
     case "$rc" in
         0)
-            log_pass "Firmware load/setup appears completed (dmesg)."
+            log_pass "Firmware load/setup appears completed (kernel log)."
             ;;
         2)
-            log_warn "Firmware load/setup completed after retry, transient errors seen earlier (dmesg)."
+            log_warn "Firmware load/setup completed after retry, transient errors seen earlier (kernel log)."
             inc_warn
             ;;
         *)
-            log_fail "Firmware load/setup does NOT look clean (see recent Bluetooth/QCA/WCN dmesg lines above)."
-            inc_fail
+            runtime_bt_ok=1
+            fallback_adapter="$BT_ADAPTER"
+
+            if [ -z "$fallback_adapter" ] && findhcisysfs >/dev/null 2>&1; then
+                fallback_adapter="$(findhcisysfs 2>/dev/null || true)"
+            fi
+
+            if ! btkmdpresent; then
+                runtime_bt_ok=0
+            fi
+            if ! bthcipresent; then
+                runtime_bt_ok=0
+            fi
+            if ! btsvcactive; then
+                runtime_bt_ok=0
+            fi
+            if [ -n "$fallback_adapter" ]; then
+                if ! btbdok "$fallback_adapter"; then
+                    runtime_bt_ok=0
+                fi
+            fi
+
+            if [ "$runtime_bt_ok" -eq 1 ]; then
+                log_warn "No retained BT firmware-load signature found, but BT runtime state is healthy."
+                inc_warn
+            else
+                log_fail "Firmware load/setup does NOT look clean and BT runtime state is also unhealthy."
+                inc_fail
+            fi
             ;;
     esac
 else
     # No SKIP: continue test, just warn.
-    log_warn "btfwloaded() helper not available firmware-load dmesg validation not performed."
+    log_warn "btfwloaded() helper not available; firmware-load kernel-log validation not performed."
     inc_warn
 fi
 
@@ -166,7 +193,7 @@ elif findhcisysfs >/dev/null 2>&1; then
 else
     ADAPTER=""
 fi
- 
+
 if [ -z "$ADAPTER" ]; then
     log_warn "No HCI adapter found; skipping BT FW/KMD test."
     echo "$TESTNAME SKIP" > "./$TESTNAME.res"

--- a/Runner/suites/Kernel/Baseport/shmbridge/run.sh
+++ b/Runner/suites/Kernel/Baseport/shmbridge/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
- 
+
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: BSD-3-Clause 
+# SPDX-License-Identifier: BSD-3-Clause
 # Locate and source init_env
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
@@ -13,15 +13,15 @@ while [ "$SEARCH" != "/" ]; do
     fi
     SEARCH=$(dirname "$SEARCH")
 done
- 
+
 if [ -z "$INIT_ENV" ]; then
     echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
     exit 1
 fi
- 
+
 # shellcheck disable=SC1090
 . "$INIT_ENV"
- 
+
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
 
@@ -36,8 +36,8 @@ log_info "==== Test Initialization ===="
 
 log_info "Checking if required tools are available"
 
-if ! check_dependencies zcat grep dmesg; then
-    log_skip "$TESTNAME SKIP - missing one or more of zcat grep dmesg utils"
+if ! check_dependencies grep; then
+    log_skip "$TESTNAME SKIP - missing required grep utility"
     echo "$TESTNAME SKIP" >"$res_file"
     exit 0
 fi
@@ -48,22 +48,37 @@ if ! check_kernel_config "CONFIG_QCOM_SCM"; then
     echo "$TESTNAME SKIP" > "$res_file"
     exit 0
 fi
- 
-log_info "Scanning dmesg logs for qcom_scm initialization"
 
-if dmesg | grep -q 'qcom_scm'; then
-    if ! scan_dmesg_errors . "" ""; then
-        log_pass "$TESTNAME : Test Passed (qcom_scm present and no probe failures)"
-        echo "$TESTNAME PASS" > "$res_file" 
-    else
-        log_fail "FAIL: 'probe failure' detected in dmesg."
-        echo "$TESTNAME FAIL" > "$res_file"
-    fi
+log_info "Checking qcom_scm presence using sysfs/current-boot kernel log"
+
+if [ -d /sys/module/qcom_scm ]; then
+    log_pass "qcom_scm driver is present in sysfs."
+elif get_kernel_log 2>/dev/null | grep -qi '\bqcom_scm\b'; then
+    log_pass "qcom_scm present in current-boot kernel log."
 else
-    log_fail "FAIL: 'qcom_scm' not found in dmesg."
+    log_fail "FAIL: qcom_scm not found in sysfs or current-boot kernel log."
     echo "$TESTNAME FAIL" > "$res_file"
+    exit 0
+fi
+
+scm_log="./qcom_scm_kernel.log"
+scm_err="./qcom_scm_errors.log"
+err_patterns='probe failed|fail(ed)?|error|timed out|not found|invalid|corrupt|abort|panic|oops|unhandled'
+
+log_info "Scanning current-boot kernel log for qcom_scm-related errors"
+get_kernel_log > "$scm_log" 2>/dev/null || true
+grep -iE "qcom_scm.*($err_patterns)" "$scm_log" > "$scm_err" || true
+
+if [ -s "$scm_err" ]; then
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        log_info "[kernel] $line"
+    done < "$scm_err"
+    log_fail "FAIL: qcom_scm-related errors detected in current-boot kernel log."
+    echo "$TESTNAME FAIL" > "$res_file"
+else
+    log_pass "$TESTNAME : Test Passed (qcom_scm present and no qcom_scm-related kernel errors)"
+    echo "$TESTNAME PASS" > "$res_file"
 fi
 
 log_info "-------------------Completed $TESTNAME Testcase----------------------------"
-
- 

--- a/Runner/utils/lib_bluetooth.sh
+++ b/Runner/utils/lib_bluetooth.sh
@@ -1903,16 +1903,25 @@ btfwloaded() {
     # Retry/transient hints: if success exists and we see these, we likely want WARN.
     transient_re="${BTFW_TRANSIENT_RE:-Retry BT power ON|retry bt power on|reset|re-init|reinit|failed.*\\(-110\\)}"
 
-    # ---- Collect recent relevant dmesg ----
-    # Filter for BT/QCA/WCN related lines; keep a reasonable window.
-    out="$(
-        dmesg 2>/dev/null \
-        | grep -i -E 'Bluetooth|hci[0-9]|QCA|wcn|btqca|WCN' \
-        | tail -n "${BTFW_DMESG_TAIL:-600}"
-    )"
+    # ---- Collect recent relevant current-boot kernel log ----
+    # Prefer get_kernel_log() so we can use journalctl -k -b when available
+    # instead of relying only on the live dmesg ring buffer.
+    if command -v get_kernel_log >/dev/null 2>&1; then
+        out="$(
+            get_kernel_log 2>/dev/null \
+            | grep -i -E 'Bluetooth|hci[0-9]|QCA|wcn|btqca|WCN' \
+            | tail -n "${BTFW_DMESG_TAIL:-600}"
+        )"
+    else
+        out="$(
+            dmesg 2>/dev/null \
+            | grep -i -E 'Bluetooth|hci[0-9]|QCA|wcn|btqca|WCN' \
+            | tail -n "${BTFW_DMESG_TAIL:-600}"
+        )"
+    fi
 
     if [ -z "$out" ]; then
-        log_warn "btfwloaded: no recent Bluetooth/QCA/WCN messages in dmesg."
+        log_warn "btfwloaded: no Bluetooth/QCA/WCN messages found in current-boot kernel log."
         return 1
     fi
 
@@ -1922,7 +1931,7 @@ btfwloaded() {
         printf '%s\n' "$out" \
         | awk -v IGNORECASE=1 -v re="$success_re" '
             $0 ~ re { n=NR }
-            END { if (n>0) print n; else print 0 }
+            END { if (n > 0) print n; else print 0 }
         '
     )"
 
@@ -1930,7 +1939,7 @@ btfwloaded() {
         printf '%s\n' "$out" \
         | awk -v IGNORECASE=1 -v re="$fatal_re" '
             $0 ~ re { n=NR }
-            END { if (n>0) print n; else print 0 }
+            END { if (n > 0) print n; else print 0 }
         '
     )"
 
@@ -1945,32 +1954,32 @@ btfwloaded() {
 
     # ---- Decision tree ----
     if [ "$last_success" -eq 0 ]; then
-        log_warn "btfwloaded: no final success marker found (pattern: $success_re). Recent tail:"
+        log_warn "btfwloaded: no final success marker found (pattern: $success_re). Recent kernel-log tail:"
         printf '%s\n' "$out" | tail -n 30 >&2
         return 1
     fi
 
     # Fatal after success => FAIL (setup looked done, but then errors happened later)
     if [ "$last_fatal" -gt "$last_success" ]; then
-        log_warn "btfwloaded: fatal BT/QCA errors occurred after final setup marker; treating as FAIL."
+        log_warn "btfwloaded: fatal BT/QCA errors occurred after final setup marker in kernel log, treating as FAIL."
         printf '%s\n' "$out" | tail -n 40 >&2
         return 1
     fi
 
     # Fatal before success OR transient hints => WARN (retry scenario)
     if [ "$last_fatal" -gt 0 ] && [ "$last_fatal" -lt "$last_success" ]; then
-        log_warn "btfwloaded: transient errors occurred before final setup marker; treating as WARN."
+        log_warn "btfwloaded: transient errors occurred before final setup marker in kernel log, treating as WARN."
         printf '%s\n' "$out" | tail -n 30 >&2
         return 2
     fi
 
     if [ "$saw_transient" -eq 1 ]; then
-        log_warn "btfwloaded: retry/transient indicators seen; final setup marker present; treating as WARN."
+        log_warn "btfwloaded: retry/transient indicators seen in kernel log, final setup marker present, treating as WARN."
         printf '%s\n' "$out" | tail -n 30 >&2
         return 2
     fi
 
-    log_info "btfwloaded: firmware load/setup completed cleanly (no fatal errors after final setup marker)."
+    log_info "btfwloaded: firmware load/setup completed cleanly from current-boot kernel log (no fatal errors after final setup marker)."
     return 0
 }
 


### PR DESCRIPTION
This PR also tightens the Bluetooth DT compatible matching so the BT test passes individual compatible strings instead of a single multiline pattern, avoiding misleading DT match output.
 
Summary of changes:
- use current-boot kernel log in btfwloaded()
- downgrade missing retained BT firmware-load signatures to WARN when runtime BT state is healthy
- replace shmbridge raw dmesg presence checks with sysfs/current-boot kernel log validation
- tighten BT DT compatible matching output
 
These changes are intended to improve robustness in LAVA and other noisy boot environments without weakening genuine failure coverage.