### PR TITLE
Enhance fastrpc_test for multi-domain and multi-PD execution

### DIFF
--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.yaml
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.yaml
@@ -1,7 +1,7 @@
 metadata:
   name: fastrpc-test
   format: "Lava-Test Test Definition 1.0"
-  description: "The **fastrpc_test** runner validates FastRPC (Fast Remote Procedure Call) on Qualcomm targets, offloading work to DSP domains (e.g., **CDSP**)."
+  description: "The **fastrpc_test** runner validates FastRPC (Fast Remote Procedure Call) on Qualcomm targets, offloading work to runtime-detected DSP domains."
   os:
     - linux
   scope:
@@ -10,9 +10,11 @@ metadata:
 params:
   ARCH: ""  # Architecture (only if explicitly provided)
   BIN_DIR: "/usr/bin"  # Directory containing 'fastrpc_test' (default: /usr/bin)
-  DOMAIN: "0"  # <0|1|2|3> DSP domain: 0=ADSP, 1=MDSP, 2=SDSP, 3=CDSP
-  DOMAIN_NAME: "adsp"  # DSP domain by name: adsp|mdsp|sdsp|cdsp
-  USER_PD: 0  # Use '-U 1' (user/unsigned PD). Default is '-U 0'.
+  DOMAIN_MODE: "all-supported"  # all-supported|single (default: all-supported)
+  DOMAIN: ""  # Optional explicit domain id in single-domain mode
+  DOMAIN_NAME: ""  # Optional explicit domain name in single-domain mode
+  PD_MODE: "both"  # both|signed-only|unsigned-only (default: both)
+  USER_PD: ""  # Compatibility override. If set to non-zero, runs only -U 1
   REPEAT: 1  # Number of repetitions (default: 1)
   TIMEOUT: ""  # Timeout for each run (no timeout if omitted)
 
@@ -21,6 +23,6 @@ run:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/CDSP/fastrpc_test
     - USER_PD_PARAM=""
-    - if [ "${USER_PD}" != 0 ]; then USER_PD_PARAM="--user-pd"; fi
-    - ./run.sh --arch "${ARCH}" --bin-dir "${BIN_DIR}" --domain "${DOMAIN}" --domain-name "${DOMAIN_NAME}" --repeat "${REPEAT}" --timeout "${TIMEOUT}" $USER_PD_PARAM || true
+    - if [ -n "${USER_PD}" ] && [ "${USER_PD}" != 0 ]; then USER_PD_PARAM="--user-pd"; fi
+    - ./run.sh --arch "${ARCH}" --bin-dir "${BIN_DIR}" --domain-mode "${DOMAIN_MODE}" --domain "${DOMAIN}" --domain-name "${DOMAIN_NAME}" --pd-mode "${PD_MODE}" --repeat "${REPEAT}" --timeout "${TIMEOUT}" $USER_PD_PARAM || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh fastrpc_test.res || true

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.yaml
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.yaml
@@ -21,7 +21,7 @@ params:
   DOMAIN: ""  # Optional explicit domain id in single-domain mode
   DOMAIN_NAME: ""  # Optional explicit domain name in single-domain mode
   PD_MODE: "both"  # both|signed-only|unsigned-only (default: both - tests both PDs where supported)
-  USER_PD: ""  # Compatibility override. If set to non-zero, runs only -U 1
+  UNSIGNED_PD: ""  # If set to non-zero, runs only unsigned PD mode (-U 1)
   REPEAT: 1  # Number of repetitions (default: 1)
   TIMEOUT: ""  # Timeout for each run (no timeout if omitted)
 
@@ -29,7 +29,7 @@ run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/CDSP/fastrpc_test
-    - USER_PD_PARAM=""
-    - if [ -n "${USER_PD}" ] && [ "${USER_PD}" != 0 ]; then USER_PD_PARAM="--user-pd"; fi
-    - ./run.sh --arch "${ARCH}" --bin-dir "${BIN_DIR}" --domain-mode "${DOMAIN_MODE}" --domain "${DOMAIN}" --domain-name "${DOMAIN_NAME}" --pd-mode "${PD_MODE}" --repeat "${REPEAT}" --timeout "${TIMEOUT}" $USER_PD_PARAM || true
+    - UNSIGNED_PD_PARAM=""
+    - if [ -n "${UNSIGNED_PD}" ] && [ "${UNSIGNED_PD}" != 0 ]; then UNSIGNED_PD_PARAM="--unsigned-pd"; fi
+    - ./run.sh --arch "${ARCH}" --bin-dir "${BIN_DIR}" --domain-mode "${DOMAIN_MODE}" --domain "${DOMAIN}" --domain-name "${DOMAIN_NAME}" --pd-mode "${PD_MODE}" --repeat "${REPEAT}" --timeout "${TIMEOUT}" $UNSIGNED_PD_PARAM || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh fastrpc_test.res || true

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.yaml
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.yaml
@@ -1,7 +1,14 @@
 metadata:
   name: fastrpc-test
   format: "Lava-Test Test Definition 1.0"
-  description: "The **fastrpc_test** runner validates FastRPC (Fast Remote Procedure Call) on Qualcomm targets, offloading work to runtime-detected DSP domains."
+  description: |
+    The **fastrpc_test** runner validates FastRPC (Fast Remote Procedure Call) on Qualcomm targets.
+
+    **Enhanced Test Coverage**:
+    - Now tests ALL supported DSP domains detected at runtime (ADSP, MDSP, SDSP, CDSP, CDSP1, GPDSP0, GPDSP1)
+    - Tests BOTH signed (system) and unsigned (user) Protection Domains where hardware supports them
+    - ADSP/MDSP/SDSP: signed PD only; CDSP/CDSP1/GPDSP: both signed and unsigned PDs
+    - For single-domain testing: set DOMAIN_MODE="single" and specify DOMAIN or DOMAIN_NAME
   os:
     - linux
   scope:
@@ -10,10 +17,10 @@ metadata:
 params:
   ARCH: ""  # Architecture (only if explicitly provided)
   BIN_DIR: "/usr/bin"  # Directory containing 'fastrpc_test' (default: /usr/bin)
-  DOMAIN_MODE: "all-supported"  # all-supported|single (default: all-supported)
+  DOMAIN_MODE: "all-supported"  # all-supported|single (default: all-supported - tests all detected domains)
   DOMAIN: ""  # Optional explicit domain id in single-domain mode
   DOMAIN_NAME: ""  # Optional explicit domain name in single-domain mode
-  PD_MODE: "both"  # both|signed-only|unsigned-only (default: both)
+  PD_MODE: "both"  # both|signed-only|unsigned-only (default: both - tests both PDs where supported)
   USER_PD: ""  # Compatibility override. If set to non-zero, runs only -U 1
   REPEAT: 1  # Number of repetitions (default: 1)
   TIMEOUT: ""  # Timeout for each run (no timeout if omitted)

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.yaml
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.yaml
@@ -1,7 +1,15 @@
 metadata:
   name: fastrpc-test
   format: "Lava-Test Test Definition 1.0"
-  description: "The **fastrpc_test** runner validates FastRPC (Fast Remote Procedure Call) on Qualcomm targets, offloading work to DSP domains (e.g., **CDSP**)."
+  description: |
+    The **fastrpc_test** runner validates FastRPC (Fast Remote Procedure Call) on Qualcomm targets.
+
+    **Enhanced Test Coverage**:
+    - Now tests ALL supported DSP domains detected at runtime (ADSP, MDSP, SDSP, CDSP, CDSP1, GPDSP0, GPDSP1)
+    - Tests BOTH signed (system) and unsigned (user) Protection Domains where hardware supports them
+    - ADSP/MDSP/SDSP: signed PD only; CDSP/CDSP1/GPDSP: both signed and unsigned PDs
+    - QCS9075, QCS8275, QCS8300, QCS9100: GPDSP0/GPDSP1 domains are skipped (fastrpc_tests binaries not supported temporarily)
+    - For single-domain testing: set DOMAIN_MODE="single" and specify DOMAIN or DOMAIN_NAME
   os:
     - linux
   scope:
@@ -10,9 +18,11 @@ metadata:
 params:
   ARCH: ""  # Architecture (only if explicitly provided)
   BIN_DIR: "/usr/bin"  # Directory containing 'fastrpc_test' (default: /usr/bin)
-  DOMAIN: "0"  # <0|1|2|3> DSP domain: 0=ADSP, 1=MDSP, 2=SDSP, 3=CDSP
-  DOMAIN_NAME: "adsp"  # DSP domain by name: adsp|mdsp|sdsp|cdsp
-  USER_PD: 0  # Use '-U 1' (user/unsigned PD). Default is '-U 0'.
+  DOMAIN_MODE: "all-supported"  # all-supported|single (default: all-supported - tests all detected domains)
+  DOMAIN: ""  # Optional explicit domain id in single-domain mode
+  DOMAIN_NAME: ""  # Optional explicit domain name in single-domain mode
+  PD_MODE: "both"  # both|signed-only|unsigned-only (default: both - tests both PDs where supported)
+  UNSIGNED_PD: ""  # If set to non-zero, runs only unsigned PD mode (-U 1)
   REPEAT: 1  # Number of repetitions (default: 1)
   TIMEOUT: ""  # Timeout for each run (no timeout if omitted)
 
@@ -20,7 +30,7 @@ run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/CDSP/fastrpc_test
-    - USER_PD_PARAM=""
-    - if [ "${USER_PD}" != 0 ]; then USER_PD_PARAM="--user-pd"; fi
-    - ./run.sh --arch "${ARCH}" --bin-dir "${BIN_DIR}" --domain "${DOMAIN}" --domain-name "${DOMAIN_NAME}" --repeat "${REPEAT}" --timeout "${TIMEOUT}" $USER_PD_PARAM || true
+    - UNSIGNED_PD_PARAM=""
+    - if [ -n "${UNSIGNED_PD}" ] && [ "${UNSIGNED_PD}" != 0 ]; then UNSIGNED_PD_PARAM="--unsigned-pd"; fi
+    - ./run.sh --arch "${ARCH}" --bin-dir "${BIN_DIR}" --domain-mode "${DOMAIN_MODE}" --domain "${DOMAIN}" --domain-name "${DOMAIN_NAME}" --pd-mode "${PD_MODE}" --repeat "${REPEAT}" --timeout "${TIMEOUT}" $UNSIGNED_PD_PARAM || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh fastrpc_test.res || true

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
@@ -40,16 +40,22 @@ VERBOSE=0
 USER_PD_FLAG=0 # default: -U 0 (system/signed PD)
 CLI_DOMAIN=""
 CLI_DOMAIN_NAME=""
-DOMAIN_MODE="all-supported" # ENHANCED: default to all-supported
-PD_MODE="both" # ENHANCED: default to both PDs
+DOMAIN_MODE="all-supported" # Default: test all supported domains
+PD_MODE="both" # Default: test both PDs where supported
 
 usage() {
     cat <<EOF
 Usage: $0 [OPTIONS]
 
+**Enhanced Test Coverage**:
+  This test now validates FastRPC across all supported DSP domains and PD modes.
+  - Tests all detected domains: ADSP, MDSP, SDSP, CDSP, CDSP1, GPDSP0, GPDSP1
+  - Tests both signed and unsigned Protection Domains where hardware supports them
+  - For legacy single-domain testing: use --domain-mode single --domain <N>
+
 Options:
   --arch <name> Architecture (only if explicitly provided)
-  --bin-dir <path> Directory containing 'fastrpc_test' (default: /usr/local/bin)
+  --bin-dir <path> Directory containing 'fastrpc_test' (default: /usr/bin)
   --assets-dir <path> (compat) previously used when assets lived under 'linux/'
   --domain <0|1|2|3|4|5|6> DSP domain: 0=ADSP, 1=MDSP, 2=SDSP, 3=CDSP, 4=CDSP1, 5=GPDSP0, 6=GPDSP1
   --domain-name <name> DSP domain by name: adsp|mdsp|sdsp|cdsp|cdsp1|gpdsp0|gpdsp1
@@ -60,6 +66,13 @@ Options:
   --timeout <sec> Timeout for each run (no timeout if omitted)
   --verbose Extra logging for CI debugging
   --help Show this help
+
+Domain Selection Priority:
+  1. --domain-name (highest priority, forces single domain)
+  2. --domain (forces single domain)
+  3. --domain-mode single + FASTRPC_DOMAIN_NAME env
+  4. --domain-mode single + FASTRPC_DOMAIN env
+  5. --domain-mode all-supported (default, discovers all)
 
 Env:
   FASTRPC_DOMAIN=0|1|2|3|4|5|6 Sets domain; CLI --domain/--domain-name wins.
@@ -77,7 +90,6 @@ Notes:
     CDSP_LIBRARY_PATH=/usr/local/share/fastrpc_test/v75[:v68]
     SDSP_LIBRARY_PATH=/usr/local/share/fastrpc_test/v75[:v68]
 - Domain mapping: ADSP=0 MDSP=1 SDSP=2 CDSP=3 CDSP1=4 GPDSP0=5 GPDSP1=6
-- Default: discover all supported domains at runtime and run both signed/unsigned PDs where supported.
 - PD support: ADSP/MDSP/SDSP support signed only; CDSP/CDSP1/GPDSP support both.
 EOF
 }
@@ -150,7 +162,7 @@ cmd_to_string() {
 }
 
 log_dsp_remoteproc_status() {
-    fw_list="adsp mdsp sdsp cdsp cdsp0 cdsp1 gdsp0 gdsp1 gpdsp0 gpdsp1" # extended list
+    fw_list="adsp mdsp sdsp cdsp cdsp0 cdsp1 gdsp0 gdsp1 gpdsp0 gpdsp1"
     any=0
     for fw in $fw_list; do
         if dt_has_remoteproc_fw "$fw"; then
@@ -176,9 +188,9 @@ name_to_domain() {
         mdsp) echo 1 ;;
         sdsp) echo 2 ;;
         cdsp) echo 3 ;;
-        cdsp1) echo 4 ;; # ENHANCED
-        gpdsp0|gdsp0) echo 5 ;; # ENHANCED
-        gpdsp1|gdsp1) echo 6 ;; # ENHANCED
+        cdsp1) echo 4 ;;
+        gpdsp0|gdsp0) echo 5 ;;
+        gpdsp1|gdsp1) echo 6 ;;
         *) echo "" ;;
     esac
 }
@@ -286,20 +298,6 @@ effective_pds_for_domain() {
     printf "%s" "$effective"
 }
 
-pick_default_domain() {
-    # Prefer CDSP if present; else ADSP; else SDSP; else 3
-    if dt_has_remoteproc_fw "cdsp" || dt_has_remoteproc_fw "cdsp0" || dt_has_remoteproc_fw "cdsp1"; then
-        echo 3; return
-    fi
-    if dt_has_remoteproc_fw "adsp"; then
-        echo 0; return
-    fi
-    if dt_has_remoteproc_fw "sdsp"; then
-        echo 2; return
-    fi
-    echo 3
-}
-
 # -------------------- Banner --------------------
 log_info "--------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
@@ -319,7 +317,7 @@ case "$BIN_DIR" in
         if [ "${ALLOW_BIN_FASTRPC:-0}" -ne 1 ]; then
 	    log_skip "$TESTNAME SKIP - unsupported layout: /bin. Set ALLOW_BIN_FASTRPC=1 or pass --bin-dir."
             echo "$TESTNAME : SKIP" >"$RESULT_FILE"
-            exit 1
+            exit 0
         fi
     ;;
 esac
@@ -330,7 +328,7 @@ RUN_BIN="$RUN_DIR/fastrpc_test"
 if [ ! -x "$RUN_BIN" ]; then
     log_skip "$TESTNAME SKIP - fastrpc_test not installed (expected at: $RUN_BIN)"
     echo "$TESTNAME : SKIP" >"$RESULT_FILE"
-    exit 1
+    exit 0
 fi
 
 # New layout checks (replace legacy 'linux/' checks)
@@ -378,7 +376,7 @@ DOMAINS_TO_TEST="$(resolve_domains_to_test)"
 if [ -z "$DOMAINS_TO_TEST" ]; then
     log_skip "$TESTNAME SKIP - no mapped/supported domains detected"
     echo "$TESTNAME : SKIP" >"$RESULT_FILE"
-    exit 1
+    exit 0
 fi
 
 log_info "Domain mode: $DOMAIN_MODE"
@@ -410,6 +408,10 @@ log_info "Repeats: $REPEAT | Timeout: $tmo_label | Buffering: $buf_label"
 PASS_COUNT=0
 TOTAL_COUNT=0
 
+# Track per-domain/per-PD results during execution
+# Format: "DOMAIN:PD:pass_count:fail_count"
+RESULTS_TRACKER=""
+
 for DOMAIN in $DOMAINS_TO_TEST; do
     dom_name="$(domain_to_name "$DOMAIN")"
     PD_VALUES="$(effective_pds_for_domain "$DOMAIN")"
@@ -426,6 +428,10 @@ for DOMAIN in $DOMAINS_TO_TEST; do
             *) pd_name="unknown" ;;
         esac
 
+        # Initialize counters for this domain/PD combo
+        combo_pass=0
+        combo_fail=0
+
         i=1
         while [ "$i" -le "$REPEAT" ]; do
             TOTAL_COUNT=$((TOTAL_COUNT+1))
@@ -441,7 +447,8 @@ for DOMAIN in $DOMAINS_TO_TEST; do
             set -- -d "$DOMAIN" -t linux
             [ -n "$ARCH" ] && set -- "$@" -a "$ARCH"
             set -- "$@" -U "$PD_VAL"
-            [ -n "${FASTRPC_EXTRA_FLAGS:-}" ] && set -- "$@" $FASTRPC_EXTRA_FLAGS
+            # shellcheck disable=SC2086
+            [ -n "${FASTRPC_EXTRA_FLAGS:-}" ] && set -- "$@" ${FASTRPC_EXTRA_FLAGS}
 
             {
                 echo "DATE_UTC=$iso_now"
@@ -494,97 +501,66 @@ for DOMAIN in $DOMAINS_TO_TEST; do
                 log_dsp_remoteproc_status
             fi
 
+            # Track result immediately
             if [ "$rc" -eq 0 ] && [ -r "$iter_log" ] && grep -F -q -e "All tests completed successfully" -e "All applicable tests PASSED" "$iter_log"; then
                 PASS_COUNT=$((PASS_COUNT+1))
+                combo_pass=$((combo_pass+1))
                 log_pass "$iter_tag: success"
             else
+                combo_fail=$((combo_fail+1))
                 log_warn "$iter_tag: success pattern not found"
             fi
 
             i=$((i+1))
         done
+
+        # Store results for this domain/PD combo
+        RESULTS_TRACKER="${RESULTS_TRACKER}${DOMAIN}:${PD_VAL}:${combo_pass}:${combo_fail}
+"
     done
 done
 
 # -------------------- Finalize --------------------------------
-# Build detailed summary table
+# Build detailed summary table from tracked results
 log_info "=========================================================================="
 log_info "                         FastRPC Test Summary"
 log_info "=========================================================================="
 
-# Collect results per domain/PD combination
 SUMMARY_FILE="$LOG_ROOT/summary.txt"
-> "$SUMMARY_FILE"
-
-for DOMAIN in $DOMAINS_TO_TEST; do
-    dom_name="$(domain_to_name "$DOMAIN")"
-    PD_VALUES="$(effective_pds_for_domain "$DOMAIN")"
-    
-    [ -z "$PD_VALUES" ] && continue
-    
-    for PD_VAL in $PD_VALUES; do
-        case "$PD_VAL" in
-            0) pd_name="Signed  " ;;
-            1) pd_name="Unsigned" ;;
-            *) pd_name="Unknown " ;;
-        esac
-        
-        # Count pass/fail for this domain/PD combo
-        combo_pass=0
-        combo_fail=0
-        combo_total=0
-        
-        i=1
-        while [ "$i" -le "$REPEAT" ]; do
-            case "$PD_VAL" in
-                0) iter_tag="${dom_name}_signed_iter${i}" ;;
-                1) iter_tag="${dom_name}_unsigned_iter${i}" ;;
-                *) iter_tag="${dom_name}_u${PD_VAL}_iter${i}" ;;
-            esac
-            
-            iter_rc="$LOG_ROOT/${iter_tag}.rc"
-            iter_log="$LOG_ROOT/${iter_tag}.out"
-            
-            if [ -f "$iter_rc" ]; then
-                combo_total=$((combo_total + 1))
-                rc=$(cat "$iter_rc")
-                if [ "$rc" -eq 0 ] && [ -r "$iter_log" ] && grep -F -q -e "All tests completed successfully" -e "All applicable tests PASSED" "$iter_log"; then
-                    combo_pass=$((combo_pass + 1))
-                else
-                    combo_fail=$((combo_fail + 1))
-                fi
-            fi
-            
-            i=$((i + 1))
-        done
-        
-        # Determine status
-        if [ "$combo_total" -eq 0 ]; then
-            status="SKIP"
-        elif [ "$combo_fail" -eq 0 ]; then
-            status="PASS"
-        else
-            status="FAIL"
-        fi
-        
-        # Write to summary file
-        printf "%-10s | %-10s | %4d | %4d | %4s\n" "$dom_name" "$pd_name" "$combo_pass" "$combo_fail" "$status" >> "$SUMMARY_FILE"
-    done
-done
+true > "$SUMMARY_FILE"
 
 # Display table header
 log_info "--------------------------------------------------------------------------"
 log_info "Domain     | PD Mode    | Pass | Fail | Status"
 log_info "--------------------------------------------------------------------------"
 
-# Display table content
-if [ -f "$SUMMARY_FILE" ] && [ -s "$SUMMARY_FILE" ]; then
-    while IFS= read -r line; do
-        log_info "$line"
-    done < "$SUMMARY_FILE"
-else
-    log_info "No test results to display"
-fi
+# Parse tracked results and build table
+echo "$RESULTS_TRACKER" | while IFS=: read -r domain pd_val pass_cnt fail_cnt; do
+    [ -z "$domain" ] && continue
+
+    dom_name="$(domain_to_name "$domain")"
+    case "$pd_val" in
+        0) pd_name="Signed  " ;;
+        1) pd_name="Unsigned" ;;
+        *) pd_name="Unknown " ;;
+    esac
+
+    combo_total=$((pass_cnt + fail_cnt))
+
+    # Determine status
+    if [ "$combo_total" -eq 0 ]; then
+        status="SKIP"
+    elif [ "$fail_cnt" -eq 0 ]; then
+        status="PASS"
+    else
+        status="FAIL"
+    fi
+
+    # Write to summary file and log (properly formatted table row)
+    line=$(printf "%-10s | %-10s | %4d | %4d | %4s" "$dom_name" "$pd_name" "$pass_cnt" "$fail_cnt" "$status")
+    echo "$line" >> "$SUMMARY_FILE"
+    log_info "$line"
+done
 
 log_info "--------------------------------------------------------------------------"
 log_info "Overall:   Total runs: $TOTAL_COUNT | Passed: $PASS_COUNT | Failed: $((TOTAL_COUNT - PASS_COUNT))"
@@ -594,17 +570,13 @@ log_info "======================================================================
 if [ "$TOTAL_COUNT" -eq 0 ]; then
     log_skip "$TESTNAME SKIP - no runnable domain/PD combinations"
     echo "$TESTNAME : SKIP" > "$RESULT_FILE"
+    exit 0
 elif [ "$PASS_COUNT" -eq "$TOTAL_COUNT" ]; then
     log_pass "$TESTNAME : Test Passed ($PASS_COUNT/$TOTAL_COUNT)"
     echo "$TESTNAME : PASS" > "$RESULT_FILE"
+    exit 0
 else
     log_fail "$TESTNAME : Test Failed ($PASS_COUNT/$TOTAL_COUNT)"
     echo "$TESTNAME : FAIL" > "$RESULT_FILE"
+    exit 1
 fi
-
-[ -f "$RESULT_FILE" ] || {
-    log_error "Missing result file ($RESULT_FILE) — creating FAIL"
-    echo "$TESTNAME : FAIL" >"$RESULT_FILE"
-}
-
-exit 0

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
@@ -2,6 +2,9 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 # --------- Robustly source init_env and functestlib.sh ----------
+
+TESTNAME="fastrpc_test"
+RESULT_FILE="$TESTNAME.res"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
 SEARCH="$SCRIPT_DIR"
@@ -15,20 +18,19 @@ done
 
 if [ -z "$INIT_ENV" ]; then
     echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
-    exit 1
+    echo "$TESTNAME : FAIL" >"$RESULT_FILE" 2>/dev/null || true
+    exit 0
 fi
 
 # Only source once (idempotent)
-if [ -z "$__INIT_ENV_LOADED" ]; then
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
     # shellcheck disable=SC1090
     . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
 fi
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
 # ---------------------------------------------------------------
-
-TESTNAME="fastrpc_test"
-RESULT_FILE="$TESTNAME.res"
 
 # Defaults
 REPEAT=1
@@ -109,7 +111,7 @@ while [ $# -gt 0 ]; do
         --timeout) TIMEOUT="$2"; shift 2 ;;
         --verbose) VERBOSE=1; shift ;;
         --help) usage; exit 0 ;;
-        *) echo "[ERROR] Unknown argument: $1" >&2; usage; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;;
+        *) echo "[ERROR] Unknown argument: $1" >&2; usage; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;;
     esac
 done
 
@@ -121,29 +123,33 @@ if [ -n "${ASSETS_DIR:-}" ]; then
 fi
 
 # ---------- Validation ----------
-case "$REPEAT" in *[!0-9]*|"") log_error "Invalid --repeat: $REPEAT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
+case "$REPEAT" in *[!0-9]*|"") log_error "Invalid --repeat: $REPEAT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;; esac
 if [ -n "$TIMEOUT" ]; then
-    case "$TIMEOUT" in *[!0-9]*|"") log_error "Invalid --timeout: $TIMEOUT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
+    case "$TIMEOUT" in *[!0-9]*|"") log_error "Invalid --timeout: $TIMEOUT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;; esac
 fi
 # Validate enhanced options
-case "$DOMAIN_MODE" in all-supported|single) : ;; *) log_error "Invalid --domain-mode: $DOMAIN_MODE"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
-case "$PD_MODE" in both|signed-only|unsigned-only) : ;; *) log_error "Invalid --pd-mode: $PD_MODE"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
+case "$DOMAIN_MODE" in all-supported|single) : ;; *) log_error "Invalid --domain-mode: $DOMAIN_MODE"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;; esac
+case "$PD_MODE" in both|signed-only|unsigned-only) : ;; *) log_error "Invalid --pd-mode: $PD_MODE"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;; esac
 
 # Ensure we're in the testcase directory (repo convention)
 test_path="$(find_test_case_by_name "$TESTNAME")" || {
     log_error "Cannot locate test path for $TESTNAME"
     echo "$TESTNAME : FAIL" >"$RESULT_FILE"
-    exit 1
+    exit 0
 }
 cd "$test_path" || {
     log_error "cd to test path failed: $test_path"
     echo "$TESTNAME : FAIL" >"$RESULT_FILE"
-    exit 1
+    exit 0
 }
 
 # -------------------- Helpers --------------------
-# shellcheck disable=SC2317  # Helper kept for optional debug use.
-log_debug() { [ "$VERBOSE" -eq 1 ] && log_info "[debug] $*"; }
+# shellcheck disable=SC2317 # Helper kept for optional debug use.
+log_debug() {
+    if [ "$VERBOSE" -eq 1 ]; then
+        log_info "[debug] $*" >&2
+    fi
+}
 
 cmd_to_string() {
     out=""
@@ -159,6 +165,22 @@ cmd_to_string() {
         esac
     done
     printf "%s" "$out"
+}
+
+extract_test_summary_counts() {
+    log_file="$1"
+
+    total="$(sed -n 's/^[[:space:]]*Total tests run:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$log_file" | tail -n 1)"
+    passed="$(sed -n 's/^[[:space:]]*Passed:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$log_file" | tail -n 1)"
+    failed="$(sed -n 's/^[[:space:]]*Failed:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$log_file" | tail -n 1)"
+    skipped="$(sed -n 's/^[[:space:]]*Skipped:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$log_file" | tail -n 1)"
+
+    case "$total" in ''|*[!0-9]*) total=0 ;; esac
+    case "$passed" in ''|*[!0-9]*) passed=0 ;; esac
+    case "$failed" in ''|*[!0-9]*) failed=0 ;; esac
+    case "$skipped" in ''|*[!0-9]*) skipped=0 ;; esac
+
+    printf '%s:%s:%s:%s\n' "$total" "$passed" "$failed" "$skipped"
 }
 
 log_dsp_remoteproc_status() {
@@ -221,30 +243,42 @@ append_unique() {
 
 # Helper to normalize remoteproc/firmware names
 canonicalize_domain_name() {
-    case "$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]')" in
+    norm="$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    case "$norm" in
         cdsp0) echo "cdsp" ;;
         gdsp0) echo "gpdsp0" ;;
         gdsp1) echo "gpdsp1" ;;
-        *) printf "%s" "$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]')" ;;
+        *) printf "%s" "$norm" ;;
     esac
 }
 
 # Discover all supported domains
 discover_supported_domains() {
-    found=""
     echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') - discover_supported_domains: helper-backed discovery active" >&2
 
-    # Prefer helper-backed runtime remoteproc discovery using actual returned names.
     for fw in adsp mdsp sdsp cdsp cdsp0 cdsp1 gpdsp0 gpdsp1 gdsp0 gdsp1; do
         entries="$(get_remoteproc_by_firmware "$fw" "" all 2>/dev/null || true)"
 
         if [ -n "$entries" ]; then
             while IFS='|' read -r rpath rstate rfirm rname; do
-                [ -n "$rname" ] || continue
-                canon="$(canonicalize_domain_name "$rname")"
+                nameguess=""
+
+                if [ -n "$rname" ]; then
+                    nameguess="$rname"
+                elif [ -n "$rfirm" ]; then
+                    nameguess=$(basename "$rfirm" 2>/dev/null | sed 's/\.[^.]*$//')
+                fi
+
+                [ -n "$nameguess" ] || continue
+
+                canon="$(canonicalize_domain_name "$nameguess")"
                 d="$(name_to_domain "$canon")"
+
                 if [ -n "$d" ]; then
-                    found="$(append_unique "$found" "$d")"
+                    printf '%s\n' "$d"
+                    log_debug "discover: fw=$fw rname=$rname rfirm=$rfirm canon=$canon domain=$d state=$rstate"
+                else
+                    log_debug "discover: fw=$fw rname=$rname rfirm=$rfirm canon=$canon domain=<none>"
                 fi
             done <<EOF
 $entries
@@ -252,13 +286,15 @@ EOF
         elif dt_has_remoteproc_fw "$fw"; then
             canon="$(canonicalize_domain_name "$fw")"
             d="$(name_to_domain "$canon")"
+
             if [ -n "$d" ]; then
-                found="$(append_unique "$found" "$d")"
+                printf '%s\n' "$d"
+                log_debug "discover: fw=$fw dt-only canon=$canon domain=$d"
             fi
+        else
+            log_debug "discover: fw=$fw not present"
         fi
     done
-
-    printf "%s" "$found"
 }
 
 # Resolve which domains to test
@@ -278,14 +314,29 @@ resolve_domains_to_test() {
         resolved="$(discover_supported_domains)"
     fi
 
+    log_debug "resolve: raw domains='$resolved'"
+
     valid=""
     for d in $resolved; do
         case "$d" in
-            0|1|2|3|4|5|6) valid="$(append_unique "$valid" "$d")" ;;
-            *) log_warn "Ignoring invalid domain '$d'" ;;
+            0|1|2|3|4|5|6)
+                case " $valid " in
+                    *" $d "*) : ;;
+                    *)
+                        if [ -n "$valid" ]; then
+                            valid="${valid} ${d}"
+                        else
+                            valid="$d"
+                        fi
+                        ;;
+                esac
+                ;;
+            *)
+                log_warn "Ignoring invalid domain '$d'"
+                ;;
         esac
     done
-    printf "%s" "$valid"
+    printf '%s' "$valid"
 }
 
 # Get supported PD values for a domain
@@ -338,7 +389,7 @@ fi
 case "$BIN_DIR" in
     /bin)
         if [ "${ALLOW_BIN_FASTRPC:-0}" -ne 1 ]; then
-	    log_skip "$TESTNAME SKIP - unsupported layout: /bin. Set ALLOW_BIN_FASTRPC=1 or pass --bin-dir."
+            log_skip "$TESTNAME SKIP - unsupported layout: /bin. Set ALLOW_BIN_FASTRPC=1 or pass --bin-dir."
             echo "$TESTNAME : SKIP" >"$RESULT_FILE"
             exit 0
         fi
@@ -434,7 +485,7 @@ fi
 # -------------------- Logging root -----------------------------
 TS="$(date +%Y%m%d-%H%M%S)"
 LOG_ROOT="./logs_${TESTNAME}_${TS}"
-mkdir -p "$LOG_ROOT" || { log_error "Cannot create $LOG_ROOT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1; }
+mkdir -p "$LOG_ROOT" || { log_error "Cannot create $LOG_ROOT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0; }
 
 tmo_label="none"; [ -n "$TIMEOUT" ] && tmo_label="${TIMEOUT}s"
 log_info "Repeats: $REPEAT | Timeout: $tmo_label | Buffering: $buf_label"
@@ -559,16 +610,25 @@ done
 # -------------------- Finalize --------------------------------
 # Build detailed summary table from tracked results
 log_info "=========================================================================="
-log_info "                         FastRPC Test Summary"
+log_info " FastRPC Test Summary"
 log_info "=========================================================================="
 
 SUMMARY_FILE="$LOG_ROOT/summary.txt"
 true > "$SUMMARY_FILE"
 
 # Display table header
-log_info "--------------------------------------------------------------------------"
-log_info "Domain     | PD Mode    | Pass | Fail | Status"
-log_info "--------------------------------------------------------------------------"
+SUMMARY_FMT="%-10s | %-10s | %6s | %6s | %6s | %6s | %-6s"
+SUMMARY_SEP="--------------------------------------------------------------------------------"
+
+log_info "$SUMMARY_SEP"
+header_line="$(printf "$SUMMARY_FMT" "Domain" "PD Mode" "Total" "Pass" "Fail" "Skip" "Status")"
+log_info "$header_line"
+log_info "$SUMMARY_SEP"
+
+overall_subtests_total=0
+overall_subtests_pass=0
+overall_subtests_fail=0
+overall_subtests_skip=0
 
 # Parse tracked results and build table
 while IFS=: read -r domain pd_val pass_cnt fail_cnt; do
@@ -576,33 +636,66 @@ while IFS=: read -r domain pd_val pass_cnt fail_cnt; do
 
     dom_name="$(domain_to_name "$domain")"
     case "$pd_val" in
-        0) pd_name="Signed  " ;;
+        0) pd_name="Signed" ;;
         1) pd_name="Unsigned" ;;
-        *) pd_name="Unknown " ;;
+        *) pd_name="Unknown" ;;
     esac
 
-    combo_total=$((pass_cnt + fail_cnt))
+    combo_total_tests=0
+    combo_pass_tests=0
+    combo_fail_tests=0
+    combo_skip_tests=0
 
-    # Determine status
-    if [ "$combo_total" -eq 0 ]; then
+    case "$pd_val" in
+        0) pd_tag="signed" ;;
+        1) pd_tag="unsigned" ;;
+        *) pd_tag="unknown" ;;
+    esac
+
+    pattern="$LOG_ROOT/${dom_name}_${pd_tag}_iter"*.out
+    for iter_file in $pattern; do
+        [ -f "$iter_file" ] || continue
+
+        counts="$(extract_test_summary_counts "$iter_file")"
+        t="$(printf '%s' "$counts" | awk -F: '{print $1}')"
+        p="$(printf '%s' "$counts" | awk -F: '{print $2}')"
+        f="$(printf '%s' "$counts" | awk -F: '{print $3}')"
+        s="$(printf '%s' "$counts" | awk -F: '{print $4}')"
+
+        combo_total_tests=$((combo_total_tests + t))
+        combo_pass_tests=$((combo_pass_tests + p))
+        combo_fail_tests=$((combo_fail_tests + f))
+        combo_skip_tests=$((combo_skip_tests + s))
+    done
+
+    overall_subtests_total=$((overall_subtests_total + combo_total_tests))
+    overall_subtests_pass=$((overall_subtests_pass + combo_pass_tests))
+    overall_subtests_fail=$((overall_subtests_fail + combo_fail_tests))
+    overall_subtests_skip=$((overall_subtests_skip + combo_skip_tests))
+
+    if [ "$combo_total_tests" -eq 0 ]; then
         status="SKIP"
-    elif [ "$fail_cnt" -eq 0 ]; then
+    elif [ "$combo_fail_tests" -eq 0 ]; then
         status="PASS"
     else
         status="FAIL"
     fi
 
-    # Write to summary file and log (properly formatted table row)
-    line=$(printf "%-10s | %-10s | %4d | %4d | %4s" "$dom_name" "$pd_name" "$pass_cnt" "$fail_cnt" "$status")
+    line="$(printf "$SUMMARY_FMT" "$dom_name" "$pd_name" "$combo_total_tests" "$combo_pass_tests" "$combo_fail_tests" "$combo_skip_tests" "$status")"
     echo "$line" >> "$SUMMARY_FILE"
     log_info "$line"
 done <<EOF
 $RESULTS_TRACKER
 EOF
 
-log_info "--------------------------------------------------------------------------"
-log_info "Overall:   Total runs: $TOTAL_COUNT | Passed: $PASS_COUNT | Failed: $((TOTAL_COUNT - PASS_COUNT))"
-log_info "=========================================================================="
+log_info "$SUMMARY_SEP"
+overall_inv_line="$(printf '%-20s Total:%6d | Passed:%6d | Failed:%6d' \
+    'Overall invocations:' "$TOTAL_COUNT" "$PASS_COUNT" "$((TOTAL_COUNT - PASS_COUNT))")"
+log_info "$overall_inv_line"
+
+overall_sub_line="$(printf '%-20s Total:%6d | Passed:%6d | Failed:%6d | Skipped:%6d' \
+    'Overall subtests:' "$overall_subtests_total" "$overall_subtests_pass" "$overall_subtests_fail" "$overall_subtests_skip")"
+log_info "$overall_sub_line"
 
 # Final result determination
 if [ "$TOTAL_COUNT" -eq 0 ]; then

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
@@ -40,6 +40,8 @@ VERBOSE=0
 USER_PD_FLAG=0 # default: -U 0 (system/signed PD)
 CLI_DOMAIN=""
 CLI_DOMAIN_NAME=""
+DOMAIN_MODE="all-supported" # ENHANCED: default to all-supported
+PD_MODE="both" # ENHANCED: default to both PDs
 
 usage() {
     cat <<EOF
@@ -49,16 +51,18 @@ Options:
   --arch <name> Architecture (only if explicitly provided)
   --bin-dir <path> Directory containing 'fastrpc_test' (default: /usr/local/bin)
   --assets-dir <path> (compat) previously used when assets lived under 'linux/'
-  --domain <0|1|2|3> DSP domain: 0=ADSP, 1=MDSP, 2=SDSP, 3=CDSP
-  --domain-name <name> DSP domain by name: adsp|mdsp|sdsp|cdsp
-  --user-pd Use '-U 1' (user/unsigned PD). Default is '-U 0'
+  --domain <0|1|2|3|4|5|6> DSP domain: 0=ADSP, 1=MDSP, 2=SDSP, 3=CDSP, 4=CDSP1, 5=GPDSP0, 6=GPDSP1
+  --domain-name <name> DSP domain by name: adsp|mdsp|sdsp|cdsp|cdsp1|gpdsp0|gpdsp1
+  --domain-mode <all-supported|single> Discover all supported domains or run only one (default: all-supported)
+  --pd-mode <both|signed-only|unsigned-only> Select PD mode(s) to run (default: both)
+  --user-pd Use '-U 1' (user/unsigned PD). Overrides --pd-mode for compatibility
   --repeat <N> Number of repetitions (default: 1)
   --timeout <sec> Timeout for each run (no timeout if omitted)
   --verbose Extra logging for CI debugging
   --help Show this help
 
 Env:
-  FASTRPC_DOMAIN=0|1|2|3 Sets domain; CLI --domain/--domain-name wins.
+  FASTRPC_DOMAIN=0|1|2|3|4|5|6 Sets domain; CLI --domain/--domain-name wins.
   FASTRPC_DOMAIN_NAME=adsp|... Named domain; CLI wins.
   FASTRPC_USER_PD=0|1 Sets PD (-U value). CLI --user-pd overrides to 1.
   FASTRPC_EXTRA_FLAGS Extra flags appended (space-separated).
@@ -72,7 +76,9 @@ Notes:
     ADSP_LIBRARY_PATH=/usr/local/share/fastrpc_test/v75[:v68]
     CDSP_LIBRARY_PATH=/usr/local/share/fastrpc_test/v75[:v68]
     SDSP_LIBRARY_PATH=/usr/local/share/fastrpc_test/v75[:v68]
-- If domain not provided, auto-pick: CDSP if present; else ADSP; else SDSP; else 3.
+- Domain mapping: ADSP=0 MDSP=1 SDSP=2 CDSP=3 CDSP1=4 GPDSP0=5 GPDSP1=6
+- Default: discover all supported domains at runtime and run both signed/unsigned PDs where supported.
+- PD support: ADSP/MDSP/SDSP support signed only; CDSP/CDSP1/GPDSP support both.
 EOF
 }
 
@@ -84,6 +90,8 @@ while [ $# -gt 0 ]; do
         --assets-dir) ASSETS_DIR="$2"; shift 2 ;;
         --domain) CLI_DOMAIN="$2"; shift 2 ;;
         --domain-name) CLI_DOMAIN_NAME="$2"; shift 2 ;;
+        --domain-mode) DOMAIN_MODE="$2"; shift 2 ;;
+        --pd-mode) PD_MODE="$2"; shift 2 ;;
         --user-pd) USER_PD_FLAG=1; shift ;;
         --repeat) REPEAT="$2"; shift 2 ;;
         --timeout) TIMEOUT="$2"; shift 2 ;;
@@ -105,6 +113,9 @@ case "$REPEAT" in *[!0-9]*|"") log_error "Invalid --repeat: $REPEAT"; echo "$TES
 if [ -n "$TIMEOUT" ]; then
     case "$TIMEOUT" in *[!0-9]*|"") log_error "Invalid --timeout: $TIMEOUT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
 fi
+# Validate enhanced options
+case "$DOMAIN_MODE" in all-supported|single) : ;; *) log_error "Invalid --domain-mode: $DOMAIN_MODE"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
+case "$PD_MODE" in both|signed-only|unsigned-only) : ;; *) log_error "Invalid --pd-mode: $PD_MODE"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
 
 # Ensure we're in the testcase directory (repo convention)
 test_path="$(find_test_case_by_name "$TESTNAME")" || {
@@ -139,7 +150,7 @@ cmd_to_string() {
 }
 
 log_dsp_remoteproc_status() {
-    fw_list="adsp cdsp cdsp0 cdsp1 sdsp gdsp0 gdsp1"
+    fw_list="adsp mdsp sdsp cdsp cdsp0 cdsp1 gdsp0 gdsp1 gpdsp0 gpdsp1" # extended list
     any=0
     for fw in $fw_list; do
         if dt_has_remoteproc_fw "$fw"; then
@@ -165,8 +176,114 @@ name_to_domain() {
         mdsp) echo 1 ;;
         sdsp) echo 2 ;;
         cdsp) echo 3 ;;
+        cdsp1) echo 4 ;; # ENHANCED
+        gpdsp0|gdsp0) echo 5 ;; # ENHANCED
+        gpdsp1|gdsp1) echo 6 ;; # ENHANCED
         *) echo "" ;;
     esac
+}
+
+# Helper to get domain name from id
+domain_to_name() {
+    case "$1" in
+        0) echo "ADSP" ;;
+        1) echo "MDSP" ;;
+        2) echo "SDSP" ;;
+        3) echo "CDSP" ;;
+        4) echo "CDSP1" ;;
+        5) echo "GPDSP0" ;;
+        6) echo "GPDSP1" ;;
+        *) echo "UNKNOWN" ;;
+    esac
+}
+
+# Helper to append unique word
+append_unique() {
+    current="$1"
+    new="$2"
+    for word in $current; do
+        [ "$word" = "$new" ] && { printf "%s" "$current"; return; }
+    done
+    [ -n "$current" ] && printf "%s %s" "$current" "$new" || printf "%s" "$new"
+}
+
+# Discover all supported domains
+discover_supported_domains() {
+    found=""
+    for fw in adsp mdsp sdsp cdsp cdsp1 gpdsp0 gpdsp1 gdsp0 gdsp1; do
+        if dt_has_remoteproc_fw "$fw"; then
+            case "$fw" in
+                adsp) found="$(append_unique "$found" "0")" ;;
+                mdsp) found="$(append_unique "$found" "1")" ;;
+                sdsp) found="$(append_unique "$found" "2")" ;;
+                cdsp) found="$(append_unique "$found" "3")" ;;
+                cdsp1) found="$(append_unique "$found" "4")" ;;
+                gpdsp0|gdsp0) found="$(append_unique "$found" "5")" ;;
+                gpdsp1|gdsp1) found="$(append_unique "$found" "6")" ;;
+            esac
+        fi
+    done
+    printf "%s" "$found"
+}
+
+# Resolve which domains to test
+resolve_domains_to_test() {
+    resolved=""
+    if [ -n "$CLI_DOMAIN_NAME" ]; then
+        resolved="$(name_to_domain "$CLI_DOMAIN_NAME")"
+    elif [ -n "$CLI_DOMAIN" ]; then
+        resolved="$CLI_DOMAIN"
+    elif [ "$DOMAIN_MODE" = "single" ]; then
+        if [ -n "${FASTRPC_DOMAIN_NAME:-}" ]; then
+            resolved="$(name_to_domain "$FASTRPC_DOMAIN_NAME")"
+        elif [ -n "${FASTRPC_DOMAIN:-}" ]; then
+            resolved="$FASTRPC_DOMAIN"
+        fi
+    else
+        resolved="$(discover_supported_domains)"
+    fi
+
+    valid=""
+    for d in $resolved; do
+        case "$d" in
+            0|1|2|3|4|5|6) valid="$(append_unique "$valid" "$d")" ;;
+            *) log_warn "Ignoring invalid domain '$d'" ;;
+        esac
+    done
+    printf "%s" "$valid"
+}
+
+# Get supported PD values for a domain
+domain_supported_pds() {
+    case "$1" in
+        0|1|2) printf "%s" "0" ;; # ADSP/MDSP/SDSP: signed only
+        3|4|5|6) printf "%s" "0 1" ;; # CDSP/CDSP1/GPDSP: both
+        *) printf "%s" "" ;;
+    esac
+}
+
+# Get requested PD values
+requested_pds() {
+    [ "$USER_PD_FLAG" -eq 1 ] && { printf "%s" "1"; return; }
+    case "$PD_MODE" in
+        signed-only) printf "%s" "0" ;;
+        unsigned-only) printf "%s" "1" ;;
+        both) printf "%s" "0 1" ;;
+    esac
+}
+
+# Get effective PD values for a domain
+effective_pds_for_domain() {
+    domain="$1"
+    requested="$(requested_pds)"
+    supported="$(domain_supported_pds "$domain")"
+    effective=""
+    for req in $requested; do
+        for sup in $supported; do
+            [ "$req" = "$sup" ] && effective="$(append_unique "$effective" "$req")"
+        done
+    done
+    printf "%s" "$effective"
 }
 
 pick_default_domain() {
@@ -238,60 +355,35 @@ log_info " file : $(file "$RUN_BIN" 2>/dev/null || echo 'N/A')"
 # >>>>>>>>>>>>>>>>>>>>>> ENV for your initramfs layout <<<<<<<<<<<<<<<<<<<<<<
 # Libraries: system + test payloads
 export LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/fastrpc_test${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-# Skeletons: export if present (don’t clobber if user already set)
+# Skeletons: export if present (don't clobber if user already set)
 [ -n "$SKEL_PATH" ] && {
     : "${ADSP_LIBRARY_PATH:=$SKEL_PATH}"; export ADSP_LIBRARY_PATH
     : "${CDSP_LIBRARY_PATH:=$SKEL_PATH}"; export CDSP_LIBRARY_PATH
     : "${SDSP_LIBRARY_PATH:=$SKEL_PATH}"; export SDSP_LIBRARY_PATH
 }
 log_info "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
-[ -n "$ADSP_LIBRARY_PATH" ] && log_info "ADSP_LIBRARY_PATH=${ADSP_LIBRARY_PATH}"
-[ -n "$CDSP_LIBRARY_PATH" ] && log_info "CDSP_LIBRARY_PATH=${CDSP_LIBRARY_PATH}"
-[ -n "$SDSP_LIBRARY_PATH" ] && log_info "SDSP_LIBRARY_PATH=${SDSP_LIBRARY_PATH}"
+[ -n "${ADSP_LIBRARY_PATH:-}" ] && log_info "ADSP_LIBRARY_PATH=${ADSP_LIBRARY_PATH}"
+[ -n "${CDSP_LIBRARY_PATH:-}" ] && log_info "CDSP_LIBRARY_PATH=${CDSP_LIBRARY_PATH}"
+[ -n "${SDSP_LIBRARY_PATH:-}" ] && log_info "SDSP_LIBRARY_PATH=${SDSP_LIBRARY_PATH}"
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 # Ensure /usr/lib/dsp has the expected DSP artifacts (generic, idempotent)
 ensure_usr_lib_dsp_symlinks
 # Log *dsp remoteproc statuses via existing helpers
 log_dsp_remoteproc_status
 
-# -------------------- PD selection -------------------
-PD_VAL="${FASTRPC_USER_PD:-0}"
-[ "$USER_PD_FLAG" -eq 1 ] && PD_VAL=1
-log_info "PD setting: -U $PD_VAL (use --user-pd or FASTRPC_USER_PD=1 to change)"
+# -------------------- Domain and PD selection -------------------
+# Resolve domains and PDs to test
+DOMAINS_TO_TEST="$(resolve_domains_to_test)"
 
-# -------------------- Domain selection -------------------
-DOMAIN=""
-# Precedence: CLI name -> CLI number -> env name -> env number -> auto-pick
-if [ -n "$CLI_DOMAIN_NAME" ]; then
-    DOMAIN="$(name_to_domain "$CLI_DOMAIN_NAME")"
-elif [ -n "$CLI_DOMAIN" ]; then
-    DOMAIN="$CLI_DOMAIN"
-elif [ -n "${FASTRPC_DOMAIN_NAME:-}" ]; then
-    DOMAIN="$(name_to_domain "$FASTRPC_DOMAIN_NAME")"
-elif [ -n "${FASTRPC_DOMAIN:-}" ]; then
-    DOMAIN="$FASTRPC_DOMAIN"
+if [ -z "$DOMAINS_TO_TEST" ]; then
+    log_skip "$TESTNAME SKIP - no mapped/supported domains detected"
+    echo "$TESTNAME : SKIP" >"$RESULT_FILE"
+    exit 1
 fi
 
-# Validate / auto-pick
-case "$DOMAIN" in
-    0|1|2|3) : ;;
-    "" )
-        DOMAIN="$(pick_default_domain)"
-        log_info "Domain auto-picked: -d $DOMAIN (CDSP=3, ADSP=0, SDSP=2)"
-        ;;
-    * )
-        log_warn "Invalid domain '$DOMAIN' auto-picking"
-        DOMAIN="$(pick_default_domain)"
-        ;;
-esac
-
-case "$DOMAIN" in
-    0) dom_name="ADSP" ;;
-    1) dom_name="MDSP" ;;
-    2) dom_name="SDSP" ;;
-    3) dom_name="CDSP" ;;
-esac
-log_info "Domain: -d $DOMAIN ($dom_name)"
+log_info "Domain mode: $DOMAIN_MODE"
+log_info "Domains to test: $DOMAINS_TO_TEST"
+log_info "PD mode: $PD_MODE"
 
 # -------------------- Buffering tool availability ---------------
 HAVE_STDBUF=0; command -v stdbuf >/dev/null 2>&1 && HAVE_STDBUF=1
@@ -305,24 +397,6 @@ elif [ $HAVE_SCRIPT -eq 1 ]; then
     buf_label="script -q"
 fi
 
-# -------------------- Build argv safely -------------------------
-set -- -d "$DOMAIN" -t linux
-
-if [ -n "$ARCH" ]; then
-    set -- "$@" -a "$ARCH"
-    log_info "Arch option: -a $ARCH"
-else
-    log_info "No --arch provided; running without -a"
-fi
-
-set -- "$@" -U "$PD_VAL"
-
-if [ -n "$FASTRPC_EXTRA_FLAGS" ]; then
-    # shellcheck disable=SC2086
-    set -- "$@" $FASTRPC_EXTRA_FLAGS
-    log_info "Extra flags: $FASTRPC_EXTRA_FLAGS"
-fi
-
 # -------------------- Logging root -----------------------------
 TS="$(date +%Y%m%d-%H%M%S)"
 LOG_ROOT="./logs_${TESTNAME}_${TS}"
@@ -332,84 +406,199 @@ tmo_label="none"; [ -n "$TIMEOUT" ] && tmo_label="${TIMEOUT}s"
 log_info "Repeats: $REPEAT | Timeout: $tmo_label | Buffering: $buf_label"
 
 # -------------------- Run loop ---------------------------------
+# Nested loop over domains and PDs
 PASS_COUNT=0
-i=1
-while [ "$i" -le "$REPEAT" ]; do
-    iter_tag="iter$i"
-    iter_log="$LOG_ROOT/${iter_tag}.out"
-    iter_rc="$LOG_ROOT/${iter_tag}.rc"
-    iter_cmd="$LOG_ROOT/${iter_tag}.cmd"
-    iter_env="$LOG_ROOT/${iter_tag}.env"
-    iter_dmesg="$LOG_ROOT/${iter_tag}.dmesg"
-    iso_now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TOTAL_COUNT=0
 
-    {
-        echo "DATE_UTC=$iso_now"
-        echo "RUN_DIR=$RUN_DIR"
-        echo "RUN_BIN=$RUN_BIN"
-        echo "PATH=$PATH"
-        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
-        echo "ADSP_LIBRARY_PATH=${ADSP_LIBRARY_PATH:-}"
-        echo "CDSP_LIBRARY_PATH=${CDSP_LIBRARY_PATH:-}"
-        echo "SDSP_LIBRARY_PATH=${SDSP_LIBRARY_PATH:-}"
-        echo "ARCH=${ARCH:-}"
-        echo "PD_VAL=$PD_VAL"
-        echo "DOMAIN=$DOMAIN ($dom_name)"
-        echo "REPEAT=$REPEAT TIMEOUT=${TIMEOUT:-none}"
-        echo "EXTRA=$FASTRPC_EXTRA_FLAGS"
-    } > "$iter_env"
+for DOMAIN in $DOMAINS_TO_TEST; do
+    dom_name="$(domain_to_name "$DOMAIN")"
+    PD_VALUES="$(effective_pds_for_domain "$DOMAIN")"
 
-    log_info "Running $iter_tag/$REPEAT | start: $iso_now | dir: $RUN_DIR"
-    log_info "Executing: ./fastrpc_test$(cmd_to_string "$@")"
-    printf "./fastrpc_test%s\n" "$(cmd_to_string "$@")" > "$iter_cmd"
+    if [ -z "$PD_VALUES" ]; then
+        log_warn "Skipping $dom_name: requested PD mode unsupported for this domain"
+        continue
+    fi
 
-    (
-        cd "$RUN_DIR" || exit 127
-        if [ $HAVE_STDBUF -eq 1 ]; then
-             runWithTimeoutIfSet stdbuf -oL -eL ./fastrpc_test "$@"
-        elif [ $HAVE_SCRIPT -eq 1 ]; then
-            cmd_str="./fastrpc_test$(cmd_to_string "$@")"
-            if [ -n "$TIMEOUT" ] && [ $HAVE_TIMEOUT -eq 1 ]; then
-                script -q -c "timeout $TIMEOUT $cmd_str" /dev/null
-            else
-                script -q -c "$cmd_str" /dev/null
+    for PD_VAL in $PD_VALUES; do
+        case "$PD_VAL" in
+            0) pd_name="signed" ;;
+            1) pd_name="unsigned" ;;
+            *) pd_name="unknown" ;;
+        esac
+
+        i=1
+        while [ "$i" -le "$REPEAT" ]; do
+            TOTAL_COUNT=$((TOTAL_COUNT+1))
+
+            iter_tag="${dom_name}_${pd_name}_iter${i}"
+            iter_log="$LOG_ROOT/${iter_tag}.out"
+            iter_rc="$LOG_ROOT/${iter_tag}.rc"
+            iter_cmd="$LOG_ROOT/${iter_tag}.cmd"
+            iter_env="$LOG_ROOT/${iter_tag}.env"
+            iter_dmesg="$LOG_ROOT/${iter_tag}.dmesg"
+            iso_now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+            set -- -d "$DOMAIN" -t linux
+            [ -n "$ARCH" ] && set -- "$@" -a "$ARCH"
+            set -- "$@" -U "$PD_VAL"
+            [ -n "${FASTRPC_EXTRA_FLAGS:-}" ] && set -- "$@" $FASTRPC_EXTRA_FLAGS
+
+            {
+                echo "DATE_UTC=$iso_now"
+                echo "RUN_DIR=$RUN_DIR"
+                echo "RUN_BIN=$RUN_BIN"
+                echo "PATH=$PATH"
+                echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
+                echo "ADSP_LIBRARY_PATH=${ADSP_LIBRARY_PATH:-}"
+                echo "CDSP_LIBRARY_PATH=${CDSP_LIBRARY_PATH:-}"
+                echo "SDSP_LIBRARY_PATH=${SDSP_LIBRARY_PATH:-}"
+                echo "ARCH=${ARCH:-}"
+                echo "PD_VAL=$PD_VAL ($pd_name)"
+                echo "DOMAIN=$DOMAIN ($dom_name)"
+                echo "REPEAT=$REPEAT TIMEOUT=${TIMEOUT:-none}"
+                echo "EXTRA=${FASTRPC_EXTRA_FLAGS:-}"
+            } > "$iter_env"
+
+            log_info "Running $iter_tag | domain=$dom_name | pd=$pd_name"
+            log_info "Executing: ./fastrpc_test$(cmd_to_string "$@")"
+            printf "./fastrpc_test%s\n" "$(cmd_to_string "$@")" > "$iter_cmd"
+
+            (
+                cd "$RUN_DIR" || exit 127
+                if [ $HAVE_STDBUF -eq 1 ]; then
+                     runWithTimeoutIfSet stdbuf -oL -eL ./fastrpc_test "$@"
+                elif [ $HAVE_SCRIPT -eq 1 ]; then
+                    cmd_str="./fastrpc_test$(cmd_to_string "$@")"
+                    if [ -n "$TIMEOUT" ] && [ $HAVE_TIMEOUT -eq 1 ]; then
+                        script -q -c "timeout $TIMEOUT $cmd_str" /dev/null
+                    else
+                        script -q -c "$cmd_str" /dev/null
+                    fi
+                else
+                    runWithTimeoutIfSet ./fastrpc_test "$@"
+                fi
+            ) >"$iter_log" 2>&1
+            rc=$?
+
+            printf '%s\n' "$rc" >"$iter_rc"
+
+            if [ -s "$iter_log" ]; then
+                echo "----- $iter_tag output begin -----"
+                cat "$iter_log"
+                echo "----- $iter_tag output end -----"
             fi
-        else
-            runWithTimeoutIfSet ./fastrpc_test "$@"
-        fi
-    ) >"$iter_log" 2>&1
-    rc=$?
 
-    printf '%s\n' "$rc" >"$iter_rc"
+            if [ "$rc" -ne 0 ]; then
+                log_fail "$iter_tag: fastrpc_test exited $rc"
+                dmesg | tail -n 300 > "$iter_dmesg" 2>/dev/null
+                log_dsp_remoteproc_status
+            fi
 
-    if [ -s "$iter_log" ]; then
-        echo "----- $iter_tag output begin -----"
-        cat "$iter_log"
-        echo "----- $iter_tag output end -----"
-    fi
+            if [ "$rc" -eq 0 ] && [ -r "$iter_log" ] && grep -F -q -e "All tests completed successfully" -e "All applicable tests PASSED" "$iter_log"; then
+                PASS_COUNT=$((PASS_COUNT+1))
+                log_pass "$iter_tag: success"
+            else
+                log_warn "$iter_tag: success pattern not found"
+            fi
 
-    if [ "$rc" -ne 0 ]; then
-        log_fail "$iter_tag: fastrpc_test exited $rc (see $iter_log)"
-        dmesg | tail -n 300 > "$iter_dmesg" 2>/dev/null
-        log_dsp_remoteproc_status
-    fi
-
-	if [ -r "$iter_log" ] && grep -F -q -e "All tests completed successfully" -e "All applicable tests PASSED" "$iter_log"; then
-        PASS_COUNT=$((PASS_COUNT+1))
-        log_pass "$iter_tag: success"
-    else
-        log_warn "$iter_tag: success pattern not found"
-    fi
-
-    i=$((i+1))
+            i=$((i+1))
+        done
+    done
 done
 
 # -------------------- Finalize --------------------------------
-if [ "$PASS_COUNT" -eq "$REPEAT" ]; then
-    log_pass "$TESTNAME : Test Passed ($PASS_COUNT/$REPEAT)"
+# Build detailed summary table
+log_info "=========================================================================="
+log_info "                         FastRPC Test Summary"
+log_info "=========================================================================="
+
+# Collect results per domain/PD combination
+SUMMARY_FILE="$LOG_ROOT/summary.txt"
+> "$SUMMARY_FILE"
+
+for DOMAIN in $DOMAINS_TO_TEST; do
+    dom_name="$(domain_to_name "$DOMAIN")"
+    PD_VALUES="$(effective_pds_for_domain "$DOMAIN")"
+    
+    [ -z "$PD_VALUES" ] && continue
+    
+    for PD_VAL in $PD_VALUES; do
+        case "$PD_VAL" in
+            0) pd_name="Signed  " ;;
+            1) pd_name="Unsigned" ;;
+            *) pd_name="Unknown " ;;
+        esac
+        
+        # Count pass/fail for this domain/PD combo
+        combo_pass=0
+        combo_fail=0
+        combo_total=0
+        
+        i=1
+        while [ "$i" -le "$REPEAT" ]; do
+            case "$PD_VAL" in
+                0) iter_tag="${dom_name}_signed_iter${i}" ;;
+                1) iter_tag="${dom_name}_unsigned_iter${i}" ;;
+                *) iter_tag="${dom_name}_u${PD_VAL}_iter${i}" ;;
+            esac
+            
+            iter_rc="$LOG_ROOT/${iter_tag}.rc"
+            iter_log="$LOG_ROOT/${iter_tag}.out"
+            
+            if [ -f "$iter_rc" ]; then
+                combo_total=$((combo_total + 1))
+                rc=$(cat "$iter_rc")
+                if [ "$rc" -eq 0 ] && [ -r "$iter_log" ] && grep -F -q -e "All tests completed successfully" -e "All applicable tests PASSED" "$iter_log"; then
+                    combo_pass=$((combo_pass + 1))
+                else
+                    combo_fail=$((combo_fail + 1))
+                fi
+            fi
+            
+            i=$((i + 1))
+        done
+        
+        # Determine status
+        if [ "$combo_total" -eq 0 ]; then
+            status="SKIP"
+        elif [ "$combo_fail" -eq 0 ]; then
+            status="PASS"
+        else
+            status="FAIL"
+        fi
+        
+        # Write to summary file
+        printf "%-10s | %-10s | %4d | %4d | %4s\n" "$dom_name" "$pd_name" "$combo_pass" "$combo_fail" "$status" >> "$SUMMARY_FILE"
+    done
+done
+
+# Display table header
+log_info "--------------------------------------------------------------------------"
+log_info "Domain     | PD Mode    | Pass | Fail | Status"
+log_info "--------------------------------------------------------------------------"
+
+# Display table content
+if [ -f "$SUMMARY_FILE" ] && [ -s "$SUMMARY_FILE" ]; then
+    while IFS= read -r line; do
+        log_info "$line"
+    done < "$SUMMARY_FILE"
+else
+    log_info "No test results to display"
+fi
+
+log_info "--------------------------------------------------------------------------"
+log_info "Overall:   Total runs: $TOTAL_COUNT | Passed: $PASS_COUNT | Failed: $((TOTAL_COUNT - PASS_COUNT))"
+log_info "=========================================================================="
+
+# Final result determination
+if [ "$TOTAL_COUNT" -eq 0 ]; then
+    log_skip "$TESTNAME SKIP - no runnable domain/PD combinations"
+    echo "$TESTNAME : SKIP" > "$RESULT_FILE"
+elif [ "$PASS_COUNT" -eq "$TOTAL_COUNT" ]; then
+    log_pass "$TESTNAME : Test Passed ($PASS_COUNT/$TOTAL_COUNT)"
     echo "$TESTNAME : PASS" > "$RESULT_FILE"
 else
-    log_fail "$TESTNAME : Test Failed ($PASS_COUNT/$REPEAT)"
+    log_fail "$TESTNAME : Test Failed ($PASS_COUNT/$TOTAL_COUNT)"
     echo "$TESTNAME : FAIL" > "$RESULT_FILE"
 fi
 

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
@@ -37,7 +37,7 @@ ARCH=""
 BIN_DIR="" # directory that CONTAINS fastrpc_test
 ASSETS_DIR="" # kept for compatibility/logging (not used by new layout)
 VERBOSE=0
-USER_PD_FLAG=0 # default: -U 0 (system/signed PD)
+UNSIGNED_PD_FLAG=0 # default: -U 0 (system/signed PD)
 CLI_DOMAIN=""
 CLI_DOMAIN_NAME=""
 DOMAIN_MODE="all-supported" # Default: test all supported domains
@@ -61,7 +61,7 @@ Options:
   --domain-name <name> DSP domain by name: adsp|mdsp|sdsp|cdsp|cdsp1|gpdsp0|gpdsp1
   --domain-mode <all-supported|single> Discover all supported domains or run only one (default: all-supported)
   --pd-mode <both|signed-only|unsigned-only> Select PD mode(s) to run (default: both)
-  --user-pd Use '-U 1' (user/unsigned PD). Overrides --pd-mode for compatibility
+  --unsigned-pd Use '-U 1' (user/unsigned PD). Overrides --pd-mode for compatibility
   --repeat <N> Number of repetitions (default: 1)
   --timeout <sec> Timeout for each run (no timeout if omitted)
   --verbose Extra logging for CI debugging
@@ -77,7 +77,7 @@ Domain Selection Priority:
 Env:
   FASTRPC_DOMAIN=0|1|2|3|4|5|6 Sets domain; CLI --domain/--domain-name wins.
   FASTRPC_DOMAIN_NAME=adsp|... Named domain; CLI wins.
-  FASTRPC_USER_PD=0|1 Sets PD (-U value). CLI --user-pd overrides to 1.
+  FASTRPC_UNSIGNED_PD=0|1 Sets PD (-U value). CLI --unsigned-pd overrides to 1.
   FASTRPC_EXTRA_FLAGS Extra flags appended (space-separated).
   ALLOW_BIN_FASTRPC=1 Permit using /bin/fastrpc_test when --bin-dir=/bin.
 
@@ -104,7 +104,7 @@ while [ $# -gt 0 ]; do
         --domain-name) CLI_DOMAIN_NAME="$2"; shift 2 ;;
         --domain-mode) DOMAIN_MODE="$2"; shift 2 ;;
         --pd-mode) PD_MODE="$2"; shift 2 ;;
-        --user-pd) USER_PD_FLAG=1; shift ;;
+        --unsigned-pd) UNSIGNED_PD_FLAG=1; shift ;;
         --repeat) REPEAT="$2"; shift 2 ;;
         --timeout) TIMEOUT="$2"; shift 2 ;;
         --verbose) VERBOSE=1; shift ;;
@@ -165,7 +165,7 @@ log_dsp_remoteproc_status() {
     fw_list="adsp mdsp sdsp cdsp cdsp0 cdsp1 gdsp0 gdsp1 gpdsp0 gpdsp1"
     any=0
     for fw in $fw_list; do
-        if dt_has_remoteproc_fw "$fw"; then
+        if dt_has_remoteproc_fw "$fw" || [ -n "$(get_remoteproc_by_firmware "$fw" "" all 2>/dev/null || true)" ]; then
             entries="$(get_remoteproc_by_firmware "$fw" "" all 2>/dev/null)" || entries=""
             if [ -n "$entries" ]; then
                 any=1
@@ -219,22 +219,45 @@ append_unique() {
     [ -n "$current" ] && printf "%s %s" "$current" "$new" || printf "%s" "$new"
 }
 
+# Helper to normalize remoteproc/firmware names
+canonicalize_domain_name() {
+    case "$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]')" in
+        cdsp0) echo "cdsp" ;;
+        gdsp0) echo "gpdsp0" ;;
+        gdsp1) echo "gpdsp1" ;;
+        *) printf "%s" "$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]')" ;;
+    esac
+}
+
 # Discover all supported domains
 discover_supported_domains() {
     found=""
-    for fw in adsp mdsp sdsp cdsp cdsp1 gpdsp0 gpdsp1 gdsp0 gdsp1; do
-        if dt_has_remoteproc_fw "$fw"; then
-            case "$fw" in
-                adsp) found="$(append_unique "$found" "0")" ;;
-                mdsp) found="$(append_unique "$found" "1")" ;;
-                sdsp) found="$(append_unique "$found" "2")" ;;
-                cdsp) found="$(append_unique "$found" "3")" ;;
-                cdsp1) found="$(append_unique "$found" "4")" ;;
-                gpdsp0|gdsp0) found="$(append_unique "$found" "5")" ;;
-                gpdsp1|gdsp1) found="$(append_unique "$found" "6")" ;;
-            esac
+    echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') - discover_supported_domains: helper-backed discovery active" >&2
+
+    # Prefer helper-backed runtime remoteproc discovery using actual returned names.
+    for fw in adsp mdsp sdsp cdsp cdsp0 cdsp1 gpdsp0 gpdsp1 gdsp0 gdsp1; do
+        entries="$(get_remoteproc_by_firmware "$fw" "" all 2>/dev/null || true)"
+
+        if [ -n "$entries" ]; then
+            while IFS='|' read -r rpath rstate rfirm rname; do
+                [ -n "$rname" ] || continue
+                canon="$(canonicalize_domain_name "$rname")"
+                d="$(name_to_domain "$canon")"
+                if [ -n "$d" ]; then
+                    found="$(append_unique "$found" "$d")"
+                fi
+            done <<EOF
+$entries
+EOF
+        elif dt_has_remoteproc_fw "$fw"; then
+            canon="$(canonicalize_domain_name "$fw")"
+            d="$(name_to_domain "$canon")"
+            if [ -n "$d" ]; then
+                found="$(append_unique "$found" "$d")"
+            fi
         fi
     done
+
     printf "%s" "$found"
 }
 
@@ -276,7 +299,7 @@ domain_supported_pds() {
 
 # Get requested PD values
 requested_pds() {
-    [ "$USER_PD_FLAG" -eq 1 ] && { printf "%s" "1"; return; }
+    [ "$UNSIGNED_PD_FLAG" -eq 1 ] && { printf "%s" "1"; return; }
     case "$PD_MODE" in
         signed-only) printf "%s" "0" ;;
         unsigned-only) printf "%s" "1" ;;
@@ -381,6 +404,19 @@ fi
 
 log_info "Domain mode: $DOMAIN_MODE"
 log_info "Domains to test: $DOMAINS_TO_TEST"
+
+# Build human-readable domain names
+domain_names=""
+for d in $DOMAINS_TO_TEST; do
+    n="$(domain_to_name "$d")"
+    if [ -n "$domain_names" ]; then
+        domain_names="${domain_names},${n}"
+    else
+        domain_names="$n"
+    fi
+done
+[ -n "$domain_names" ] && log_info "Resolved domain names: $domain_names"
+
 log_info "PD mode: $PD_MODE"
 
 # -------------------- Buffering tool availability ---------------
@@ -535,7 +571,7 @@ log_info "Domain     | PD Mode    | Pass | Fail | Status"
 log_info "--------------------------------------------------------------------------"
 
 # Parse tracked results and build table
-echo "$RESULTS_TRACKER" | while IFS=: read -r domain pd_val pass_cnt fail_cnt; do
+while IFS=: read -r domain pd_val pass_cnt fail_cnt; do
     [ -z "$domain" ] && continue
 
     dom_name="$(domain_to_name "$domain")"
@@ -560,7 +596,9 @@ echo "$RESULTS_TRACKER" | while IFS=: read -r domain pd_val pass_cnt fail_cnt; d
     line=$(printf "%-10s | %-10s | %4d | %4d | %4s" "$dom_name" "$pd_name" "$pass_cnt" "$fail_cnt" "$status")
     echo "$line" >> "$SUMMARY_FILE"
     log_info "$line"
-done
+done <<EOF
+$RESULTS_TRACKER
+EOF
 
 log_info "--------------------------------------------------------------------------"
 log_info "Overall:   Total runs: $TOTAL_COUNT | Passed: $PASS_COUNT | Failed: $((TOTAL_COUNT - PASS_COUNT))"
@@ -578,5 +616,5 @@ elif [ "$PASS_COUNT" -eq "$TOTAL_COUNT" ]; then
 else
     log_fail "$TESTNAME : Test Failed ($PASS_COUNT/$TOTAL_COUNT)"
     echo "$TESTNAME : FAIL" > "$RESULT_FILE"
-    exit 1
+    exit 0
 fi

--- a/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
+++ b/Runner/suites/Multimedia/CDSP/fastrpc_test/run.sh
@@ -2,6 +2,9 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 # --------- Robustly source init_env and functestlib.sh ----------
+
+TESTNAME="fastrpc_test"
+RESULT_FILE="$TESTNAME.res"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INIT_ENV=""
 SEARCH="$SCRIPT_DIR"
@@ -15,20 +18,19 @@ done
 
 if [ -z "$INIT_ENV" ]; then
     echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
-    exit 1
+    echo "$TESTNAME : FAIL" >"$RESULT_FILE" 2>/dev/null || true
+    exit 0
 fi
 
 # Only source once (idempotent)
-if [ -z "$__INIT_ENV_LOADED" ]; then
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
     # shellcheck disable=SC1090
     . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
 fi
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
 # ---------------------------------------------------------------
-
-TESTNAME="fastrpc_test"
-RESULT_FILE="$TESTNAME.res"
 
 # Defaults
 REPEAT=1
@@ -37,30 +39,47 @@ ARCH=""
 BIN_DIR="" # directory that CONTAINS fastrpc_test
 ASSETS_DIR="" # kept for compatibility/logging (not used by new layout)
 VERBOSE=0
-USER_PD_FLAG=0 # default: -U 0 (system/signed PD)
+UNSIGNED_PD_FLAG=0 # default: -U 0 (system/signed PD)
 CLI_DOMAIN=""
 CLI_DOMAIN_NAME=""
+DOMAIN_MODE="all-supported" # Default: test all supported domains
+PD_MODE="both" # Default: test both PDs where supported
 
 usage() {
     cat <<EOF
 Usage: $0 [OPTIONS]
 
+**Enhanced Test Coverage**:
+  This test now validates FastRPC across all supported DSP domains and PD modes.
+  - Tests all detected domains: ADSP, MDSP, SDSP, CDSP, CDSP1, GPDSP0, GPDSP1
+  - Tests both signed and unsigned Protection Domains where hardware supports them
+  - For legacy single-domain testing: use --domain-mode single --domain <N>
+
 Options:
   --arch <name> Architecture (only if explicitly provided)
-  --bin-dir <path> Directory containing 'fastrpc_test' (default: /usr/local/bin)
+  --bin-dir <path> Directory containing 'fastrpc_test' (default: /usr/bin)
   --assets-dir <path> (compat) previously used when assets lived under 'linux/'
-  --domain <0|1|2|3> DSP domain: 0=ADSP, 1=MDSP, 2=SDSP, 3=CDSP
-  --domain-name <name> DSP domain by name: adsp|mdsp|sdsp|cdsp
-  --user-pd Use '-U 1' (user/unsigned PD). Default is '-U 0'
+  --domain <0|1|2|3|4|5|6> DSP domain: 0=ADSP, 1=MDSP, 2=SDSP, 3=CDSP, 4=CDSP1, 5=GPDSP0, 6=GPDSP1
+  --domain-name <name> DSP domain by name: adsp|mdsp|sdsp|cdsp|cdsp1|gpdsp0|gpdsp1
+  --domain-mode <all-supported|single> Discover all supported domains or run only one (default: all-supported)
+  --pd-mode <both|signed-only|unsigned-only> Select PD mode(s) to run (default: both)
+  --unsigned-pd Use '-U 1' (user/unsigned PD). Overrides --pd-mode for compatibility
   --repeat <N> Number of repetitions (default: 1)
   --timeout <sec> Timeout for each run (no timeout if omitted)
   --verbose Extra logging for CI debugging
   --help Show this help
 
+Domain Selection Priority:
+  1. --domain-name (highest priority, forces single domain)
+  2. --domain (forces single domain)
+  3. --domain-mode single + FASTRPC_DOMAIN_NAME env
+  4. --domain-mode single + FASTRPC_DOMAIN env
+  5. --domain-mode all-supported (default, discovers all)
+
 Env:
-  FASTRPC_DOMAIN=0|1|2|3 Sets domain; CLI --domain/--domain-name wins.
+  FASTRPC_DOMAIN=0|1|2|3|4|5|6 Sets domain; CLI --domain/--domain-name wins.
   FASTRPC_DOMAIN_NAME=adsp|... Named domain; CLI wins.
-  FASTRPC_USER_PD=0|1 Sets PD (-U value). CLI --user-pd overrides to 1.
+  FASTRPC_UNSIGNED_PD=0|1 Sets PD (-U value). CLI --unsigned-pd overrides to 1.
   FASTRPC_EXTRA_FLAGS Extra flags appended (space-separated).
   ALLOW_BIN_FASTRPC=1 Permit using /bin/fastrpc_test when --bin-dir=/bin.
 
@@ -72,7 +91,8 @@ Notes:
     ADSP_LIBRARY_PATH=/usr/local/share/fastrpc_test/v75[:v68]
     CDSP_LIBRARY_PATH=/usr/local/share/fastrpc_test/v75[:v68]
     SDSP_LIBRARY_PATH=/usr/local/share/fastrpc_test/v75[:v68]
-- If domain not provided, auto-pick: CDSP if present; else ADSP; else SDSP; else 3.
+- Domain mapping: ADSP=0 MDSP=1 SDSP=2 CDSP=3 CDSP1=4 GPDSP0=5 GPDSP1=6
+- PD support: ADSP/MDSP/SDSP support signed only; CDSP/CDSP1/GPDSP support both.
 EOF
 }
 
@@ -84,12 +104,14 @@ while [ $# -gt 0 ]; do
         --assets-dir) ASSETS_DIR="$2"; shift 2 ;;
         --domain) CLI_DOMAIN="$2"; shift 2 ;;
         --domain-name) CLI_DOMAIN_NAME="$2"; shift 2 ;;
-        --user-pd) USER_PD_FLAG=1; shift ;;
+        --domain-mode) DOMAIN_MODE="$2"; shift 2 ;;
+        --pd-mode) PD_MODE="$2"; shift 2 ;;
+        --unsigned-pd) UNSIGNED_PD_FLAG=1; shift ;;
         --repeat) REPEAT="$2"; shift 2 ;;
         --timeout) TIMEOUT="$2"; shift 2 ;;
         --verbose) VERBOSE=1; shift ;;
         --help) usage; exit 0 ;;
-        *) echo "[ERROR] Unknown argument: $1" >&2; usage; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;;
+        *) echo "[ERROR] Unknown argument: $1" >&2; usage; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;;
     esac
 done
 
@@ -101,26 +123,33 @@ if [ -n "${ASSETS_DIR:-}" ]; then
 fi
 
 # ---------- Validation ----------
-case "$REPEAT" in *[!0-9]*|"") log_error "Invalid --repeat: $REPEAT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
+case "$REPEAT" in *[!0-9]*|"") log_error "Invalid --repeat: $REPEAT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;; esac
 if [ -n "$TIMEOUT" ]; then
-    case "$TIMEOUT" in *[!0-9]*|"") log_error "Invalid --timeout: $TIMEOUT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1 ;; esac
+    case "$TIMEOUT" in *[!0-9]*|"") log_error "Invalid --timeout: $TIMEOUT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;; esac
 fi
+# Validate enhanced options
+case "$DOMAIN_MODE" in all-supported|single) : ;; *) log_error "Invalid --domain-mode: $DOMAIN_MODE"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;; esac
+case "$PD_MODE" in both|signed-only|unsigned-only) : ;; *) log_error "Invalid --pd-mode: $PD_MODE"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0 ;; esac
 
 # Ensure we're in the testcase directory (repo convention)
 test_path="$(find_test_case_by_name "$TESTNAME")" || {
     log_error "Cannot locate test path for $TESTNAME"
     echo "$TESTNAME : FAIL" >"$RESULT_FILE"
-    exit 1
+    exit 0
 }
 cd "$test_path" || {
     log_error "cd to test path failed: $test_path"
     echo "$TESTNAME : FAIL" >"$RESULT_FILE"
-    exit 1
+    exit 0
 }
 
 # -------------------- Helpers --------------------
-# shellcheck disable=SC2317  # Helper kept for optional debug use.
-log_debug() { [ "$VERBOSE" -eq 1 ] && log_info "[debug] $*"; }
+# shellcheck disable=SC2317 # Helper kept for optional debug use.
+log_debug() {
+    if [ "$VERBOSE" -eq 1 ]; then
+        log_info "[debug] $*" >&2
+    fi
+}
 
 cmd_to_string() {
     out=""
@@ -138,11 +167,36 @@ cmd_to_string() {
     printf "%s" "$out"
 }
 
+extract_test_summary_counts() {
+    log_file="$1"
+
+    total="$(sed -n 's/^[[:space:]]*Total tests run:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$log_file" | tail -n 1)"
+    passed="$(sed -n 's/^[[:space:]]*Passed:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$log_file" | tail -n 1)"
+    failed="$(sed -n 's/^[[:space:]]*Failed:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$log_file" | tail -n 1)"
+    skipped="$(sed -n 's/^[[:space:]]*Skipped:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$log_file" | tail -n 1)"
+
+    case "$total" in ''|*[!0-9]*) total=0 ;; esac
+    case "$passed" in ''|*[!0-9]*) passed=0 ;; esac
+    case "$failed" in ''|*[!0-9]*) failed=0 ;; esac
+    case "$skipped" in ''|*[!0-9]*) skipped=0 ;; esac
+
+    printf '%s:%s:%s:%s\n' "$total" "$passed" "$failed" "$skipped"
+}
+
+# Returns true if the only failing subtest is libhap_example.so
+# Used to treat HAP_mem DMA failures as known-skip on affected SoCs
+only_hap_example_failed() {
+    log_file="$1"
+    [ -r "$log_file" ] || return 1
+    grep -F -q "[FAIL]" "$log_file" || return 1
+    ! grep -F "[FAIL]" "$log_file" | grep -q -v "libhap_example.so"
+}
+
 log_dsp_remoteproc_status() {
-    fw_list="adsp cdsp cdsp0 cdsp1 sdsp gdsp0 gdsp1"
+    fw_list="adsp mdsp sdsp cdsp cdsp0 cdsp1 gdsp0 gdsp1 gpdsp0 gpdsp1"
     any=0
     for fw in $fw_list; do
-        if dt_has_remoteproc_fw "$fw"; then
+        if dt_has_remoteproc_fw "$fw" || [ -n "$(get_remoteproc_by_firmware "$fw" "" all 2>/dev/null || true)" ]; then
             entries="$(get_remoteproc_by_firmware "$fw" "" all 2>/dev/null)" || entries=""
             if [ -n "$entries" ]; then
                 any=1
@@ -165,22 +219,168 @@ name_to_domain() {
         mdsp) echo 1 ;;
         sdsp) echo 2 ;;
         cdsp) echo 3 ;;
+        cdsp1) echo 4 ;;
+        gpdsp0|gdsp0) echo 5 ;;
+        gpdsp1|gdsp1) echo 6 ;;
         *) echo "" ;;
     esac
 }
 
-pick_default_domain() {
-    # Prefer CDSP if present; else ADSP; else SDSP; else 3
-    if dt_has_remoteproc_fw "cdsp" || dt_has_remoteproc_fw "cdsp0" || dt_has_remoteproc_fw "cdsp1"; then
-        echo 3; return
+# Helper to get domain name from id
+domain_to_name() {
+    case "$1" in
+        0) echo "ADSP" ;;
+        1) echo "MDSP" ;;
+        2) echo "SDSP" ;;
+        3) echo "CDSP" ;;
+        4) echo "CDSP1" ;;
+        5) echo "GPDSP0" ;;
+        6) echo "GPDSP1" ;;
+        *) echo "UNKNOWN" ;;
+    esac
+}
+
+# Helper to append unique word
+append_unique() {
+    current="$1"
+    new="$2"
+    for word in $current; do
+        [ "$word" = "$new" ] && { printf "%s" "$current"; return; }
+    done
+    [ -n "$current" ] && printf "%s %s" "$current" "$new" || printf "%s" "$new"
+}
+
+# Helper to normalize remoteproc/firmware names
+canonicalize_domain_name() {
+    norm="$(printf "%s" "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    case "$norm" in
+        cdsp0) echo "cdsp" ;;
+        gdsp0) echo "gpdsp0" ;;
+        gdsp1) echo "gpdsp1" ;;
+        *) printf "%s" "$norm" ;;
+    esac
+}
+
+# Discover all supported domains
+discover_supported_domains() {
+    echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') - discover_supported_domains: helper-backed discovery active" >&2
+
+    for fw in adsp mdsp sdsp cdsp cdsp0 cdsp1 gpdsp0 gpdsp1 gdsp0 gdsp1; do
+        entries="$(get_remoteproc_by_firmware "$fw" "" all 2>/dev/null || true)"
+
+        if [ -n "$entries" ]; then
+            while IFS='|' read -r rpath rstate rfirm rname; do
+                nameguess=""
+
+                if [ -n "$rname" ]; then
+                    nameguess="$rname"
+                elif [ -n "$rfirm" ]; then
+                    nameguess=$(basename "$rfirm" 2>/dev/null | sed 's/\.[^.]*$//')
+                fi
+
+                [ -n "$nameguess" ] || continue
+
+                canon="$(canonicalize_domain_name "$nameguess")"
+                d="$(name_to_domain "$canon")"
+
+                if [ -n "$d" ]; then
+                    printf '%s\n' "$d"
+                    log_debug "discover: fw=$fw rname=$rname rfirm=$rfirm canon=$canon domain=$d state=$rstate"
+                else
+                    log_debug "discover: fw=$fw rname=$rname rfirm=$rfirm canon=$canon domain=<none>"
+                fi
+            done <<EOF
+$entries
+EOF
+        elif dt_has_remoteproc_fw "$fw"; then
+            canon="$(canonicalize_domain_name "$fw")"
+            d="$(name_to_domain "$canon")"
+
+            if [ -n "$d" ]; then
+                printf '%s\n' "$d"
+                log_debug "discover: fw=$fw dt-only canon=$canon domain=$d"
+            fi
+        else
+            log_debug "discover: fw=$fw not present"
+        fi
+    done
+}
+
+# Resolve which domains to test
+resolve_domains_to_test() {
+    resolved=""
+    if [ -n "$CLI_DOMAIN_NAME" ]; then
+        resolved="$(name_to_domain "$CLI_DOMAIN_NAME")"
+    elif [ -n "$CLI_DOMAIN" ]; then
+        resolved="$CLI_DOMAIN"
+    elif [ "$DOMAIN_MODE" = "single" ]; then
+        if [ -n "${FASTRPC_DOMAIN_NAME:-}" ]; then
+            resolved="$(name_to_domain "$FASTRPC_DOMAIN_NAME")"
+        elif [ -n "${FASTRPC_DOMAIN:-}" ]; then
+            resolved="$FASTRPC_DOMAIN"
+        fi
+    else
+        resolved="$(discover_supported_domains)"
     fi
-    if dt_has_remoteproc_fw "adsp"; then
-        echo 0; return
-    fi
-    if dt_has_remoteproc_fw "sdsp"; then
-        echo 2; return
-    fi
-    echo 3
+
+    log_debug "resolve: raw domains='$resolved'"
+
+    valid=""
+    for d in $resolved; do
+        case "$d" in
+            0|1|2|3|4|5|6)
+                case " $valid " in
+                    *" $d "*) : ;;
+                    *)
+                        if [ -n "$valid" ]; then
+                            valid="${valid} ${d}"
+                        else
+                            valid="$d"
+                        fi
+                        ;;
+                esac
+                ;;
+            *)
+                log_warn "Ignoring invalid domain '$d'"
+                ;;
+        esac
+    done
+    printf '%s' "$valid"
+}
+
+# Get supported PD values for a domain
+domain_supported_pds() {
+    case "$1" in
+        0|1|2) printf "%s" "0" ;; # ADSP/MDSP/SDSP: signed only
+        3|4|5|6) printf "%s" "0 1" ;; # CDSP/CDSP1/GPDSP: both
+        *) printf "%s" "" ;;
+    esac
+}
+
+# Get requested PD values
+# Priority: --unsigned-pd CLI flag > FASTRPC_UNSIGNED_PD env > --pd-mode
+requested_pds() {
+    [ "$UNSIGNED_PD_FLAG" -eq 1 ] && { printf "%s" "1"; return; }
+    [ "${FASTRPC_UNSIGNED_PD:-0}" -eq 1 ] && { printf "%s" "1"; return; }
+    case "$PD_MODE" in
+        signed-only) printf "%s" "0" ;;
+        unsigned-only) printf "%s" "1" ;;
+        both) printf "%s" "0 1" ;;
+    esac
+}
+
+# Get effective PD values for a domain
+effective_pds_for_domain() {
+    domain="$1"
+    requested="$(requested_pds)"
+    supported="$(domain_supported_pds "$domain")"
+    effective=""
+    for req in $requested; do
+        for sup in $supported; do
+            [ "$req" = "$sup" ] && effective="$(append_unique "$effective" "$req")"
+        done
+    done
+    printf "%s" "$effective"
 }
 
 # -------------------- Banner --------------------
@@ -189,6 +389,7 @@ log_info "-------------------Starting $TESTNAME Testcase------------------------
 log_info "Kernel: $(uname -a 2>/dev/null || echo N/A)"
 log_info "Date(UTC): $(date -u 2>/dev/null || echo N/A)"
 log_soc_info
+SOC_MACHINE="$(tr -s ' ' < /sys/devices/soc0/machine 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 
 # -------------------- Binary directory resolution -----------------
 if [ -n "$BIN_DIR" ]; then
@@ -200,9 +401,9 @@ fi
 case "$BIN_DIR" in
     /bin)
         if [ "${ALLOW_BIN_FASTRPC:-0}" -ne 1 ]; then
-	    log_skip "$TESTNAME SKIP - unsupported layout: /bin. Set ALLOW_BIN_FASTRPC=1 or pass --bin-dir."
+            log_skip "$TESTNAME SKIP - unsupported layout: /bin. Set ALLOW_BIN_FASTRPC=1 or pass --bin-dir."
             echo "$TESTNAME : SKIP" >"$RESULT_FILE"
-            exit 1
+            exit 0
         fi
     ;;
 esac
@@ -213,7 +414,7 @@ RUN_BIN="$RUN_DIR/fastrpc_test"
 if [ ! -x "$RUN_BIN" ]; then
     log_skip "$TESTNAME SKIP - fastrpc_test not installed (expected at: $RUN_BIN)"
     echo "$TESTNAME : SKIP" >"$RESULT_FILE"
-    exit 1
+    exit 0
 fi
 
 # New layout checks (replace legacy 'linux/' checks)
@@ -238,60 +439,87 @@ log_info " file : $(file "$RUN_BIN" 2>/dev/null || echo 'N/A')"
 # >>>>>>>>>>>>>>>>>>>>>> ENV for your initramfs layout <<<<<<<<<<<<<<<<<<<<<<
 # Libraries: system + test payloads
 export LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/fastrpc_test${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-# Skeletons: export if present (don’t clobber if user already set)
+# Skeletons: export if present (don't clobber if user already set)
 [ -n "$SKEL_PATH" ] && {
     : "${ADSP_LIBRARY_PATH:=$SKEL_PATH}"; export ADSP_LIBRARY_PATH
     : "${CDSP_LIBRARY_PATH:=$SKEL_PATH}"; export CDSP_LIBRARY_PATH
     : "${SDSP_LIBRARY_PATH:=$SKEL_PATH}"; export SDSP_LIBRARY_PATH
 }
 log_info "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
-[ -n "$ADSP_LIBRARY_PATH" ] && log_info "ADSP_LIBRARY_PATH=${ADSP_LIBRARY_PATH}"
-[ -n "$CDSP_LIBRARY_PATH" ] && log_info "CDSP_LIBRARY_PATH=${CDSP_LIBRARY_PATH}"
-[ -n "$SDSP_LIBRARY_PATH" ] && log_info "SDSP_LIBRARY_PATH=${SDSP_LIBRARY_PATH}"
+[ -n "${ADSP_LIBRARY_PATH:-}" ] && log_info "ADSP_LIBRARY_PATH=${ADSP_LIBRARY_PATH}"
+[ -n "${CDSP_LIBRARY_PATH:-}" ] && log_info "CDSP_LIBRARY_PATH=${CDSP_LIBRARY_PATH}"
+[ -n "${SDSP_LIBRARY_PATH:-}" ] && log_info "SDSP_LIBRARY_PATH=${SDSP_LIBRARY_PATH}"
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 # Ensure /usr/lib/dsp has the expected DSP artifacts (generic, idempotent)
 ensure_usr_lib_dsp_symlinks
 # Log *dsp remoteproc statuses via existing helpers
 log_dsp_remoteproc_status
 
-# -------------------- PD selection -------------------
-PD_VAL="${FASTRPC_USER_PD:-0}"
-[ "$USER_PD_FLAG" -eq 1 ] && PD_VAL=1
-log_info "PD setting: -U $PD_VAL (use --user-pd or FASTRPC_USER_PD=1 to change)"
+# -------------------- Domain and PD selection -------------------
+# Resolve domains and PDs to test
+DOMAINS_TO_TEST="$(resolve_domains_to_test)"
 
-# -------------------- Domain selection -------------------
-DOMAIN=""
-# Precedence: CLI name -> CLI number -> env name -> env number -> auto-pick
-if [ -n "$CLI_DOMAIN_NAME" ]; then
-    DOMAIN="$(name_to_domain "$CLI_DOMAIN_NAME")"
-elif [ -n "$CLI_DOMAIN" ]; then
-    DOMAIN="$CLI_DOMAIN"
-elif [ -n "${FASTRPC_DOMAIN_NAME:-}" ]; then
-    DOMAIN="$(name_to_domain "$FASTRPC_DOMAIN_NAME")"
-elif [ -n "${FASTRPC_DOMAIN:-}" ]; then
-    DOMAIN="$FASTRPC_DOMAIN"
+if [ -z "$DOMAINS_TO_TEST" ]; then
+    log_skip "$TESTNAME SKIP - no mapped/supported domains detected"
+    echo "$TESTNAME : SKIP" >"$RESULT_FILE"
+    exit 0
 fi
 
-# Validate / auto-pick
-case "$DOMAIN" in
-    0|1|2|3) : ;;
-    "" )
-        DOMAIN="$(pick_default_domain)"
-        log_info "Domain auto-picked: -d $DOMAIN (CDSP=3, ADSP=0, SDSP=2)"
+# -------------------- SoC-specific domain blacklist --------------------
+# QRB2210, Glymur CRD : FastRPC not supported - skip entire test
+# QCS9075, QCS8275, QCS8300, QCS9100: GPDSP0 (domain 5) and GPDSP1 (domain 6) not supported currently
+# SM8850: libhap_example HAP_mem DMA not supported - treat as known skip per invocation
+soc_skip_all=0
+soc_skip_gpdsp=0
+
+case "$SOC_MACHINE" in
+    *QRB2210*|*"Glymur CRD"*)
+        soc_skip_all=1
         ;;
-    * )
-        log_warn "Invalid domain '$DOMAIN' auto-picking"
-        DOMAIN="$(pick_default_domain)"
+    *QCS9075*|*QCS8275*|*QCS8300*|*QCS9100*)
+        soc_skip_gpdsp=1
         ;;
 esac
 
-case "$DOMAIN" in
-    0) dom_name="ADSP" ;;
-    1) dom_name="MDSP" ;;
-    2) dom_name="SDSP" ;;
-    3) dom_name="CDSP" ;;
-esac
-log_info "Domain: -d $DOMAIN ($dom_name)"
+if [ "$soc_skip_all" -eq 1 ]; then
+    log_skip "$TESTNAME SKIP - SoC $SOC_MACHINE does not support FastRPC"
+    echo "$TESTNAME : SKIP" >"$RESULT_FILE"
+    exit 0
+fi
+
+if [ "$soc_skip_gpdsp" -eq 1 ]; then
+    filtered=""
+    for d in $DOMAINS_TO_TEST; do
+        case "$d" in
+            5|6) log_info "SoC $SOC_MACHINE: skipping $(domain_to_name "$d") (not supported)" ;;
+            *)   filtered="${filtered:+$filtered }$d" ;;
+        esac
+    done
+    DOMAINS_TO_TEST="$filtered"
+fi
+
+if [ -z "$DOMAINS_TO_TEST" ]; then
+    log_skip "$TESTNAME SKIP - no supported domains remain after SoC filter ($SOC_MACHINE)"
+    echo "$TESTNAME : SKIP" >"$RESULT_FILE"
+    exit 0
+fi
+
+log_info "Domain mode: $DOMAIN_MODE"
+log_info "Domains to test: $DOMAINS_TO_TEST"
+
+# Build human-readable domain names
+domain_names=""
+for d in $DOMAINS_TO_TEST; do
+    n="$(domain_to_name "$d")"
+    if [ -n "$domain_names" ]; then
+        domain_names="${domain_names},${n}"
+    else
+        domain_names="$n"
+    fi
+done
+[ -n "$domain_names" ] && log_info "Resolved domain names: $domain_names"
+
+log_info "PD mode: $PD_MODE"
 
 # -------------------- Buffering tool availability ---------------
 HAVE_STDBUF=0; command -v stdbuf >/dev/null 2>&1 && HAVE_STDBUF=1
@@ -305,117 +533,232 @@ elif [ $HAVE_SCRIPT -eq 1 ]; then
     buf_label="script -q"
 fi
 
-# -------------------- Build argv safely -------------------------
-set -- -d "$DOMAIN" -t linux
-
-if [ -n "$ARCH" ]; then
-    set -- "$@" -a "$ARCH"
-    log_info "Arch option: -a $ARCH"
-else
-    log_info "No --arch provided; running without -a"
-fi
-
-set -- "$@" -U "$PD_VAL"
-
-if [ -n "$FASTRPC_EXTRA_FLAGS" ]; then
-    # shellcheck disable=SC2086
-    set -- "$@" $FASTRPC_EXTRA_FLAGS
-    log_info "Extra flags: $FASTRPC_EXTRA_FLAGS"
-fi
-
 # -------------------- Logging root -----------------------------
 TS="$(date +%Y%m%d-%H%M%S)"
 LOG_ROOT="./logs_${TESTNAME}_${TS}"
-mkdir -p "$LOG_ROOT" || { log_error "Cannot create $LOG_ROOT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 1; }
+mkdir -p "$LOG_ROOT" || { log_error "Cannot create $LOG_ROOT"; echo "$TESTNAME : FAIL" >"$RESULT_FILE"; exit 0; }
 
 tmo_label="none"; [ -n "$TIMEOUT" ] && tmo_label="${TIMEOUT}s"
 log_info "Repeats: $REPEAT | Timeout: $tmo_label | Buffering: $buf_label"
 
 # -------------------- Run loop ---------------------------------
+# Nested loop over domains and PDs
 PASS_COUNT=0
-i=1
-while [ "$i" -le "$REPEAT" ]; do
-    iter_tag="iter$i"
-    iter_log="$LOG_ROOT/${iter_tag}.out"
-    iter_rc="$LOG_ROOT/${iter_tag}.rc"
-    iter_cmd="$LOG_ROOT/${iter_tag}.cmd"
-    iter_env="$LOG_ROOT/${iter_tag}.env"
-    iter_dmesg="$LOG_ROOT/${iter_tag}.dmesg"
-    iso_now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TOTAL_COUNT=0
 
-    {
-        echo "DATE_UTC=$iso_now"
-        echo "RUN_DIR=$RUN_DIR"
-        echo "RUN_BIN=$RUN_BIN"
-        echo "PATH=$PATH"
-        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
-        echo "ADSP_LIBRARY_PATH=${ADSP_LIBRARY_PATH:-}"
-        echo "CDSP_LIBRARY_PATH=${CDSP_LIBRARY_PATH:-}"
-        echo "SDSP_LIBRARY_PATH=${SDSP_LIBRARY_PATH:-}"
-        echo "ARCH=${ARCH:-}"
-        echo "PD_VAL=$PD_VAL"
-        echo "DOMAIN=$DOMAIN ($dom_name)"
-        echo "REPEAT=$REPEAT TIMEOUT=${TIMEOUT:-none}"
-        echo "EXTRA=$FASTRPC_EXTRA_FLAGS"
-    } > "$iter_env"
+# Track per-domain/per-PD results during execution
+# Format: "DOMAIN:PD:pass_count:fail_count:subtests_total:subtests_pass:subtests_fail:subtests_skip"
+RESULTS_TRACKER=""
 
-    log_info "Running $iter_tag/$REPEAT | start: $iso_now | dir: $RUN_DIR"
-    log_info "Executing: ./fastrpc_test$(cmd_to_string "$@")"
-    printf "./fastrpc_test%s\n" "$(cmd_to_string "$@")" > "$iter_cmd"
+for DOMAIN in $DOMAINS_TO_TEST; do
+    dom_name="$(domain_to_name "$DOMAIN")"
+    PD_VALUES="$(effective_pds_for_domain "$DOMAIN")"
 
-    (
-        cd "$RUN_DIR" || exit 127
-        if [ $HAVE_STDBUF -eq 1 ]; then
-             runWithTimeoutIfSet stdbuf -oL -eL ./fastrpc_test "$@"
-        elif [ $HAVE_SCRIPT -eq 1 ]; then
-            cmd_str="./fastrpc_test$(cmd_to_string "$@")"
-            if [ -n "$TIMEOUT" ] && [ $HAVE_TIMEOUT -eq 1 ]; then
-                script -q -c "timeout $TIMEOUT $cmd_str" /dev/null
-            else
-                script -q -c "$cmd_str" /dev/null
+    if [ -z "$PD_VALUES" ]; then
+        log_warn "Skipping $dom_name: requested PD mode unsupported for this domain"
+        continue
+    fi
+
+    for PD_VAL in $PD_VALUES; do
+        case "$PD_VAL" in
+            0) pd_name="signed" ;;
+            1) pd_name="unsigned" ;;
+            *) pd_name="unknown" ;;
+        esac
+
+        # Initialize counters for this domain/PD combo
+        combo_pass=0
+        combo_fail=0
+        combo_subtests_total=0
+        combo_subtests_pass=0
+        combo_subtests_fail=0
+        combo_subtests_skip=0
+
+        i=1
+        while [ "$i" -le "$REPEAT" ]; do
+            TOTAL_COUNT=$((TOTAL_COUNT+1))
+
+            iter_tag="${dom_name}_${pd_name}_iter${i}"
+            iter_log="$LOG_ROOT/${iter_tag}.out"
+            iter_rc="$LOG_ROOT/${iter_tag}.rc"
+            iter_cmd="$LOG_ROOT/${iter_tag}.cmd"
+            iter_env="$LOG_ROOT/${iter_tag}.env"
+            iter_dmesg="$LOG_ROOT/${iter_tag}.dmesg"
+            iso_now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+            set -- -d "$DOMAIN" -t linux
+            [ -n "$ARCH" ] && set -- "$@" -a "$ARCH"
+            set -- "$@" -U "$PD_VAL"
+            # shellcheck disable=SC2086
+            [ -n "${FASTRPC_EXTRA_FLAGS:-}" ] && set -- "$@" ${FASTRPC_EXTRA_FLAGS}
+
+            {
+                echo "DATE_UTC=$iso_now"
+                echo "RUN_DIR=$RUN_DIR"
+                echo "RUN_BIN=$RUN_BIN"
+                echo "PATH=$PATH"
+                echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
+                echo "ADSP_LIBRARY_PATH=${ADSP_LIBRARY_PATH:-}"
+                echo "CDSP_LIBRARY_PATH=${CDSP_LIBRARY_PATH:-}"
+                echo "SDSP_LIBRARY_PATH=${SDSP_LIBRARY_PATH:-}"
+                echo "ARCH=${ARCH:-}"
+                echo "PD_VAL=$PD_VAL ($pd_name)"
+                echo "DOMAIN=$DOMAIN ($dom_name)"
+                echo "REPEAT=$REPEAT TIMEOUT=${TIMEOUT:-none}"
+                echo "EXTRA=${FASTRPC_EXTRA_FLAGS:-}"
+            } > "$iter_env"
+
+            log_info "Running $iter_tag | domain=$dom_name | pd=$pd_name"
+            log_info "Executing: ./fastrpc_test$(cmd_to_string "$@")"
+            printf "./fastrpc_test%s\n" "$(cmd_to_string "$@")" > "$iter_cmd"
+
+            (
+                cd "$RUN_DIR" || exit 127
+                if [ $HAVE_STDBUF -eq 1 ]; then
+                     runWithTimeoutIfSet stdbuf -oL -eL ./fastrpc_test "$@"
+                elif [ $HAVE_SCRIPT -eq 1 ]; then
+                    cmd_str="./fastrpc_test$(cmd_to_string "$@")"
+                    if [ -n "$TIMEOUT" ] && [ $HAVE_TIMEOUT -eq 1 ]; then
+                        script -q -c "timeout $TIMEOUT $cmd_str" /dev/null
+                    else
+                        script -q -c "$cmd_str" /dev/null
+                    fi
+                else
+                    runWithTimeoutIfSet ./fastrpc_test "$@"
+                fi
+            ) >"$iter_log" 2>&1
+            rc=$?
+
+            printf '%s\n' "$rc" >"$iter_rc"
+
+            if [ -s "$iter_log" ]; then
+                echo "----- $iter_tag output begin -----"
+                cat "$iter_log"
+                echo "----- $iter_tag output end -----"
             fi
-        else
-            runWithTimeoutIfSet ./fastrpc_test "$@"
-        fi
-    ) >"$iter_log" 2>&1
-    rc=$?
 
-    printf '%s\n' "$rc" >"$iter_rc"
+            if [ "$rc" -ne 0 ]; then
+                log_fail "$iter_tag: fastrpc_test exited $rc"
+                dmesg | tail -n 300 > "$iter_dmesg" 2>/dev/null
+                log_dsp_remoteproc_status
+            fi
 
-    if [ -s "$iter_log" ]; then
-        echo "----- $iter_tag output begin -----"
-        cat "$iter_log"
-        echo "----- $iter_tag output end -----"
-    fi
+            # Extract and accumulate subtest counts from this iteration's log
+            if [ -r "$iter_log" ]; then
+                iter_counts="$(extract_test_summary_counts "$iter_log")"
+                iter_t="$(printf '%s' "$iter_counts" | awk -F: '{print $1}')"
+                iter_p="$(printf '%s' "$iter_counts" | awk -F: '{print $2}')"
+                iter_f="$(printf '%s' "$iter_counts" | awk -F: '{print $3}')"
+                iter_s="$(printf '%s' "$iter_counts" | awk -F: '{print $4}')"
+                combo_subtests_total=$((combo_subtests_total + iter_t))
+                combo_subtests_pass=$((combo_subtests_pass  + iter_p))
+                combo_subtests_fail=$((combo_subtests_fail  + iter_f))
+                combo_subtests_skip=$((combo_subtests_skip  + iter_s))
+            fi
 
-    if [ "$rc" -ne 0 ]; then
-        log_fail "$iter_tag: fastrpc_test exited $rc (see $iter_log)"
-        dmesg | tail -n 300 > "$iter_dmesg" 2>/dev/null
-        log_dsp_remoteproc_status
-    fi
+            # Track invocation result immediately
+            # SM8850: libhap_example HAP_mem DMA handle not supported - treat as known skip
+            if [ "$rc" -eq 0 ] && [ -r "$iter_log" ] && grep -F -q -e "All tests completed successfully" -e "All applicable tests PASSED" "$iter_log"; then
+                PASS_COUNT=$((PASS_COUNT+1))
+                combo_pass=$((combo_pass+1))
+                log_pass "$iter_tag: success"
+            elif case "$SOC_MACHINE" in *SM8850*) true ;; *) false ;; esac && only_hap_example_failed "$iter_log"; then
+                PASS_COUNT=$((PASS_COUNT+1))
+                combo_pass=$((combo_pass+1))
+                log_pass "$iter_tag: success (libhap_example.so HAP_mem skipped on $SOC_MACHINE - DMA handle not supported)"
+            else
+                combo_fail=$((combo_fail+1))
+                log_warn "$iter_tag: success pattern not found"
+            fi
 
-	if [ -r "$iter_log" ] && grep -F -q -e "All tests completed successfully" -e "All applicable tests PASSED" "$iter_log"; then
-        PASS_COUNT=$((PASS_COUNT+1))
-        log_pass "$iter_tag: success"
-    else
-        log_warn "$iter_tag: success pattern not found"
-    fi
+            i=$((i+1))
+        done
 
-    i=$((i+1))
+        # Store results for this domain/PD combo (including subtest counts)
+        RESULTS_TRACKER="${RESULTS_TRACKER}${DOMAIN}:${PD_VAL}:${combo_pass}:${combo_fail}:${combo_subtests_total}:${combo_subtests_pass}:${combo_subtests_fail}:${combo_subtests_skip}
+"
+    done
 done
 
 # -------------------- Finalize --------------------------------
-if [ "$PASS_COUNT" -eq "$REPEAT" ]; then
-    log_pass "$TESTNAME : Test Passed ($PASS_COUNT/$REPEAT)"
+# Build detailed summary table from tracked results
+log_info "=========================================================================="
+log_info " FastRPC Test Summary"
+log_info "=========================================================================="
+
+SUMMARY_FILE="$LOG_ROOT/summary.txt"
+true > "$SUMMARY_FILE"
+
+# Display table header
+SUMMARY_SEP="--------------------------------------------------------------------------------"
+
+log_info "$SUMMARY_SEP"
+header_line="$(printf '%-10s | %-10s | %6s | %6s | %6s | %6s | %-6s' "Domain" "PD Mode" "Total" "Pass" "Fail" "Skip" "Status")"
+log_info "$header_line"
+log_info "$SUMMARY_SEP"
+
+overall_subtests_total=0
+overall_subtests_pass=0
+overall_subtests_fail=0
+overall_subtests_skip=0
+
+# shellcheck disable=SC2034  # _pass_cnt/_fail_cnt consumed from tracker but not used in display
+while IFS=: read -r domain pd_val _pass_cnt _fail_cnt combo_total_tests combo_pass_tests combo_fail_tests combo_skip_tests; do
+    [ -z "$domain" ] && continue
+
+    dom_name="$(domain_to_name "$domain")"
+    case "$pd_val" in
+        0) pd_name="Signed" ;;
+        1) pd_name="Unsigned" ;;
+        *) pd_name="Unknown" ;;
+    esac
+
+    # Sanitize counts read from tracker
+    case "$combo_total_tests" in ''|*[!0-9]*) combo_total_tests=0 ;; esac
+    case "$combo_pass_tests"  in ''|*[!0-9]*) combo_pass_tests=0  ;; esac
+    case "$combo_fail_tests"  in ''|*[!0-9]*) combo_fail_tests=0  ;; esac
+    case "$combo_skip_tests"  in ''|*[!0-9]*) combo_skip_tests=0  ;; esac
+
+    overall_subtests_total=$((overall_subtests_total + combo_total_tests))
+    overall_subtests_pass=$((overall_subtests_pass  + combo_pass_tests))
+    overall_subtests_fail=$((overall_subtests_fail  + combo_fail_tests))
+    overall_subtests_skip=$((overall_subtests_skip  + combo_skip_tests))
+
+    if [ "$combo_total_tests" -eq 0 ]; then
+        status="SKIP"
+    elif [ "$combo_fail_tests" -eq 0 ]; then
+        status="PASS"
+    else
+        status="FAIL"
+    fi
+
+    line="$(printf '%-10s | %-10s | %6s | %6s | %6s | %6s | %-6s' "$dom_name" "$pd_name" "$combo_total_tests" "$combo_pass_tests" "$combo_fail_tests" "$combo_skip_tests" "$status")"
+    echo "$line" >> "$SUMMARY_FILE"
+    log_info "$line"
+done <<EOF
+$RESULTS_TRACKER
+EOF
+
+log_info "$SUMMARY_SEP"
+overall_inv_line="$(printf '%-20s Total:%6d | Passed:%6d | Failed:%6d' \
+    'Overall invocations:' "$TOTAL_COUNT" "$PASS_COUNT" "$((TOTAL_COUNT - PASS_COUNT))")"
+log_info "$overall_inv_line"
+
+overall_sub_line="$(printf '%-20s Total:%6d | Passed:%6d | Failed:%6d | Skipped:%6d' \
+    'Overall subtests:' "$overall_subtests_total" "$overall_subtests_pass" "$overall_subtests_fail" "$overall_subtests_skip")"
+log_info "$overall_sub_line"
+
+# Final result determination
+if [ "$TOTAL_COUNT" -eq 0 ]; then
+    log_skip "$TESTNAME SKIP - no runnable domain/PD combinations"
+    echo "$TESTNAME : SKIP" > "$RESULT_FILE"
+    exit 0
+elif [ "$PASS_COUNT" -eq "$TOTAL_COUNT" ]; then
+    log_pass "$TESTNAME : Test Passed ($PASS_COUNT/$TOTAL_COUNT)"
     echo "$TESTNAME : PASS" > "$RESULT_FILE"
+    exit 0
 else
-    log_fail "$TESTNAME : Test Failed ($PASS_COUNT/$REPEAT)"
+    log_fail "$TESTNAME : Test Failed ($PASS_COUNT/$TOTAL_COUNT)"
     echo "$TESTNAME : FAIL" > "$RESULT_FILE"
+    exit 0
 fi
-
-[ -f "$RESULT_FILE" ] || {
-    log_error "Missing result file ($RESULT_FILE) — creating FAIL"
-    echo "$TESTNAME : FAIL" >"$RESULT_FILE"
-}
-
-exit 0


### PR DESCRIPTION
## Summary
This PR enhances fastrpc_test by expanding test coverage from a single DSP domain to runtime discovery and validation of all supported DSP domains.
The change improves coverage on platforms with multiple DSPs while preserving compatibility with legacy single-domain execution.

---

## Changes

### Runtime DSP domain discovery
- Discover available DSP domains at runtime using `get_remoteproc_by_firmware()` with `dt_has_remoteproc_fw()` as fallback
- Remove reliance on a fixed default domain
- Canonicalize firmware names (`cdsp0`→`cdsp`, `gdsp0`→`gpdsp0`, `gdsp1`→`gpdsp1`)

### Expanded domain support
- Add support for CDSP1, GPDSP0, and GPDSP1
- Covers domains 4, 5, and 6

### Domain-aware PD execution
- Enforce PD execution rules based on domain capabilities:
  - ADSP / MDSP / SDSP: signed PD only
  - CDSP / CDSP1 / GPDSP: signed and unsigned PDs
- Automatically select supported PD modes per domain
- Honour `FASTRPC_UNSIGNED_PD` env var with correct priority: `--unsigned-pd` CLI > `FASTRPC_UNSIGNED_PD` env > `--pd-mode`

### Result tracking and reporting
- Track pass/fail and subtest counts per domain and per PD mode during execution
- Remove post-run log reparsing — all counts accumulated in `RESULTS_TRACKER` during run loop
- Print a tabular summary per domain and PD mode with aligned columns showing Total/Pass/Fail/Skip per invocation

### SoC-specific handling
- Skip `QRB2210` and `Glymur CRD` entirely — FastRPC not supported
- Filter `GPDSP0`/`GPDSP1` (domains 5/6) for `QCS9075`, `QCS8275` and `QCS8300`
- Treat `libhap_example` HAP_mem DMA failure as known skip on `SM8850` — remaining subtests pass
- Fix `SOC_MACHINE` extraction to preserve full string for reliable multi-word SoC name matching

---

## Behavior

### Default behavior
- Test all discovered DSP domains with supported PD modes

### Legacy behavior
- Preserve single-domain execution via:
  `--domain-mode single --domain <N>`

---

## Maintenance
- Remove unused `pick_default_domain()` helper
- Rename `USER_PD` → `UNSIGNED_PD` across YAML params, CLI flags and env vars
- Fix SKIP paths to exit with status 0
- Resolve ShellCheck warnings (SC2002, SC2317, SC2086, SC2188, SC2034)
- Fix trailing whitespace and missing EOF newline
- Update YAML metadata and `run.sh` usage documentation

**Expected Sample Output: (qcs9100-ride-sx)**
<img width="521" height="330" alt="image" src="https://github.com/user-attachments/assets/9ec850fb-f659-4b22-97d1-f5c87e8ce04a" />