### PR TITLE
fix: add RB1 Bluetooth DT and firmware detection support

### DIFF
--- a/Runner/suites/Connectivity/Bluetooth/BT_FW_KMD_Service/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/BT_FW_KMD_Service/run.sh
@@ -89,6 +89,7 @@ fi
 # ---------- DT node / compatible ----------
 # ---------- DT node / compatible ----------
 if dt_confirm_node_or_compatible_all \
+    "qcom,wcn3950-bt" \
     "qcom,wcn7850-bt" \
     "qcom,wcn6855-bt" \
     "qcom,wcn6750-bt" \
@@ -104,7 +105,7 @@ fi
 if fw_dir="$(btfwpresent 2>/dev/null)"; then
     log_pass "Firmware present in: $fw_dir"
 else
-    log_warn "No BT firmware matching msbtfw*/msnv* found under standard firmware paths."
+    log_warn "No BT firmware matching msbtfw*/msnv* or cmbtfw*/cmnv* found under standard firmware paths."
     inc_warn
 fi
 

--- a/Runner/utils/lib_bluetooth.sh
+++ b/Runner/utils/lib_bluetooth.sh
@@ -1880,15 +1880,30 @@ btpower() {
 
 btfwpresent() {
     dir=""
+    pattern=""
+    file=""
+ 
     for d in /lib/firmware/qca /usr/lib/firmware/qca /lib/firmware /usr/lib/firmware; do
         [ -d "$d" ] || continue
-        if ls "$d"/msbtfw*.mbn "$d"/msbtfw*.tlv "$d"/msnv*.bin >/dev/null 2>&1; then
-            dir="$d"; break
-        fi
+ 
+        for pattern in \
+            "msbtfw*.mbn" \
+            "msbtfw*.tlv" \
+            "msnv*.bin" \
+            "cmbtfw*.tlv" \
+            "cmnv*.bin"
+        do
+            for file in "$d"/$pattern; do
+                if [ -e "$file" ]; then
+                    dir="$d"
+                    printf '%s\n' "$dir"
+                    return 0
+                fi
+            done
+        done
     done
-    [ -n "$dir" ] || return 1
-    printf '%s\n' "$dir"
-    return 0
+ 
+    return 1
 }
 
 btfwloaded() {


### PR DESCRIPTION
This update fixes BT_FW_KMD_Service on RB1 by aligning the testcase with RB1 Bluetooth DT and firmware naming.
 
Changes included:
- add qcom,wcn3950-bt to the DT compatible allowlist in   BT_FW_KMD_Service/[run.sh](http://run.sh/)
- extend btfwpresent() in [lib_bluetooth.sh](http://lib_bluetooth.sh/) to detect legacy QCA   Bluetooth firmware files such as cmbtfw*.tlv and cmnv*.bin
- make firmware presence detection robust by checking patterns   individually instead of relying on a single multi-glob ls call
 
Why:
- RB1 exposes Bluetooth as qcom,wcn3950-bt in device tree
- RB1 firmware uses legacy QCA naming under /lib/firmware/qca
- the previous logic missed both cases, causing false DT failure and   firmware warning even though Bluetooth runtime was healthy
 
Validation:
- RB1 now reports DT node/compatible

Sample reference lava job - https://lava.infra.foundries.io/scheduler/job/183627