### PR TITLE
Fail weston-simple-egl on base when Weston runtime is missing

### DIFF
--- a/Runner/suites/Multimedia/Graphics/weston-simple-egl/run.sh
+++ b/Runner/suites/Multimedia/Graphics/weston-simple-egl/run.sh
@@ -207,8 +207,8 @@ if [ -z "$sock" ]; then
       log_warn "overlay_start_weston_drm returned non-zero; private Weston may have failed to start."
     fi
   else
-    log_warn "No Wayland socket found and not starting Weston on base build; skipping ${TESTNAME}."
-    echo "${TESTNAME} SKIP" >"$RES_FILE"
+    log_fail "No Wayland socket found and not starting Weston on base build, failing ${TESTNAME}."
+    echo "${TESTNAME} FAIL" >"$RES_FILE"
     exit 0
   fi
 fi
@@ -219,10 +219,10 @@ if command -v discover_wayland_socket_anywhere >/dev/null 2>&1; then
   [ -n "$new_sock" ] && sock="$new_sock"
 fi
 
-# Final decision: run or SKIP
+# Final decision: run or FAIL
 if [ -z "$sock" ]; then
-  log_warn "No Wayland socket found after autodetection; skipping ${TESTNAME}."
-  echo "${TESTNAME} SKIP" >"$RES_FILE"
+  log_fail "No Wayland socket found after autodetection, failing ${TESTNAME}."
+  echo "${TESTNAME} FAIL" >"$RES_FILE"
   exit 0
 fi
 
@@ -237,7 +237,7 @@ fi
 if command -v wayland_connection_ok >/dev/null 2>&1; then
   if ! wayland_connection_ok; then
     if [ "$BUILD_FLAVOUR" = "base" ] && command -v weston_wait_ready >/dev/null 2>&1; then
-      log_warn "Initial Wayland connection test failed; waiting briefly and retrying..."
+      log_warn "Initial Wayland connection test failed, waiting briefly and retrying..."
       if weston_wait_ready 5; then
         if command -v discover_wayland_socket_anywhere >/dev/null 2>&1; then
           sock=$(discover_wayland_socket_anywhere | head -n 1 || true)
@@ -249,8 +249,8 @@ if command -v wayland_connection_ok >/dev/null 2>&1; then
     fi
 
     if ! wayland_connection_ok; then
-      log_fail "Wayland connection test failed; cannot run ${TESTNAME}."
-      echo "${TESTNAME} SKIP" >"$RES_FILE"
+      log_fail "Wayland connection test failed, cannot run ${TESTNAME}."
+      echo "${TESTNAME} FAIL" >"$RES_FILE"
       exit 0
     fi
   fi


### PR DESCRIPTION
This PR fixes weston-simple-egl result handling on base builds so real Weston runtime regressions are reported as FAIL instead of SKIP.

This change updates the base-build result handling so these cases are treated as FAIL:
- connected display is present but no Wayland socket is found on base
- no Wayland socket is found after autodetection/retry on base
- Wayland connection test fails after retry

Why this change is needed:
A Weston upstream or integration regression on base can currently be masked as SKIP, which allows the change to pass post-merge validation without surfacing the failure. With this update, missing Weston runtime on base is treated as a real testcase failure, which is the expected behavior.
 
Expected outcome:
- base build + connected display + missing Weston runtime => FAIL
- base build + connected display + broken Wayland connection => FAIL
- no display / missing prerequisite => SKIP (unchanged)