### PR TITLE
add logging validation helpers and Logging_Journalctl_Validation testcase

### DIFF
--- a/Runner/suites/System/Logging/Logging_Journalctl_Validation/Logging_Journalctl_Validation.yaml
+++ b/Runner/suites/System/Logging/Logging_Journalctl_Validation/Logging_Journalctl_Validation.yaml
@@ -1,0 +1,19 @@
+metadata:
+  name: logging-journalctl-validation
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validate systemd-journald, journalctl access, and log propagation into /var/log on Qualcomm Linux platforms."
+  os:
+    - linux
+  scope:
+    - functional
+
+params:
+  RETRY_COUNT: 5
+  RETRY_SLEEP_SECS: 1
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/System/Logging/Logging_Journalctl_Validation/ || true
+    - RETRY_COUNT="${RETRY_COUNT}" RETRY_SLEEP_SECS="${RETRY_SLEEP_SECS}" ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Logging_Journalctl_Validation.res

--- a/Runner/suites/System/Logging/Logging_Journalctl_Validation/Logging_Journalctl_Validation_README.md
+++ b/Runner/suites/System/Logging/Logging_Journalctl_Validation/Logging_Journalctl_Validation_README.md
@@ -1,0 +1,187 @@
+# Logging_Journalctl_Validation
+
+## Overview
+
+`Logging_Journalctl_Validation` verifies that the system logging pipeline is working correctly after boot.
+
+The testcase checks that:
+
+- required logging tools are available
+- `systemd-journald.service` is active
+- a readable log sink exists under `/var/log`
+- a custom test message can be written using `logger`
+- the same test message can be retrieved using `journalctl`
+- the same test message is also present in the selected `/var/log` file
+
+This testcase is intended to validate journald and file-based logging behavior on the target system.
+
+---
+
+## Validation Scope
+
+The testcase covers the following:
+
+1. **Tool availability**
+   - `journalctl`
+   - `systemctl`
+   - `logger`
+   - `grep`
+   - `sed`
+   - `awk`
+   - `tail`
+
+2. **Journald service validation**
+   - verifies that `systemd-journald.service` is active
+
+3. **Log file detection**
+   - checks for a readable log sink under `/var/log`
+   - supported files include:
+     - `/var/log/messages`
+     - `/var/log/syslog`
+     - `/var/log/user.log`
+     - `/var/log/daemon.log`
+     - `/var/log/kern.log`
+
+4. **Custom message injection**
+   - creates a unique test token
+   - emits the message using `logger`
+
+5. **Journal verification**
+   - verifies that the emitted message is visible through `journalctl`
+
+6. **File log verification**
+   - verifies that the emitted message is present in the detected log file
+
+---
+
+## Prerequisites
+
+Before running the testcase, ensure that:
+
+- the target has booted successfully
+- `systemd-journald.service` is available on the target
+- `logger` is available
+- `journalctl` is available
+- at least one readable log file exists under `/var/log`
+
+---
+
+## Test Location
+
+```text
+Runner/suites/System/Logging/Logging_Journalctl_Validation/
+```
+
+---
+
+## Files
+
+Typical contents of this testcase directory:
+
+```text
+run.sh
+Logging_Journalctl_Validation.yaml
+README.md
+```
+
+---
+
+## How to Run
+
+Run the testcase directly:
+
+```sh
+cd Runner/suites/System/Logging/Logging_Journalctl_Validation
+chmod +x run.sh
+./run.sh
+```
+
+---
+
+## Optional Environment Variables
+
+The testcase supports the following optional variables:
+
+- `RETRY_COUNT`
+  - number of retries used while searching for the injected message
+  - default: `5`
+
+- `RETRY_SLEEP_SECS`
+  - delay in seconds between retries
+  - default: `1`
+
+Example:
+
+```sh
+RETRY_COUNT=10 RETRY_SLEEP_SECS=2 ./run.sh
+```
+
+---
+
+## Expected Result
+
+### PASS
+The testcase passes when:
+
+- required tools are present
+- `systemd-journald.service` is active
+- a readable `/var/log` file is detected
+- the injected test message is found in `journalctl`
+- the injected test message is found in the detected log file
+
+### FAIL
+The testcase fails when any of the following occurs:
+
+- required tools are missing
+- `systemd-journald.service` is not active
+- no readable log file is found under `/var/log`
+- the test message cannot be emitted
+- the test message is not visible through `journalctl`
+- the test message is not visible in the selected log file
+
+### SKIP
+The testcase is skipped when required runtime dependencies are not available.
+
+---
+
+## Result File
+
+The testcase writes the result to:
+
+```text
+Logging_Journalctl_Validation.res
+```
+
+Possible values:
+
+```text
+Logging_Journalctl_Validation PASS
+Logging_Journalctl_Validation FAIL
+Logging_Journalctl_Validation SKIP
+```
+
+The script is expected to write the result file even when the shell exit code remains `0` for CI/LAVA flow continuity.
+
+---
+
+## Notes
+
+- This testcase does **not** require `/var/log/journal` to exist.
+- This testcase is intended to work on systems that use file-based logging under `/var/log`.
+- This testcase does **not** validate unrelated failed services.
+- This testcase is focused only on journald visibility and log propagation.
+
+---
+
+## Example Checks Performed
+
+Typical validation sequence:
+
+1. detect logging tools
+2. verify `systemd-journald.service`
+3. identify active log file
+4. emit unique test message
+5. verify message in `journalctl`
+6. verify message in `/var/log/*`
+
+---

--- a/Runner/suites/System/Logging/Logging_Journalctl_Validation/run.sh
+++ b/Runner/suites/System/Logging/Logging_Journalctl_Validation/run.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Logging / journalctl validation:
+# - verifies required logging tools are available
+# - verifies systemd-journald service is active
+# - prints journald service status to stdout
+# - detects an active /var/log sink file
+# - prints available log files under /var/log
+# - emits a custom test message through logger
+# - verifies the message in journalctl and prints the matched line
+# - verifies the message in the detected log file and prints the matched line
+# - validates journal storage mode sanity
+# - validates journal boot list sanity
+# - validates unit-scoped journal queries
+# - validates priority-based journal filtering
+# - writes PASS/FAIL to .res and exits 0 so LAVA can continue
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    exit 1
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/lib_logger.sh"
+
+TESTNAME="Logging_Journalctl_Validation"
+RETRY_COUNT="${RETRY_COUNT:-5}"
+RETRY_SLEEP_SECS="${RETRY_SLEEP_SECS:-1}"
+
+test_path="$(find_test_case_by_name "$TESTNAME")"
+if [ -n "$test_path" ]; then
+    cd "$test_path" || exit 1
+else
+    cd "$SCRIPT_DIR" || exit 1
+fi
+
+RES_FILE="./$TESTNAME.res"
+rm -f "$RES_FILE"
+
+if ! CHECK_DEPS_NO_EXIT=1 check_dependencies journalctl systemctl logger grep sed awk tail; then
+    log_skip "$TESTNAME SKIP: missing dependencies"
+    echo "$TESTNAME SKIP" > "$RES_FILE"
+    exit 0
+fi
+
+log_info "--------------------------------------------------------------------------"
+log_info "------------------- Starting $TESTNAME Testcase --------------------------"
+log_info "Config, RETRY_COUNT=$RETRY_COUNT RETRY_SLEEP_SECS=$RETRY_SLEEP_SECS"
+
+if command -v detect_platform >/dev/null 2>&1; then
+    detect_platform
+fi
+
+log_info "Platform Details: machine='${PLATFORM_MACHINE:-unknown}' target='${PLATFORM_TARGET:-unknown}' kernel='$(uname -r 2>/dev/null || echo unknown)' arch='$(uname -m 2>/dev/null || echo unknown)'"
+
+log_info "----- systemd-journald service snapshot -----"
+journald_state="$(systemctl is-active systemd-journald.service 2>/dev/null || echo unknown)"
+log_info "Service: systemd-journald.service state=$journald_state"
+systemctl status systemd-journald.service --no-pager --full 2>/dev/null | sed -n '1,12p' | while IFS= read -r line; do
+    [ -n "$line" ] && log_info "[journald-status] $line"
+done
+log_info "----- End systemd-journald service snapshot -----"
+
+if ! check_systemd_services systemd-journald.service; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_detect_log_file; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_emit_test_message; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_verify_test_message_in_journalctl "$RETRY_COUNT" "$RETRY_SLEEP_SECS"; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_verify_test_message_in_log_file "$RETRY_COUNT" "$RETRY_SLEEP_SECS"; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_check_journal_storage_mode; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_check_boot_list_sanity; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_check_unit_scoped_query systemd-journald.service; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_emit_priority_test_message; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+if ! logging_verify_priority_message_in_journalctl "$RETRY_COUNT" "$RETRY_SLEEP_SECS"; then
+    log_fail "$TESTNAME : FAIL"
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+log_pass "$TESTNAME : PASS"
+echo "$TESTNAME PASS" > "$RES_FILE"
+exit 0

--- a/Runner/utils/lib_logger.sh
+++ b/Runner/utils/lib_logger.sh
@@ -1,0 +1,323 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Logging / journald helpers
+# Assumes functestlib.sh provides log_info, log_warn, log_fail, log_pass.
+
+# Detect a readable system log file under /var/log for validation.
+# Logs candidate file presence to help CI debug missing or misrouted logs.
+logging_detect_log_file() {
+    LOGGING_ACTIVE_LOG_FILE=""
+
+    log_info "----- /var/log candidate files -----"
+    for log_file in \
+        /var/log/messages \
+        /var/log/syslog \
+        /var/log/user.log \
+        /var/log/daemon.log \
+        /var/log/kern.log
+    do
+        if [ -f "$log_file" ]; then
+            if [ -r "$log_file" ]; then
+                log_info "[log-file] present: $log_file"
+                if [ -z "$LOGGING_ACTIVE_LOG_FILE" ]; then
+                    LOGGING_ACTIVE_LOG_FILE="$log_file"
+                fi
+            else
+                log_warn "[log-file] present but not readable: $log_file"
+            fi
+        else
+            log_info "[log-file] missing: $log_file"
+        fi
+    done
+    log_info "----- End /var/log candidate files -----"
+
+    if [ -n "$LOGGING_ACTIVE_LOG_FILE" ]; then
+        export LOGGING_ACTIVE_LOG_FILE
+        log_pass "Detected log file: $LOGGING_ACTIVE_LOG_FILE"
+        return 0
+    fi
+
+    log_fail "No readable log file found under /var/log"
+    return 1
+}
+
+# Emit a unique test message through logger for journald and file-log verification.
+# Sets and exports LOGGING_TEST_TAG and LOGGING_TEST_TOKEN for later match checks.
+logging_emit_test_message() {
+    tag_arg="$1"
+    token_arg="$2"
+    token_ts="0"
+
+    if [ -z "$tag_arg" ]; then
+        tag_arg="QLI_LOGGING_TEST"
+    fi
+
+    if [ -z "$token_arg" ]; then
+        token_ts="$(date +%s 2>/dev/null || echo 0)"
+        token_arg="qli-logging-test-$token_ts-$$"
+    fi
+
+    LOGGING_TEST_TAG="$tag_arg"
+    LOGGING_TEST_TOKEN="$token_arg"
+
+    export LOGGING_TEST_TAG LOGGING_TEST_TOKEN
+
+    log_info "Emitting test log message: tag=$LOGGING_TEST_TAG token=$LOGGING_TEST_TOKEN"
+
+    if logger -t "$LOGGING_TEST_TAG" "$LOGGING_TEST_TOKEN"; then
+        log_pass "Custom log message emitted successfully"
+        return 0
+    fi
+
+    log_fail "Failed to emit custom log message"
+    return 1
+}
+
+# Verify that the emitted test token is visible through journalctl for the current boot.
+# Logs the exact matched journal line to improve CI-side debugging and traceability.
+logging_verify_test_message_in_journalctl() {
+    retry_count="$1"
+    sleep_secs="$2"
+    attempt=1
+    matched_line=""
+
+    if [ -z "$retry_count" ]; then
+        retry_count=5
+    fi
+    if [ -z "$sleep_secs" ]; then
+        sleep_secs=1
+    fi
+
+    if [ -z "${LOGGING_TEST_TAG:-}" ] || [ -z "${LOGGING_TEST_TOKEN:-}" ]; then
+        log_fail "logging_verify_test_message_in_journalctl: test message is not initialized"
+        return 1
+    fi
+
+    while [ "$attempt" -le "$retry_count" ]; do
+        matched_line="$(journalctl -b -t "$LOGGING_TEST_TAG" --no-pager 2>/dev/null | grep -F "$LOGGING_TEST_TOKEN" | tail -n 1)"
+
+        if [ -n "$matched_line" ]; then
+            log_info "[journalctl-match] $matched_line"
+            log_pass "Custom log message found in journalctl"
+            return 0
+        fi
+
+        sleep "$sleep_secs"
+        attempt=$((attempt + 1))
+    done
+
+    log_fail "Custom log message not found in journalctl"
+    return 1
+}
+
+# Verify that the emitted test token is present in the selected /var/log file sink.
+# Logs the exact matched file-log line to make CI triage easier on logging failures.
+logging_verify_test_message_in_log_file() {
+    retry_count="$1"
+    sleep_secs="$2"
+    attempt=1
+    matched_line=""
+
+    if [ -z "$retry_count" ]; then
+        retry_count=5
+    fi
+    if [ -z "$sleep_secs" ]; then
+        sleep_secs=1
+    fi
+
+    if [ -z "${LOGGING_ACTIVE_LOG_FILE:-}" ]; then
+        log_fail "logging_verify_test_message_in_log_file: active log file is not initialized"
+        return 1
+    fi
+
+    if [ -z "${LOGGING_TEST_TOKEN:-}" ]; then
+        log_fail "logging_verify_test_message_in_log_file: test message is not initialized"
+        return 1
+    fi
+
+    while [ "$attempt" -le "$retry_count" ]; do
+        matched_line="$(grep -F "$LOGGING_TEST_TOKEN" "$LOGGING_ACTIVE_LOG_FILE" 2>/dev/null | tail -n 1)"
+
+        if [ -n "$matched_line" ]; then
+            log_info "[log-file-match] $matched_line"
+            log_pass "Custom log message found in $LOGGING_ACTIVE_LOG_FILE"
+            return 0
+        fi
+
+        sleep "$sleep_secs"
+        attempt=$((attempt + 1))
+    done
+
+    log_fail "Custom log message not found in $LOGGING_ACTIVE_LOG_FILE"
+    return 1
+}
+
+# Check whether journal storage is persistent or volatile and print useful details.
+# Passes if either journal directory exists or journalctl reports disk usage successfully.
+logging_check_journal_storage_mode() {
+    persistent_dir="/var/log/journal"
+    volatile_dir="/run/log/journal"
+    found_mode=""
+    usage_line=""
+
+    log_info "----- Journal storage mode check -----"
+
+    if [ -d "$persistent_dir" ]; then
+        log_info "[journal-storage] persistent directory present: $persistent_dir"
+        found_mode="persistent"
+    fi
+
+    if [ -d "$volatile_dir" ]; then
+        log_info "[journal-storage] volatile directory present: $volatile_dir"
+        if [ -z "$found_mode" ]; then
+            found_mode="volatile"
+        fi
+    fi
+
+    usage_line="$(journalctl --disk-usage 2>/dev/null | tail -n 1)"
+    if [ -n "$usage_line" ]; then
+        log_info "[journal-disk-usage] $usage_line"
+    fi
+
+    if [ -n "$found_mode" ]; then
+        log_pass "Journal storage mode sanity passed: $found_mode"
+        log_info "----- End journal storage mode check -----"
+        return 0
+    fi
+
+    if [ -n "$usage_line" ]; then
+        log_warn "Journal storage directories not found, but journalctl reports disk usage"
+        log_pass "Journal storage mode sanity passed"
+        log_info "----- End journal storage mode check -----"
+        return 0
+    fi
+
+    log_fail "Unable to determine journal storage mode"
+    log_info "----- End journal storage mode check -----"
+    return 1
+}
+
+# Verify that journal boot indexing is available for the current system.
+# Prints the first few entries from journalctl --list-boots for CI debug visibility.
+logging_check_boot_list_sanity() {
+    boot_lines=""
+    boot_count="0"
+
+    log_info "----- journalctl --list-boots snapshot -----"
+    boot_lines="$(journalctl --list-boots 2>/dev/null | sed -n '1,5p')"
+
+    if [ -n "$boot_lines" ]; then
+        printf '%s\n' "$boot_lines" | while IFS= read -r line; do
+            [ -n "$line" ] && log_info "[boot-list] $line"
+        done
+        boot_count="$(printf '%s\n' "$boot_lines" | grep -c . 2>/dev/null || echo 0)"
+    fi
+
+    if [ "$boot_count" -ge 1 ]; then
+        log_pass "journalctl boot list sanity passed"
+        log_info "----- End journalctl --list-boots snapshot -----"
+        return 0
+    fi
+
+    log_fail "journalctl boot list is empty"
+    log_info "----- End journalctl --list-boots snapshot -----"
+    return 1
+}
+
+# Verify that unit-scoped journal queries return data for systemd-journald.service.
+# Prints a small sample of the unit logs to help debug missing unit metadata indexing.
+logging_check_unit_scoped_query() {
+    unit_name="$1"
+    unit_lines=""
+
+    if [ -z "$unit_name" ]; then
+        unit_name="systemd-journald.service"
+    fi
+
+    log_info "----- journalctl unit query snapshot: $unit_name -----"
+    unit_lines="$(journalctl -u "$unit_name" --no-pager 2>/dev/null | sed -n '1,5p')"
+
+    if [ -n "$unit_lines" ]; then
+        printf '%s\n' "$unit_lines" | while IFS= read -r line; do
+            [ -n "$line" ] && log_info "[unit-log] $line"
+        done
+        log_pass "Unit-scoped journal query passed for $unit_name"
+        log_info "----- End journalctl unit query snapshot: $unit_name -----"
+        return 0
+    fi
+
+    log_fail "Unit-scoped journal query returned no data for $unit_name"
+    log_info "----- End journalctl unit query snapshot: $unit_name -----"
+    return 1
+}
+
+# Emit a priority-tagged error message through logger for priority filter validation.
+# Sets and exports LOGGING_PRIO_TEST_TAG and LOGGING_PRIO_TEST_TOKEN for later checks.
+logging_emit_priority_test_message() {
+    tag_arg="$1"
+    token_arg="$2"
+    token_ts="0"
+
+    if [ -z "$tag_arg" ]; then
+        tag_arg="QLI_LOGGING_PRIO_TEST"
+    fi
+
+    if [ -z "$token_arg" ]; then
+        token_ts="$(date +%s 2>/dev/null || echo 0)"
+        token_arg="qli-logging-prio-test-$token_ts-$$"
+    fi
+
+    LOGGING_PRIO_TEST_TAG="$tag_arg"
+    LOGGING_PRIO_TEST_TOKEN="$token_arg"
+
+    export LOGGING_PRIO_TEST_TAG LOGGING_PRIO_TEST_TOKEN
+
+    log_info "Emitting priority test log message: priority=user.err tag=$LOGGING_PRIO_TEST_TAG token=$LOGGING_PRIO_TEST_TOKEN"
+
+    if logger -p user.err -t "$LOGGING_PRIO_TEST_TAG" "$LOGGING_PRIO_TEST_TOKEN"; then
+        log_pass "Priority test log message emitted successfully"
+        return 0
+    fi
+
+    log_fail "Failed to emit priority test log message"
+    return 1
+}
+
+# Verify that a priority-tagged error message is visible using journalctl priority filtering.
+# Prints the matched line so CI can confirm both message content and retrieval path.
+logging_verify_priority_message_in_journalctl() {
+    retry_count="$1"
+    sleep_secs="$2"
+    attempt=1
+    matched_line=""
+
+    if [ -z "$retry_count" ]; then
+        retry_count=5
+    fi
+    if [ -z "$sleep_secs" ]; then
+        sleep_secs=1
+    fi
+
+    if [ -z "${LOGGING_PRIO_TEST_TOKEN:-}" ]; then
+        log_fail "logging_verify_priority_message_in_journalctl: priority test message is not initialized"
+        return 1
+    fi
+
+    while [ "$attempt" -le "$retry_count" ]; do
+        matched_line="$(journalctl -p err --no-pager 2>/dev/null | grep -F "$LOGGING_PRIO_TEST_TOKEN" | tail -n 1)"
+
+        if [ -n "$matched_line" ]; then
+            log_info "[priority-match] $matched_line"
+            log_pass "Priority-based journal query passed"
+            return 0
+        fi
+
+        sleep "$sleep_secs"
+        attempt=$((attempt + 1))
+    done
+
+    log_fail "Priority-based journal query did not find the emitted error message"
+    return 1
+}


### PR DESCRIPTION
Add reusable logging helpers in Runner/utils/[lib_logger.sh](http://lib_logger.sh/) and introduce
the Logging_Journalctl_Validation testcase under
Runner/suites/System/Logging/Logging_Journalctl_Validation.
 
This change keeps journald and log-file validation logic out of [functestlib.sh](http://functestlib.sh/) and adds an end-to-end logging test that verifies:
- systemd-journald service health
- required logging tools
- available /var/log sink files
- custom logger message injection
- message visibility in journalctl
- message visibility in file-based logs
- journal storage and boot-list sanity
- unit-scoped journal queries
- priority-based journal filtering
 
The testcase is LAVA-friendly and records PASS or FAIL in the result file while allowing subsequent steps to continue.

Lava job for reference on the execution - https://lava.infra.foundries.io/scheduler/job/181206#L2546