### PR TITLE
add Weston runtime preflight test and strengthen Weston runtime handling

### DIFF
--- a/Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/README_Weston_Runtime_Preflight.md
+++ b/Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/README_Weston_Runtime_Preflight.md
@@ -1,0 +1,324 @@
+# Weston_Runtime_Preflight
+
+## Overview
+
+`Weston_Runtime_Preflight` validates Weston and Wayland runtime health before any Weston client-level display or graphics tests are executed.
+
+This testcase is a **runtime gate only**. It does **not** launch `weston-simple-shm`, `weston-simple-egl`, or any other Weston client application.
+
+The goal is to catch real Weston bring-up issues early, such as:
+
+- `weston.service` in failed state
+- `weston.socket` active but compositor process not running
+- missing or inconsistent Wayland runtime state
+- broken systemd-managed Weston recovery on target
+- runtime directory / socket issues for the configured Weston service user
+
+Client-level validation must be handled separately:
+
+- `weston-simple-shm` should be the first client-level blocker
+- `weston-simple-egl` should be the EGL-specific blocker after that
+
+---
+
+## Behavior
+
+### Default mode
+
+```sh
+./run.sh
+
+This is the strict runtime health check.
+
+In this mode, the testcase:
+
+checks DRM/display connectivity
+
+captures display snapshot and modetest diagnostics
+
+checks weston.service and weston.socket state
+
+inspects Weston service runtime context
+
+checks whether a Weston compositor process is actually running
+
+validates discovered Wayland runtime information
+
+optionally collects EGL pipeline diagnostics
+
+
+This mode does not attempt to restart or recover Weston.
+
+If Weston runtime is unhealthy, the testcase reports FAIL.
+
+Typical examples that cause FAIL in default mode:
+
+weston.service is failed
+
+no Weston process is running
+
+runtime state is inconsistent
+
+Wayland runtime cannot be validated
+
+
+
+---
+
+Relaunch mode
+
+./run.sh --allow-relaunch
+
+This mode enables an explicit recovery attempt for a broken systemd-managed Weston runtime.
+
+In this mode, if Weston runtime is unhealthy, the testcase may:
+
+stop weston.socket
+
+stop weston.service
+
+reset failed systemd state
+
+restart the systemd-managed Weston runtime
+
+re-check Weston service state, runtime directory, Wayland socket, and compositor process
+
+
+If Weston is already healthy, relaunch is not performed and the test logs:
+
+Relaunch not required, Weston already running
+
+
+If recovery succeeds, the testcase reports PASS.
+
+If recovery does not restore a healthy Weston runtime, the testcase reports FAIL.
+
+
+---
+
+PASS / FAIL / SKIP semantics
+
+PASS
+
+Reported when:
+
+a connected display is available
+
+Weston runtime is healthy
+
+Wayland runtime discovery succeeds
+
+optional EGL diagnostics do not block runtime success
+
+
+FAIL
+
+Reported when:
+
+weston.service is failed or unhealthy in strict mode
+
+no Weston compositor process is running
+
+systemd-managed relaunch fails to recover Weston
+
+runtime validation fails after cleanup/restart attempt
+
+runtime remains inconsistent after recovery
+
+
+SKIP
+
+Reported when:
+
+no usable connected display is present for the test
+
+
+This testcase should not hide runtime issues behind SKIP when a display is present and Weston is expected to work.
+
+
+---
+
+What this test validates
+
+connected display presence
+
+DRM / connector snapshot
+
+modetest capture for debug
+
+weston.service state
+
+weston.socket state
+
+Weston service user / UID context
+
+preferred runtime directory for Weston service user
+
+existence of Wayland runtime directory
+
+existence of Wayland socket when applicable
+
+actual Weston compositor process presence
+
+adopted Wayland environment used for reproduction
+
+optional EGL pipeline diagnostics for debug visibility
+
+
+
+---
+
+What this test does not validate
+
+This testcase does not validate:
+
+Weston client rendering correctness
+
+shared-memory client rendering
+
+EGL window rendering
+
+repeated client launch / kill lifecycle
+
+graphics functional behavior beyond runtime diagnostics
+
+
+Those must be covered by separate tests such as:
+
+weston-simple-shm
+
+weston-simple-egl
+
+
+
+---
+
+Runtime model notes
+
+This test performs dynamic runtime inspection and does not hardcode a single runtime path.
+
+It can log context such as:
+
+Weston service user
+
+Weston service UID
+
+preferred runtime directory, for example /run/user/1000
+
+discovered runtime socket
+
+current XDG_RUNTIME_DIR
+
+current WAYLAND_DISPLAY
+
+
+This helps distinguish between:
+
+service-level failure
+
+runtime directory creation failure
+
+socket creation failure
+
+compositor process failure
+
+environment mismatch
+
+
+
+---
+
+Parameters
+
+The testcase supports the following controls through environment variables and CLI.
+
+Environment variables
+
+WAIT_SECS
+
+default: 10
+
+time to wait for runtime readiness checks
+
+
+VALIDATE_EGLINFO
+
+default: 1
+
+when enabled, collects EGL pipeline diagnostics for debugging
+
+this is diagnostic and not intended to be the primary runtime gate
+
+
+
+CLI option
+
+--allow-relaunch
+
+default: disabled
+
+enables cleanup and restart attempt for systemd-managed Weston runtime
+
+
+
+
+---
+
+Example usage
+
+Strict mode:
+
+./run.sh
+
+Recovery mode:
+
+./run.sh --allow-relaunch
+
+With custom wait time:
+
+WAIT_SECS=15 ./run.sh
+
+With EGL diagnostics disabled:
+
+VALIDATE_EGLINFO=0 ./run.sh
+
+Strict mode with diagnostics disabled:
+
+WAIT_SECS=15 VALIDATE_EGLINFO=0 ./run.sh
+
+Recovery mode with custom wait:
+
+WAIT_SECS=15 ./run.sh --allow-relaunch
+
+
+---
+
+Result files
+
+The testcase writes:
+
+Weston_Runtime_Preflight.res
+
+Weston_Runtime_Preflight_run.log
+
+
+Possible result values:
+
+Weston_Runtime_Preflight PASS
+
+Weston_Runtime_Preflight FAIL
+
+Weston_Runtime_Preflight SKIP
+
+---
+
+Recommended execution order
+
+Recommended gate order:
+1. Weston_Runtime_Preflight
+
+2. weston-simple-shm
+
+3. weston-simple-egl
+
+This ordering ensures runtime failures are caught before client-level failures are investigated.

--- a/Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/Weston_Runtime_Preflight.yaml
+++ b/Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/Weston_Runtime_Preflight.yaml
@@ -1,0 +1,19 @@
+metadata:
+  name: weston-runtime-preflight
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validate Weston and Wayland runtime health before Weston client-level tests."
+  os:
+    - linux
+  scope:
+    - functional
+
+params:
+  WAIT_SECS: "10"
+  VALIDATE_EGLINFO: "1"
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/
+    - WAIT_SECS="${WAIT_SECS}" VALIDATE_EGLINFO="${VALIDATE_EGLINFO}" ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Weston_Runtime_Preflight.res

--- a/Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/Weston_Runtime_Preflight_Relaunch.yaml
+++ b/Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/Weston_Runtime_Preflight_Relaunch.yaml
@@ -1,0 +1,19 @@
+metadata:
+  name: weston-runtime-preflight-relaunch
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validate Weston and Wayland runtime health, allowing Weston relaunch recovery before Weston client-level tests."
+  os:
+    - linux
+  scope:
+    - functional
+
+params:
+  WAIT_SECS: "10"
+  VALIDATE_EGLINFO: "1"
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/
+    - WAIT_SECS="${WAIT_SECS}" VALIDATE_EGLINFO="${VALIDATE_EGLINFO}" ./run.sh --allow-relaunch || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Weston_Runtime_Preflight.res

--- a/Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/run.sh
+++ b/Runner/suites/Multimedia/Display/Weston_Runtime_Preflight/run.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Validate Weston and Wayland runtime health before Weston client tests.
+# - Dynamic runtime discovery, no hardcoded runtime path assumptions
+# - Default mode is strict runtime gating, no relaunch attempted
+# - Optional relaunch mode can try to recover Weston runtime
+# - CI-friendly PASS/FAIL/SKIP semantics, always exits 0
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env, starting at $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1091
+. "$TOOLS/lib_display.sh"
+
+TESTNAME="Weston_Runtime_Preflight"
+
+usage()
+{
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --wait-secs N Seconds to wait for Weston runtime discovery, default: 10
+  --validate-eglinfo Enable EGL pipeline diagnostics, default
+  --no-validate-eglinfo Disable EGL pipeline diagnostics
+  --allow-relaunch Allow runtime relaunch attempt when Weston is unhealthy
+  -h, --help Show this help
+EOF
+}
+
+WAIT_SECS="${WAIT_SECS:-10}"
+VALIDATE_EGLINFO="${VALIDATE_EGLINFO:-1}"
+ALLOW_RELAUNCH="${ALLOW_RELAUNCH:-0}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --wait-secs)
+            shift
+            if [ $# -eq 0 ]; then
+                echo "[ERROR] --wait-secs requires an argument" >&2
+                exit 1
+            fi
+            WAIT_SECS="$1"
+            ;;
+        --wait-secs=*)
+            WAIT_SECS=${1#*=}
+            ;;
+        --validate-eglinfo)
+            VALIDATE_EGLINFO=1
+            ;;
+        --no-validate-eglinfo)
+            VALIDATE_EGLINFO=0
+            ;;
+        --allow-relaunch)
+            ALLOW_RELAUNCH=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "[ERROR] Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+test_path="$(find_test_case_by_name "$TESTNAME")" || {
+    log_fail "$TESTNAME, test directory not found"
+    echo "$TESTNAME FAIL" > "./$TESTNAME.res"
+    exit 1
+}
+
+cd "$test_path" || exit 1
+
+RES_FILE="./${TESTNAME}.res"
+RUN_LOG="./${TESTNAME}_run.log"
+
+: >"$RES_FILE"
+: >"$RUN_LOG"
+
+log_info "Weston log directory, $SCRIPT_DIR"
+log_info "--------------------------------------------------------------------------"
+log_info "------------------- Starting ${TESTNAME} Testcase --------------------------"
+log_info "Config, WAIT_SECS=${WAIT_SECS} VALIDATE_EGLINFO=${VALIDATE_EGLINFO} ALLOW_RELAUNCH=${ALLOW_RELAUNCH}"
+
+if command -v detect_platform >/dev/null 2>&1; then
+    detect_platform
+fi
+
+if command -v display_detect_build_flavour >/dev/null 2>&1; then
+    display_detect_build_flavour
+else
+    DISPLAY_BUILD_FLAVOUR="base"
+    DISPLAY_EGL_VENDOR_JSON=""
+fi
+
+if [ "$DISPLAY_BUILD_FLAVOUR" = "overlay" ]; then
+    log_info "Build flavor, overlay, EGL vendor JSON present: ${DISPLAY_EGL_VENDOR_JSON}"
+else
+    log_info "Build flavor, base, no Adreno EGL vendor JSON found"
+fi
+
+if ! display_log_snapshot_and_require_connector "$TESTNAME" 200; then
+    echo "${TESTNAME} SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+export ALLOW_RELAUNCH
+if ! weston_prepare_runtime "$TESTNAME" "$WAIT_SECS" runtime; then
+    echo "${TESTNAME} FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v display_select_primary_connector >/dev/null 2>&1; then
+    primary_connector="$(display_select_primary_connector 2>/dev/null || true)"
+    if [ -n "$primary_connector" ]; then
+        log_info "Primary connector, ${primary_connector}"
+        if command -v display_connector_cur_mode >/dev/null 2>&1; then
+            primary_mode="$(display_connector_cur_mode "$primary_connector" 2>/dev/null || true)"
+            if [ -n "$primary_mode" ] && [ "$primary_mode" != "-" ]; then
+                log_info "Primary connector current mode, ${primary_mode}"
+            fi
+        fi
+    fi
+fi
+
+if [ "$VALIDATE_EGLINFO" -ne 0 ] && command -v display_print_eglinfo_pipeline >/dev/null 2>&1; then
+    log_info "Collecting EGL pipeline diagnostics"
+    if ! display_print_eglinfo_pipeline auto; then
+        log_warn "EGL pipeline detection did not complete cleanly, continuing"
+    fi
+fi
+
+log_info "Final decision for ${TESTNAME}, PASS"
+echo "${TESTNAME} PASS" >"$RES_FILE"
+log_pass "${TESTNAME} : PASS"
+exit 0

--- a/Runner/utils/lib_display.sh
+++ b/Runner/utils/lib_display.sh
@@ -1948,3 +1948,598 @@ display_parse_fps_log() {
 
     return 0
 }
+
+# Detect display build flavour dynamically from available EGL vendor JSON files.
+# Exports:
+#   DISPLAY_BUILD_FLAVOUR, base or overlay
+#   DISPLAY_EGL_VENDOR_JSON, matched vendor JSON path, empty when not found
+# Return:
+#   0 always, detection is best-effort and defaults to base
+display_detect_build_flavour() {
+    DISPLAY_BUILD_FLAVOUR="base"
+    DISPLAY_EGL_VENDOR_JSON=""
+
+    for d in /usr/share/glvnd/egl_vendor.d /etc/glvnd/egl_vendor.d; do
+        [ -d "$d" ] || continue
+
+        for f in "$d"/*adreno*.json "$d"/*EGL_adreno*.json; do
+            [ -e "$f" ] || continue
+            if [ -f "$f" ]; then
+                DISPLAY_EGL_VENDOR_JSON="$f"
+                DISPLAY_BUILD_FLAVOUR="overlay"
+                export DISPLAY_BUILD_FLAVOUR
+                export DISPLAY_EGL_VENDOR_JSON
+                return 0
+            fi
+        done
+    done
+
+    export DISPLAY_BUILD_FLAVOUR
+    export DISPLAY_EGL_VENDOR_JSON
+    return 0
+}
+
+# Log display snapshots and require at least one connected DRM display.
+# This helper keeps display gating dynamic, no connector names or fixed paths are hardcoded.
+# Arguments:
+#   $1, testcase name for log messages
+#   $2, optional modetest line cap, default 200
+# Exports:
+#   DISPLAY_CONNECTED_SUMMARY, sysfs display summary, or none
+# Return:
+#   0 when at least one connected display is found
+#   1 when no connected DRM display is found
+display_log_snapshot_and_require_connector() {
+    ds_testname="$1"
+    ds_modetest_cap="${2:-200}"
+
+    DISPLAY_CONNECTED_SUMMARY="none"
+    export DISPLAY_CONNECTED_SUMMARY
+
+    if command -v display_debug_snapshot >/dev/null 2>&1; then
+        display_debug_snapshot "pre-display-check"
+    fi
+
+    if command -v modetest >/dev/null 2>&1; then
+        log_info "----- modetest -M msm -ac, capped at ${ds_modetest_cap} lines -----"
+        modetest -M msm -ac 2>&1 | sed -n "1,${ds_modetest_cap}p" | while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            log_info "[modetest] $line"
+        done
+        log_info "----- End modetest -M msm -ac -----"
+    else
+        log_warn "modetest not found in PATH, skipping modetest snapshot"
+    fi
+
+    if command -v display_connected_summary >/dev/null 2>&1; then
+        DISPLAY_CONNECTED_SUMMARY="$(display_connected_summary 2>/dev/null || true)"
+        export DISPLAY_CONNECTED_SUMMARY
+    fi
+
+    if [ -z "$DISPLAY_CONNECTED_SUMMARY" ] || [ "$DISPLAY_CONNECTED_SUMMARY" = "none" ]; then
+        log_warn "No connected DRM display found, skipping ${ds_testname}"
+        return 1
+    fi
+
+    log_info "Connected display, ${DISPLAY_CONNECTED_SUMMARY}"
+    return 0
+}
+
+# Return success when a Weston process is running.
+weston_has_running_process() {
+    if command -v weston_is_running >/dev/null 2>&1; then
+        if weston_is_running >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    if command -v pgrep >/dev/null 2>&1; then
+        if pgrep -x weston >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+# Print Weston runtime diagnostics, including systemd unit state, process list, and env.
+# Arguments:
+# $1, snapshot label
+weston_log_runtime_snapshot() {
+    wlr_label="$1"
+    wlr_pids=""
+    wlr_state=""
+
+    log_info "----- Weston runtime snapshot, ${wlr_label} -----"
+
+    if command -v systemd_service_exists >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
+        if systemd_service_exists weston.service; then
+            wlr_state="$(systemctl is-active weston.service 2>/dev/null || true)"
+            if [ "$wlr_state" = "failed" ]; then
+                log_warn "systemd weston.service, state=${wlr_state}"
+            else
+                log_info "systemd weston.service, state=${wlr_state:-unknown}"
+            fi
+        fi
+
+        if systemd_service_exists weston.socket; then
+            wlr_state="$(systemctl is-active weston.socket 2>/dev/null || true)"
+            if [ "$wlr_state" = "failed" ]; then
+                log_warn "systemd weston.socket, state=${wlr_state}"
+            else
+                log_info "systemd weston.socket, state=${wlr_state:-unknown}"
+            fi
+        fi
+    fi
+
+    if command -v weston_log_service_runtime_context >/dev/null 2>&1; then
+        weston_log_service_runtime_context || true
+    fi
+
+    if command -v pgrep >/dev/null 2>&1; then
+        wlr_pids="$(pgrep -x weston 2>/dev/null || true)"
+    fi
+
+    if [ -n "$wlr_pids" ]; then
+        log_info "weston PIDs, $(printf '%s' "$wlr_pids" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        if command -v ps >/dev/null 2>&1; then
+            printf '%s\n' "$wlr_pids" | while IFS= read -r pid; do
+                if [ -n "$pid" ]; then
+                    ps -o pid= -o user= -o group= -o args= -p "$pid" 2>/dev/null | while IFS= read -r line; do
+                        log_info "[ps] $line"
+                    done
+                fi
+            done
+        fi
+    else
+        log_warn "No weston process found"
+    fi
+
+    log_info "Env now, XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-<unset>} WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-<unset>}"
+    log_info "----- End Weston runtime snapshot, ${wlr_label} -----"
+}
+
+# Print the configured systemd user for weston.service.
+weston_systemd_service_user() {
+    wsu_user=""
+
+    if ! command -v systemd_service_exists >/dev/null 2>&1; then
+        return 1
+    fi
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 1
+    fi
+    if ! systemd_service_exists weston.service; then
+        return 1
+    fi
+
+    wsu_user="$(systemctl show -p User --value weston.service 2>/dev/null || true)"
+    if [ -n "$wsu_user" ]; then
+        printf '%s\n' "$wsu_user"
+        return 0
+    fi
+
+    return 1
+}
+
+# Prefer the Wayland socket that belongs to the systemd-managed Weston user.
+# Fall back to generic discovery only when needed.
+weston_preferred_socket() {
+    wps_user=""
+    wps_uid=""
+    wps_dir=""
+    wps_sock=""
+
+    if wps_user="$(weston_systemd_service_user 2>/dev/null)"; then
+        wps_uid="$(id -u "$wps_user" 2>/dev/null || true)"
+        if [ -n "$wps_uid" ]; then
+            wps_dir="/run/user/$wps_uid"
+            if [ -d "$wps_dir" ]; then
+                for wps_sock in "$wps_dir"/wayland-*; do
+                    if [ -S "$wps_sock" ]; then
+                        printf '%s\n' "$wps_sock"
+                        return 0
+                    fi
+                done
+            fi
+        fi
+    fi
+
+    if command -v discover_wayland_socket_anywhere >/dev/null 2>&1; then
+        discover_wayland_socket_anywhere 2>/dev/null | head -n 1
+        return 0
+    fi
+
+    return 1
+}
+
+# Restart the systemd-managed Weston runtime cleanly.
+# This is the preferred relaunch path when weston.service exists.
+weston_restart_systemd_runtime() {
+    wrs_wait="${1:-10}"
+    wrs_user=""
+    wrs_uid=""
+    wrs_dir=""
+
+    if ! command -v systemd_service_exists >/dev/null 2>&1; then
+        return 1
+    fi
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 1
+    fi
+    if ! systemd_service_exists weston.service; then
+        return 1
+    fi
+
+    log_info "Relaunch path, restarting systemd-managed Weston runtime"
+
+    if systemd_service_exists weston.socket; then
+        log_info "Stopping weston.socket before relaunch"
+        systemctl stop weston.socket >/dev/null 2>&1 || true
+    fi
+
+    log_info "Stopping weston.service before relaunch"
+    systemctl stop weston.service >/dev/null 2>&1 || true
+
+    log_info "Resetting failed Weston systemd state before relaunch"
+    systemctl reset-failed weston.service weston.socket >/dev/null 2>&1 || true
+
+    wrs_user="$(weston_systemd_service_user 2>/dev/null || true)"
+    if [ -n "$wrs_user" ]; then
+        wrs_uid="$(id -u "$wrs_user" 2>/dev/null || true)"
+        if [ -n "$wrs_uid" ]; then
+            wrs_dir="/run/user/$wrs_uid"
+            log_info "Preferred Weston service user, ${wrs_user}"
+            log_info "Preferred Weston runtime directory, ${wrs_dir}"
+        fi
+    fi
+
+    if systemd_service_exists weston.socket; then
+        log_info "Starting weston.socket"
+        systemctl start weston.socket >/dev/null 2>&1 || true
+    fi
+
+    log_info "Starting weston.service"
+    if ! systemctl start weston.service >/dev/null 2>&1; then
+        return 1
+    fi
+
+    if command -v weston_wait_ready >/dev/null 2>&1; then
+        weston_wait_ready "$wrs_wait" || true
+    fi
+
+    if systemctl is-failed --quiet weston.service 2>/dev/null; then
+        return 1
+    fi
+
+    if ! weston_has_running_process; then
+        return 1
+    fi
+
+    return 0
+}
+
+# Log the runtime context derived from weston.service user configuration.
+weston_log_service_runtime_context() {
+    wls_user=""
+    wls_uid=""
+    wls_dir=""
+    wls_sock_found=0
+    wls_sock=""
+
+    if ! command -v weston_systemd_service_user >/dev/null 2>&1; then
+        log_warn "weston_systemd_service_user helper not available"
+        return 1
+    fi
+
+    wls_user="$(weston_systemd_service_user 2>/dev/null || true)"
+    if [ -z "$wls_user" ]; then
+        log_warn "Could not determine Weston service user"
+        return 1
+    fi
+
+    log_info "Weston service user, ${wls_user}"
+
+    if id "$wls_user" >/dev/null 2>&1; then
+        wls_uid="$(id -u "$wls_user" 2>/dev/null || true)"
+        log_info "Weston service UID, ${wls_uid:-<unknown>}"
+    else
+        log_warn "Weston service user does not exist on target, ${wls_user}"
+        return 1
+    fi
+
+    if [ -n "$wls_uid" ]; then
+        wls_dir="/run/user/$wls_uid"
+        log_info "Weston preferred runtime directory, ${wls_dir}"
+
+        if [ -d "$wls_dir" ]; then
+            log_info "Weston runtime directory exists, ${wls_dir}"
+            find "$wls_dir" -prune -print 2>/dev/null | while IFS= read -r line; do
+                log_info "[runtime-dir] $line"
+            done
+
+            for wls_sock in "$wls_dir"/wayland-*; do
+                if [ -S "$wls_sock" ]; then
+                    if [ "$wls_sock_found" -eq 0 ]; then
+                        log_info "Wayland sockets under preferred runtime directory:"
+                    fi
+                    log_info "[socket] ${wls_sock}"
+                    wls_sock_found=1
+                fi
+            done
+
+            if [ "$wls_sock_found" -eq 0 ]; then
+                log_info "No Wayland sockets found under preferred runtime directory, ${wls_dir}"
+            fi
+        else
+            log_warn "Weston runtime directory does not exist, ${wls_dir}"
+        fi
+    fi
+
+    return 0
+}
+
+# Prepare a usable Weston and Wayland runtime dynamically for a display test.
+# Validation mode:
+# runtime, only verify Weston runtime readiness, process and socket
+# client, also verify a real Wayland client path through wayland_connection_ok
+# Relaunch policy:
+# default is disabled
+# when enabled, failed Weston systemd state is cleaned before relaunch
+# Arguments:
+# $1, testcase name for log messages
+# $2, wait timeout in seconds, default 10
+# $3, validation mode, runtime or client, default runtime
+# $4, allow relaunch, 1 enables relaunch, 0 disables it, default 0
+# Exports:
+# DISPLAY_WAYLAND_SOCKET, final adopted Wayland socket path
+# DISPLAY_RUNTIME_MODEL, per-user, global, or custom
+# Return:
+# 0 when runtime is ready and usable
+# 1 when no Wayland socket is found on base, connected display is present, Weston runtime is expected
+# 2 when no Wayland socket is found on overlay after optional relaunch handling
+# 3 when runtime validation fails, or Weston process is missing and relaunch is disabled
+weston_prepare_runtime() {
+    wr_testname="$1"
+    wr_wait_secs="${2:-10}"
+    wr_validate_mode="${3:-runtime}"
+    wr_allow_relaunch="${4:-0}"
+
+    DISPLAY_WAYLAND_SOCKET=""
+    DISPLAY_RUNTIME_MODEL="unknown"
+    export DISPLAY_WAYLAND_SOCKET
+    export DISPLAY_RUNTIME_MODEL
+
+    if [ -z "${DISPLAY_BUILD_FLAVOUR:-}" ]; then
+        display_detect_build_flavour
+    fi
+
+    if command -v weston_log_runtime_snapshot >/dev/null 2>&1; then
+        weston_log_runtime_snapshot "${wr_testname}: start"
+    elif command -v wayland_debug_snapshot >/dev/null 2>&1; then
+        wayland_debug_snapshot "${wr_testname}: start"
+    fi
+
+    wr_sock=""
+    wr_new_sock=""
+    wr_service_failed=0
+    wr_need_relaunch=0
+
+    if command -v systemd_service_exists >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
+        if systemd_service_exists weston.service; then
+            if systemctl is-failed --quiet weston.service 2>/dev/null; then
+                wr_service_failed=1
+            fi
+        fi
+    fi
+
+    if weston_has_running_process; then
+        if [ "$wr_allow_relaunch" -eq 1 ]; then
+            log_info "Relaunch not required, Weston already running"
+        fi
+    else
+        wr_need_relaunch=1
+    fi
+
+    if [ "$wr_service_failed" -eq 1 ]; then
+        if [ "$wr_allow_relaunch" -eq 1 ]; then
+            wr_need_relaunch=1
+            log_warn "weston.service is in failed state, cleanup and relaunch will be attempted"
+        else
+            log_fail "weston.service is in failed state, runtime is not healthy"
+            return 3
+        fi
+    fi
+
+    if [ "$wr_need_relaunch" -eq 1 ]; then
+        if [ "$wr_allow_relaunch" -ne 1 ]; then
+            if [ "$wr_service_failed" -eq 1 ]; then
+                log_fail "weston.service is in failed state, runtime relaunch is disabled"
+            else
+                log_fail "No weston process found, runtime relaunch is disabled"
+            fi
+            return 3
+        fi
+
+        log_warn "Preparing Weston runtime relaunch, cleaning stale systemd state first"
+
+        if command -v systemd_service_exists >/dev/null 2>&1 && systemd_service_exists weston.service; then
+            if ! weston_restart_systemd_runtime "$wr_wait_secs"; then
+                if command -v weston_log_runtime_snapshot >/dev/null 2>&1; then
+                    weston_log_runtime_snapshot "${wr_testname}: after-relaunch"
+                fi
+                log_fail "Weston relaunch attempt failed, systemd-managed Weston could not be recovered"
+                return 3
+            fi
+        elif command -v weston_restore_runtime >/dev/null 2>&1; then
+            log_info "Attempting weston_restore_runtime"
+            if ! weston_restore_runtime "$wr_wait_secs"; then
+                if command -v weston_log_runtime_snapshot >/dev/null 2>&1; then
+                    weston_log_runtime_snapshot "${wr_testname}: after-relaunch"
+                fi
+                log_fail "Weston relaunch attempt failed, weston_restore_runtime returned non-zero"
+                return 3
+            fi
+        elif [ "$DISPLAY_BUILD_FLAVOUR" = "overlay" ] && command -v overlay_start_weston_drm >/dev/null 2>&1; then
+            log_info "Attempting overlay_start_weston_drm"
+
+            if command -v weston_force_primary_1080p60_if_not_60 >/dev/null 2>&1; then
+                log_info "Pre-configuring primary output to about 60Hz before starting Weston, best effort"
+                weston_force_primary_1080p60_if_not_60 || true
+            fi
+
+            if ! overlay_start_weston_drm; then
+                if command -v weston_log_runtime_snapshot >/dev/null 2>&1; then
+                    weston_log_runtime_snapshot "${wr_testname}: after-relaunch"
+                fi
+                log_fail "Weston relaunch attempt failed, overlay_start_weston_drm returned non-zero"
+                return 3
+            fi
+
+            if command -v weston_wait_ready >/dev/null 2>&1; then
+                weston_wait_ready "$wr_wait_secs" || true
+            fi
+        else
+            log_fail "No Weston relaunch helper is available"
+            return 3
+        fi
+
+        if command -v weston_log_runtime_snapshot >/dev/null 2>&1; then
+            weston_log_runtime_snapshot "${wr_testname}: after-relaunch"
+        fi
+
+        if command -v systemd_service_exists >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
+            if systemd_service_exists weston.service; then
+                if systemctl is-failed --quiet weston.service 2>/dev/null; then
+                    log_fail "weston.service is still in failed state after relaunch attempt"
+                    return 3
+                fi
+            fi
+        fi
+
+        if ! weston_has_running_process; then
+            log_fail "Weston relaunch did not result in a running process"
+            return 3
+        fi
+    fi
+
+    if ! weston_has_running_process; then
+        log_fail "Wayland runtime validation failed, Weston process is not running"
+        return 3
+    fi
+
+    if command -v weston_preferred_socket >/dev/null 2>&1; then
+        wr_sock="$(weston_preferred_socket 2>/dev/null || true)"
+    elif command -v discover_wayland_socket_anywhere >/dev/null 2>&1; then
+        wr_sock="$(discover_wayland_socket_anywhere 2>/dev/null | head -n 1 || true)"
+    fi
+
+    if [ -n "$wr_sock" ] && command -v adopt_wayland_env_from_socket >/dev/null 2>&1; then
+        log_info "Found existing Wayland socket, ${wr_sock}"
+        if ! adopt_wayland_env_from_socket "$wr_sock"; then
+            log_warn "Failed to adopt environment from ${wr_sock}"
+        fi
+    fi
+
+    if [ -z "$wr_sock" ] && command -v weston_wait_ready >/dev/null 2>&1; then
+        log_info "No usable Wayland socket yet, waiting briefly for Weston runtime"
+        if weston_wait_ready "$wr_wait_secs"; then
+            if command -v weston_preferred_socket >/dev/null 2>&1; then
+                wr_sock="$(weston_preferred_socket 2>/dev/null || true)"
+            elif command -v discover_wayland_socket_anywhere >/dev/null 2>&1; then
+                wr_sock="$(discover_wayland_socket_anywhere 2>/dev/null | head -n 1 || true)"
+            fi
+
+            if [ -n "$wr_sock" ] && command -v adopt_wayland_env_from_socket >/dev/null 2>&1; then
+                log_info "Weston runtime became ready, ${wr_sock}"
+                if ! adopt_wayland_env_from_socket "$wr_sock"; then
+                    log_warn "Failed to adopt environment from ${wr_sock} after wait"
+                fi
+            fi
+        fi
+    fi
+
+    if command -v weston_preferred_socket >/dev/null 2>&1; then
+        wr_new_sock="$(weston_preferred_socket 2>/dev/null || true)"
+        if [ -n "$wr_new_sock" ]; then
+            wr_sock="$wr_new_sock"
+        fi
+    elif command -v discover_wayland_socket_anywhere >/dev/null 2>&1; then
+        wr_new_sock="$(discover_wayland_socket_anywhere 2>/dev/null | head -n 1 || true)"
+        if [ -n "$wr_new_sock" ]; then
+            wr_sock="$wr_new_sock"
+        fi
+    fi
+
+    if [ -z "$wr_sock" ]; then
+        if [ "$DISPLAY_BUILD_FLAVOUR" = "base" ]; then
+            log_fail "No Wayland socket found on base build, connected display is present, Weston runtime is expected"
+            return 1
+        fi
+
+        log_fail "No Wayland socket found on overlay build after optional relaunch handling"
+        return 2
+    fi
+
+    case "$wr_sock" in
+        /run/user/*/wayland-*)
+            DISPLAY_RUNTIME_MODEL="per-user"
+            ;;
+        /run/wayland-*)
+            DISPLAY_RUNTIME_MODEL="global"
+            ;;
+        *)
+            DISPLAY_RUNTIME_MODEL="custom"
+            ;;
+    esac
+
+    DISPLAY_WAYLAND_SOCKET="$wr_sock"
+    export DISPLAY_RUNTIME_MODEL
+    export DISPLAY_WAYLAND_SOCKET
+
+    log_info "Wayland runtime model, ${DISPLAY_RUNTIME_MODEL}"
+    log_info "Wayland socket, ${DISPLAY_WAYLAND_SOCKET}"
+    log_info "XDG_RUNTIME_DIR, ${XDG_RUNTIME_DIR:-<unset>}"
+    log_info "WAYLAND_DISPLAY, ${WAYLAND_DISPLAY:-<unset>}"
+
+    if [ "$wr_validate_mode" = "client" ]; then
+        if command -v wayland_connection_ok >/dev/null 2>&1; then
+            if ! wayland_connection_ok; then
+                log_fail "Wayland client probe failed, runtime is not usable"
+                return 3
+            fi
+            log_info "Wayland client probe, OK"
+        else
+            log_warn "wayland_connection_ok helper not found, continuing with runtime-only checks"
+        fi
+    else
+        if ! weston_has_running_process; then
+            log_fail "Wayland runtime validation failed, Weston process is not running"
+            return 3
+        fi
+
+        if command -v weston_runtime_socket_exists >/dev/null 2>&1; then
+            if ! weston_runtime_socket_exists; then
+                log_fail "Wayland runtime validation failed, socket is not present after adoption"
+                return 3
+            fi
+        fi
+
+        if command -v systemd_service_exists >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
+            if systemd_service_exists weston.service; then
+                if systemctl is-failed --quiet weston.service 2>/dev/null; then
+                    log_fail "Wayland runtime validation failed, weston.service is in failed state"
+                    return 3
+                fi
+            fi
+        fi
+
+        if command -v weston_log_runtime_snapshot >/dev/null 2>&1; then
+            weston_log_runtime_snapshot "${wr_testname}: final"
+        fi
+
+        log_info "Wayland runtime validation, OK"
+    fi
+
+    return 0
+}


### PR DESCRIPTION
Add Weston_Runtime_Preflight under Runner/suites/Multimedia/Display and enhance shared Weston runtime handling in Runner/utils/[lib_display.sh](http://lib_display.sh/).

- This change introduces a pure Weston and Wayland runtime gate that validates display connectivity, Weston process and systemd health, dynamic Wayland runtime discovery, and EGL pipeline diagnostics. 
- It fails by default when Weston runtime is unhealthy, and supports an explicit --allow-relaunch path for controlled runtime recovery with better logging and post-relaunch validation.
- It also keeps runtime validation separate from client-level coverage, so weston-simple-shm and weston-simple-egl remain dedicated follow-on blockers.

Job for reference https://lava.infra.foundries.io/scheduler/job/178825