### PR TITLE
Add test wl_shm (shared-memory) rendering paths in a Wayland/Weston compositor 

### DIFF
--- a/Runner/suites/Multimedia/Graphics/weston-simple-shm/run.sh
+++ b/Runner/suites/Multimedia/Graphics/weston-simple-shm/run.sh
@@ -1,0 +1,447 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# weston-simple-shm validation
+# - Uses lib_display runtime helpers
+# - No local overlay detection duplication
+# - Base expects healthy Weston runtime
+# - CI default does not relaunch Weston
+# - Overlay can optionally relaunch only with --allow-relaunch
+# - Exercises actual weston-simple-shm format behaviour
+# - Logs client command, env, stdout/stderr, and result into each case log
+# - CI friendly PASS FAIL SKIP semantics, always exits 0 after test start
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env, starting at $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1091
+. "$TOOLS/lib_display.sh"
+
+TESTNAME="weston-simple-shm"
+
+test_path="$(find_test_case_by_name "$TESTNAME")" || {
+    log_fail "$TESTNAME, test directory not found"
+    echo "$TESTNAME FAIL" > "./$TESTNAME.res"
+    exit 0
+}
+
+cd "$test_path" || exit 1
+
+RES_FILE="./${TESTNAME}.res"
+RUN_LOG="./${TESTNAME}_run.log"
+
+: >"$RES_FILE"
+: >"$RUN_LOG"
+
+WAIT_SECS="${WAIT_SECS:-10}"
+DURATION="${DURATION:-5}"
+STARTUP_WAIT="${STARTUP_WAIT:-3}"
+STOP_GRACE="${STOP_GRACE:-3}"
+ALLOW_RELAUNCH="${ALLOW_RELAUNCH:-0}"
+REQUIRED_FORMATS="${REQUIRED_FORMATS:-default xrgb8888}"
+OPTIONAL_FORMATS="${OPTIONAL_FORMATS:-argb8888 rgb565}"
+CASE_LOG_LINES="${CASE_LOG_LINES:-40}"
+
+print_usage() {
+    cat <<EOF
+Usage: ./run.sh [OPTIONS]
+
+Options:
+  --allow-relaunch Allow Weston runtime relaunch when runtime is unhealthy
+                          Default is disabled and should stay disabled for CI
+  --duration SEC Keep each weston-simple-shm case running for SEC seconds, default: ${DURATION}
+  --startup-wait SEC Wait SEC seconds after launch before startup verdict, default: ${STARTUP_WAIT}
+  --stop-grace SEC Grace period after INT before KILL, default: ${STOP_GRACE}
+  --required-formats STR Space-separated required formats, default: "${REQUIRED_FORMATS}"
+  --optional-formats STR Space-separated optional formats, default: "${OPTIONAL_FORMATS}"
+  -h, --help Show this help
+
+Notes:
+  - Use the literal token "default" to run weston-simple-shm without -F.
+  - Required formats affect PASS/FAIL.
+  - Optional formats are logged for coverage and do not change final verdict.
+  - CI should not use --allow-relaunch by default.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --allow-relaunch)
+            ALLOW_RELAUNCH=1
+            shift
+            ;;
+        --duration)
+            if [ $# -lt 2 ]; then
+                log_fail "$TESTNAME, missing value for --duration"
+                echo "$TESTNAME FAIL" >"$RES_FILE"
+                exit 0
+            fi
+            DURATION="$2"
+            shift 2
+            ;;
+        --startup-wait)
+            if [ $# -lt 2 ]; then
+                log_fail "$TESTNAME, missing value for --startup-wait"
+                echo "$TESTNAME FAIL" >"$RES_FILE"
+                exit 0
+            fi
+            STARTUP_WAIT="$2"
+            shift 2
+            ;;
+        --stop-grace)
+            if [ $# -lt 2 ]; then
+                log_fail "$TESTNAME, missing value for --stop-grace"
+                echo "$TESTNAME FAIL" >"$RES_FILE"
+                exit 0
+            fi
+            STOP_GRACE="$2"
+            shift 2
+            ;;
+        --required-formats)
+            if [ $# -lt 2 ]; then
+                log_fail "$TESTNAME, missing value for --required-formats"
+                echo "$TESTNAME FAIL" >"$RES_FILE"
+                exit 0
+            fi
+            REQUIRED_FORMATS="$2"
+            shift 2
+            ;;
+        --optional-formats)
+            if [ $# -lt 2 ]; then
+                log_fail "$TESTNAME, missing value for --optional-formats"
+                echo "$TESTNAME FAIL" >"$RES_FILE"
+                exit 0
+            fi
+            OPTIONAL_FORMATS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            print_usage
+            echo "$TESTNAME SKIP" >"$RES_FILE"
+            exit 0
+            ;;
+        *)
+            log_fail "$TESTNAME, unknown argument $1"
+            print_usage
+            echo "$TESTNAME FAIL" >"$RES_FILE"
+            exit 0
+            ;;
+    esac
+done
+
+APP_PID=""
+
+# Called indirectly via trap.
+# shellcheck disable=SC2317
+cleanup_client() {
+    if [ -n "$APP_PID" ]; then
+        if kill -0 "$APP_PID" 2>/dev/null; then
+            kill -INT "$APP_PID" 2>/dev/null || true
+            sleep 1
+            if kill -0 "$APP_PID" 2>/dev/null; then
+                kill -KILL "$APP_PID" 2>/dev/null || true
+            fi
+        fi
+        wait "$APP_PID" 2>/dev/null || true
+        APP_PID=""
+    fi
+}
+
+show_case_log_output() {
+    scl_log="$1"
+    scl_prefix="$2"
+
+    if [ ! -f "$scl_log" ]; then
+        log_info "[$scl_prefix] log file not found, $scl_log"
+        return 0
+    fi
+
+    if [ ! -s "$scl_log" ]; then
+        log_info "[$scl_prefix] client log is empty"
+        return 0
+    fi
+
+    log_info "[$scl_prefix] client output from, $scl_log"
+    sed -n "1,${CASE_LOG_LINES}p" "$scl_log" 2>/dev/null | while IFS= read -r line; do
+        [ -n "$line" ] && log_info "[$scl_prefix] $line"
+    done
+
+    line_count="$(wc -l <"$scl_log" 2>/dev/null | tr -d '[:space:]')"
+    if [ -z "$line_count" ]; then
+        line_count=0
+    fi
+    if [ "$line_count" -gt "$CASE_LOG_LINES" ]; then
+        log_info "[$scl_prefix] output truncated to first ${CASE_LOG_LINES} lines, total_lines=${line_count}"
+    fi
+}
+
+run_format_case() {
+    rfc_format="$1"
+    rfc_required="$2"
+    rfc_case_name="$1"
+    rfc_case_log=""
+    rfc_rc=0
+    rfc_elapsed=0
+    rfc_status="FAIL"
+    rfc_cmd=""
+
+    if [ "$rfc_format" = "default" ]; then
+        rfc_case_name="default"
+        rfc_cmd="$SHM_BIN"
+    else
+        rfc_cmd="$SHM_BIN -F $rfc_format"
+    fi
+
+    timestamp="$(date +%Y%m%d-%H%M%S 2>/dev/null || echo 19700101-000000)"
+    rfc_case_log="./${TESTNAME}_${rfc_case_name}_${timestamp}.log"
+
+    : >"$rfc_case_log"
+
+    {
+        printf '%s\n' "case_name=${rfc_case_name}"
+        printf '%s\n' "format=${rfc_format}"
+        printf '%s\n' "required=${rfc_required}"
+        printf '%s\n' "command=${rfc_cmd}"
+        printf '%s\n' "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-<unset>}"
+        printf '%s\n' "WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-<unset>}"
+        printf '%s\n' "----- client stdout/stderr begin -----"
+    } >>"$rfc_case_log"
+
+    log_info "----- weston-simple-shm case start, format=${rfc_format} required=${rfc_required} -----"
+    log_info "Case log, ${rfc_case_log}"
+    log_info "Launch command, ${rfc_cmd}"
+
+    if [ "$rfc_format" = "default" ]; then
+        "$SHM_BIN" >>"$rfc_case_log" 2>&1 &
+    else
+        "$SHM_BIN" -F "$rfc_format" >>"$rfc_case_log" 2>&1 &
+    fi
+    APP_PID="$!"
+
+    sleep "$STARTUP_WAIT"
+
+    if ! kill -0 "$APP_PID" 2>/dev/null; then
+        wait "$APP_PID" 2>/dev/null
+        rfc_rc=$?
+
+        {
+            printf '%s\n' "----- client stdout/stderr end -----"
+            printf '%s\n' "startup_rc=${rfc_rc}"
+        } >>"$rfc_case_log"
+
+        if grep -F "not supported by compositor" "$rfc_case_log" >/dev/null 2>&1; then
+            if [ "$rfc_required" = "1" ]; then
+                log_fail "Required format not supported by compositor, ${rfc_format}"
+                printf '%s\n' "result=FAIL reason=compositor-unsupported" >>"$rfc_case_log"
+                show_case_log_output "$rfc_case_log" "client"
+                printf '%s\n' "case=${rfc_format} status=FAIL reason=compositor-unsupported log=${rfc_case_log}" >>"$RUN_LOG"
+                APP_PID=""
+                return 1
+            fi
+            log_warn "Optional format not supported by compositor, ${rfc_format}"
+            printf '%s\n' "result=SKIP reason=compositor-unsupported" >>"$rfc_case_log"
+            show_case_log_output "$rfc_case_log" "client"
+            printf '%s\n' "case=${rfc_format} status=SKIP reason=compositor-unsupported log=${rfc_case_log}" >>"$RUN_LOG"
+            APP_PID=""
+            return 2
+        fi
+
+        if grep -F "not supported by client" "$rfc_case_log" >/dev/null 2>&1; then
+            if [ "$rfc_required" = "1" ]; then
+                log_fail "Required format not supported by client binary, ${rfc_format}"
+                printf '%s\n' "result=FAIL reason=client-unsupported" >>"$rfc_case_log"
+                show_case_log_output "$rfc_case_log" "client"
+                printf '%s\n' "case=${rfc_format} status=FAIL reason=client-unsupported log=${rfc_case_log}" >>"$RUN_LOG"
+                APP_PID=""
+                return 1
+            fi
+            log_warn "Optional format not supported by client binary, ${rfc_format}"
+            printf '%s\n' "result=SKIP reason=client-unsupported" >>"$rfc_case_log"
+            show_case_log_output "$rfc_case_log" "client"
+            printf '%s\n' "case=${rfc_format} status=SKIP reason=client-unsupported log=${rfc_case_log}" >>"$RUN_LOG"
+            APP_PID=""
+            return 2
+        fi
+
+        log_fail "weston-simple-shm exited during startup, format=${rfc_format}, rc=${rfc_rc}"
+        printf '%s\n' "result=FAIL reason=startup-exit rc=${rfc_rc}" >>"$rfc_case_log"
+        show_case_log_output "$rfc_case_log" "client"
+        printf '%s\n' "case=${rfc_format} status=FAIL reason=startup-exit rc=${rfc_rc} log=${rfc_case_log}" >>"$RUN_LOG"
+        APP_PID=""
+        return 1
+    fi
+
+    log_info "weston-simple-shm started successfully, format=${rfc_format}, monitoring for ${DURATION} seconds"
+
+    rfc_elapsed=0
+    while [ "$rfc_elapsed" -lt "$DURATION" ]; do
+        if ! kill -0 "$APP_PID" 2>/dev/null; then
+            wait "$APP_PID" 2>/dev/null
+            rfc_rc=$?
+
+            {
+                printf '%s\n' "----- client stdout/stderr end -----"
+                printf '%s\n' "monitor_rc=${rfc_rc}"
+                printf '%s\n' "result=FAIL reason=early-exit"
+            } >>"$rfc_case_log"
+
+            log_fail "weston-simple-shm exited before completing monitor window, format=${rfc_format}, rc=${rfc_rc}"
+            show_case_log_output "$rfc_case_log" "client"
+            printf '%s\n' "case=${rfc_format} status=FAIL reason=early-exit rc=${rfc_rc} log=${rfc_case_log}" >>"$RUN_LOG"
+            APP_PID=""
+            return 1
+        fi
+        sleep 1
+        rfc_elapsed=$((rfc_elapsed + 1))
+    done
+
+    log_info "Stopping weston-simple-shm with SIGINT, format=${rfc_format}, grace=${STOP_GRACE}s"
+    kill -INT "$APP_PID" 2>/dev/null || true
+
+    rfc_elapsed=0
+    while [ "$rfc_elapsed" -lt "$STOP_GRACE" ]; do
+        if ! kill -0 "$APP_PID" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+        rfc_elapsed=$((rfc_elapsed + 1))
+    done
+
+    if kill -0 "$APP_PID" 2>/dev/null; then
+        log_warn "weston-simple-shm did not stop after SIGINT, sending KILL, format=${rfc_format}"
+        kill -KILL "$APP_PID" 2>/dev/null || true
+    fi
+
+    wait "$APP_PID" 2>/dev/null || true
+    APP_PID=""
+
+    {
+        printf '%s\n' "----- client stdout/stderr end -----"
+        printf '%s\n' "result=PASS"
+    } >>"$rfc_case_log"
+
+    show_case_log_output "$rfc_case_log" "client"
+
+    rfc_status="PASS"
+    log_pass "weston-simple-shm case passed, format=${rfc_format}"
+    printf '%s\n' "case=${rfc_format} status=${rfc_status} log=${rfc_case_log}" >>"$RUN_LOG"
+    log_info "----- weston-simple-shm case end, format=${rfc_format}, status=${rfc_status} -----"
+    return 0
+}
+
+trap 'cleanup_client' EXIT HUP INT TERM
+
+log_info "Weston log directory, $SCRIPT_DIR"
+log_info "--------------------------------------------------------------------------"
+log_info "------------------- Starting ${TESTNAME} Testcase --------------------------"
+log_info "Config, WAIT_SECS=${WAIT_SECS} DURATION=${DURATION} STARTUP_WAIT=${STARTUP_WAIT} STOP_GRACE=${STOP_GRACE} ALLOW_RELAUNCH=${ALLOW_RELAUNCH}"
+log_info "Required formats, ${REQUIRED_FORMATS}"
+log_info "Optional formats, ${OPTIONAL_FORMATS}"
+
+if [ "$ALLOW_RELAUNCH" = "1" ]; then
+    log_warn "Weston relaunch is enabled for this run"
+else
+    log_info "Weston relaunch is disabled by default, recommended for CI"
+fi
+
+if command -v detect_platform >/dev/null 2>&1; then
+    detect_platform
+fi
+
+display_detect_build_flavour
+
+if [ "$DISPLAY_BUILD_FLAVOUR" = "overlay" ]; then
+    log_info "Build flavor, overlay, EGL vendor JSON present: ${DISPLAY_EGL_VENDOR_JSON}"
+else
+    log_info "Build flavor, base, no Adreno EGL vendor JSON found"
+fi
+
+if ! display_log_snapshot_and_require_connector "$TESTNAME" 200; then
+    echo "${TESTNAME} SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if ! weston_prepare_runtime "$TESTNAME" "$WAIT_SECS" runtime "$ALLOW_RELAUNCH"; then
+    echo "${TESTNAME} FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if ! CHECK_DEPS_NO_EXIT=1 check_dependencies grep sed wc; then
+    log_skip "$TESTNAME SKIP: missing dependencies"
+    echo "${TESTNAME} SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+SHM_BIN="$(command -v weston-simple-shm 2>/dev/null || true)"
+if [ -z "$SHM_BIN" ]; then
+    log_skip "weston-simple-shm binary not found, skipping"
+    echo "${TESTNAME} SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+required_fail_count=0
+required_pass_count=0
+optional_pass_count=0
+optional_skip_count=0
+
+for fmt in $REQUIRED_FORMATS; do
+    if run_format_case "$fmt" 1; then
+        required_pass_count=$((required_pass_count + 1))
+    else
+        required_fail_count=$((required_fail_count + 1))
+    fi
+done
+
+for fmt in $OPTIONAL_FORMATS; do
+    if run_format_case "$fmt" 0; then
+        optional_pass_count=$((optional_pass_count + 1))
+    else
+        rc=$?
+        if [ "$rc" -eq 2 ]; then
+            optional_skip_count=$((optional_skip_count + 1))
+        else
+            log_warn "Optional format case failed unexpectedly, ${fmt}"
+            optional_skip_count=$((optional_skip_count + 1))
+        fi
+    fi
+done
+
+trap - EXIT HUP INT TERM
+
+log_info "Summary, required_pass=${required_pass_count} required_fail=${required_fail_count} optional_pass=${optional_pass_count} optional_skip=${optional_skip_count}"
+
+if [ "$required_fail_count" -eq 0 ] && [ "$required_pass_count" -gt 0 ]; then
+    log_info "Final decision for ${TESTNAME}, PASS"
+    echo "${TESTNAME} PASS" >"$RES_FILE"
+    log_pass "${TESTNAME} : PASS"
+    exit 0
+fi
+
+log_fail "${TESTNAME}, one or more required format cases failed"
+echo "${TESTNAME} FAIL" >"$RES_FILE"
+exit 0

--- a/Runner/suites/Multimedia/Graphics/weston-simple-shm/weston-simple-shm.yaml
+++ b/Runner/suites/Multimedia/Graphics/weston-simple-shm/weston-simple-shm.yaml
@@ -1,0 +1,23 @@
+metadata:
+  name: weston-simple-shm
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validate weston-simple-shm runtime and wl_shm format coverage on Qualcomm Linux platforms."
+  os:
+    - linux
+  scope:
+    - functional
+
+params:
+  WAIT_SECS: 10
+  DURATION: 5
+  STARTUP_WAIT: 3
+  STOP_GRACE: 3
+  REQUIRED_FORMATS: "default xrgb8888"
+  OPTIONAL_FORMATS: "argb8888 rgb565"
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Multimedia/Graphics/weston-simple-shm/
+    - WAIT_SECS="${WAIT_SECS}" DURATION="${DURATION}" STARTUP_WAIT="${STARTUP_WAIT}" STOP_GRACE="${STOP_GRACE}" REQUIRED_FORMATS="${REQUIRED_FORMATS}" OPTIONAL_FORMATS="${OPTIONAL_FORMATS}" ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh weston-simple-shm.res

--- a/Runner/suites/Multimedia/Graphics/weston-simple-shm/weston-simple-shm_README.md
+++ b/Runner/suites/Multimedia/Graphics/weston-simple-shm/weston-simple-shm_README.md
@@ -1,0 +1,270 @@
+# weston-simple-shm
+
+## Overview
+
+`weston-simple-shm` validates the Wayland shared-memory (`wl_shm`) rendering path using CPU-rendered buffers.
+
+This testcase verifies:
+
+- Weston runtime is healthy and usable
+- `weston-simple-shm` launches successfully
+- the default format path works
+- required explicit formats work
+- optional formats can be exercised for additional coverage
+- the client remains alive for the configured monitor window
+- the client can be stopped cleanly after validation
+
+This test is intended as a low-level compositor sanity check before moving to GPU or EGL-based client validation.
+
+---
+
+## Validation Scope
+
+The testcase covers the following:
+
+1. **Weston runtime validation**
+   - uses shared runtime helpers from `lib_display.sh`
+   - validates a connected display is present
+   - validates Weston runtime is available before launching the client
+   - optionally allows runtime relaunch using `--allow-relaunch`
+
+2. **Client availability**
+   - checks that `weston-simple-shm` is available on the target
+
+3. **Format-based validation**
+   - runs one default case without `-F`
+   - runs required explicit format cases
+   - runs optional format cases for additional coverage
+
+4. **Startup and monitor window**
+   - ensures the client starts successfully
+   - ensures the client remains alive for the configured duration
+
+5. **Client log capture**
+   - saves per-case client logs
+   - prints helpful tail output on failures
+
+---
+
+## Default Format Policy
+
+By default, the testcase uses:
+
+- **Required formats**
+  - `default`
+  - `xrgb8888`
+
+- **Optional formats**
+  - `argb8888`
+  - `rgb565`
+
+The testcase passes only if all required format cases pass.
+
+Optional format failures are logged for coverage and debugging, but do not fail the testcase.
+
+---
+
+## Prerequisites
+
+Before running the testcase, ensure that:
+
+- Weston is installed and functional on the target
+- a display is connected
+- `weston-simple-shm` is available in `PATH`
+- the target has the required Wayland runtime environment
+- the display stack is already brought up on the system
+
+---
+
+## Test Location
+
+```text
+Runner/suites/Multimedia/Graphics/weston-simple-shm/
+```
+
+---
+
+## Files
+
+Typical contents of this testcase directory:
+
+```text
+run.sh
+weston-simple-shm.yaml
+README.md
+```
+
+---
+
+## How to Run
+
+Run the testcase directly:
+
+```sh
+cd Runner/suites/Multimedia/Graphics/weston-simple-shm
+chmod +x run.sh
+./run.sh
+```
+
+Run with Weston relaunch allowed:
+
+```sh
+./run.sh --allow-relaunch
+```
+
+Run with a custom format set:
+
+```sh
+./run.sh \
+  --required-formats "default xrgb8888 argb8888" \
+  --optional-formats "rgb565"
+```
+
+---
+
+## Command Line Options
+
+```text
+--allow-relaunch
+    Allow Weston runtime relaunch when runtime is unhealthy
+
+--duration SEC
+    Keep each weston-simple-shm case running for SEC seconds
+
+--startup-wait SEC
+    Wait SEC seconds after launch before startup verdict
+
+--stop-grace SEC
+    Grace period after INT before KILL
+
+--required-formats "LIST"
+    Space-separated required formats
+
+--optional-formats "LIST"
+    Space-separated optional formats
+
+-h, --help
+    Show usage
+```
+
+---
+
+## Optional Environment Variables
+
+The testcase supports the following optional variables:
+
+- `WAIT_SECS`
+  - Weston runtime preparation timeout
+  - default: `10`
+
+- `DURATION`
+  - monitor time per format case
+  - default: `5`
+
+- `STARTUP_WAIT`
+  - delay before checking whether the client survived startup
+  - default: `3`
+
+- `STOP_GRACE`
+  - grace period after sending `SIGINT`
+  - default: `3`
+
+- `ALLOW_RELAUNCH`
+  - allow runtime relaunch
+  - default: `0`
+
+- `REQUIRED_FORMATS`
+  - required format cases
+  - default: `default xrgb8888`
+
+- `OPTIONAL_FORMATS`
+  - optional format cases
+  - default: `argb8888 rgb565`
+
+Example:
+
+```sh
+WAIT_SECS=10 \
+DURATION=5 \
+STARTUP_WAIT=3 \
+STOP_GRACE=3 \
+ALLOW_RELAUNCH=1 \
+REQUIRED_FORMATS="default xrgb8888" \
+OPTIONAL_FORMATS="argb8888 rgb565" \
+./run.sh
+```
+
+---
+
+## Expected Result
+
+### PASS
+The testcase passes when:
+
+- Weston runtime is healthy
+- `weston-simple-shm` is present
+- all required format cases launch successfully
+- all required format cases remain alive for the configured duration
+
+### FAIL
+The testcase fails when any of the following occurs:
+
+- Weston runtime is unavailable
+- `weston-simple-shm` exits during startup for a required case
+- `weston-simple-shm` exits before the monitor window completes for a required case
+- a required format is not supported by the compositor
+- a required format is not supported by the client binary
+
+### SKIP
+The testcase is skipped when:
+
+- no connected display is detected
+- the binary is not present
+- help/usage path is explicitly requested
+
+---
+
+## Result File
+
+The testcase writes the result to:
+
+```text
+weston-simple-shm.res
+```
+
+Possible values:
+
+```text
+weston-simple-shm PASS
+weston-simple-shm FAIL
+weston-simple-shm SKIP
+```
+
+The testcase is CI/LAVA friendly and keeps the shell exit path non-blocking after runtime start, while using the `.res` file for PASS/FAIL/SKIP reporting.
+
+---
+
+## Logs
+
+The testcase generates:
+
+- a testcase result file
+- a help snapshot log
+- per-format client logs
+- summary entries in the testcase run log
+
+These logs are useful for debugging:
+
+- startup failures
+- compositor format support failures
+- early client exits
+- shutdown behavior
+
+---
+
+## Notes
+
+- The literal token `default` means the client is run **without** `-F`
+- Required and optional format groups are intentionally separated
+- Optional formats are useful for broader compositor coverage without introducing unnecessary hard failures
+- This testcase is a compositor and shared-memory client validation, not a GPU or EGL benchmark


### PR DESCRIPTION
Add new weston-simple-shm test and validation logging to make CI and LAVA triage easier.
 
Changes:
- log the actual weston-simple-shm launch command per format case
- record requested format and required/optional classification
- record XDG_RUNTIME_DIR and WAYLAND_DISPLAY used for the case
- capture client stdout/stderr into each per-format log file
- append final case result and failure reason into the same log
- keep CI-default behaviour without Weston relaunch unless explicitly enabled
 
This improves visibility into wl_shm format validation without changing the overall PASS/FAIL flow of the testcase.