### PR TITLE
fix: improve BT_FW_KMD_Service readiness and firmware detection on RB4

### DIFF
--- a/Runner/suites/Connectivity/Bluetooth/BT_FW_KMD_Service/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/BT_FW_KMD_Service/run.sh
@@ -77,6 +77,11 @@ if ! check_dependencies bluetoothctl hciconfig lsmod; then
     echo "$TESTNAME SKIP" > "$RES_FILE"
     exit 0
 fi
+
+# ---------- Bluetooth runtime check/ readiness ----------
+log_info "Waiting for Bluetooth runtime readiness..."
+bt_wait_ready 60 2 || true
+
 # ---------- Bluetooth service / daemon ----------
 log_info "Checking if bluetoothd (or bluetooth.service) is running..."
 if btsvcactive; then
@@ -196,11 +201,15 @@ else
 fi
 
 if [ -z "$ADAPTER" ]; then
-    log_warn "No HCI adapter found; skipping BT FW/KMD test."
-    echo "$TESTNAME SKIP" > "./$TESTNAME.res"
+    log_warn "No HCI adapter found."
+ 
+    if [ "$FAIL_COUNT" -gt 0 ]; then
+        echo "$TESTNAME FAIL" > "$RES_FILE"
+    else
+        echo "$TESTNAME SKIP" > "$RES_FILE"
+    fi
     exit 0
 fi
-
 # ---------- BD address sanity check ----------
 if [ -n "$ADAPTER" ]; then
     if btbdok "$ADAPTER"; then

--- a/Runner/utils/lib_bluetooth.sh
+++ b/Runner/utils/lib_bluetooth.sh
@@ -1891,7 +1891,13 @@ btfwpresent() {
             "msbtfw*.tlv" \
             "msnv*.bin" \
             "cmbtfw*.tlv" \
-            "cmnv*.bin"
+            "cmnv*.bin" \
+            "hpbtfw*.tlv" \
+            "wcnhpbtfw*.tlv" \
+            "hmtbtfw*.tlv" \
+            "hmtnv*.bin" \
+            "hpnv*.bin" \
+            "wcnhpnv*.bin"
         do
             for file in "$d"/$pattern; do
                 if [ -e "$file" ]; then
@@ -1903,6 +1909,61 @@ btfwpresent() {
         done
     done
  
+    return 1
+}
+
+bt_wait_ready() {
+    max_wait="${1:-60}"
+    sleep_step="${2:-2}"
+    waited=0
+    started_service=0
+ 
+    if [ -z "$max_wait" ]; then
+        max_wait=60
+    fi
+    if [ -z "$sleep_step" ]; then
+        sleep_step=2
+    fi
+ 
+    case "$max_wait" in
+        ''|*[!0-9]*)
+            max_wait=60
+            ;;
+    esac
+    case "$sleep_step" in
+        ''|*[!0-9]*)
+            sleep_step=2
+            ;;
+    esac
+ 
+    if [ "$max_wait" -le 0 ] 2>/dev/null; then
+        max_wait=60
+    fi
+    if [ "$sleep_step" -le 0 ] 2>/dev/null; then
+        sleep_step=2
+    fi
+ 
+    while [ "$waited" -lt "$max_wait" ]; do
+        if btsvcactive && bthcipresent; then
+            log_info "Bluetooth runtime became ready after ${waited}s."
+            return 0
+        fi
+ 
+        if [ "$started_service" -eq 0 ]; then
+            if command -v systemctl >/dev/null 2>&1; then
+                if ! btsvcactive; then
+                    log_info "Bluetooth service not active yet, attempting start."
+                    systemctl start bluetooth.service >/dev/null 2>&1 || true
+                fi
+            fi
+            started_service=1
+        fi
+ 
+        sleep "$sleep_step"
+        waited=$((waited + sleep_step))
+    done
+ 
+    log_warn "Bluetooth runtime did not become ready within ${max_wait}s."
     return 1
 }
 


### PR DESCRIPTION
This fix  #413  the BT_FW_KMD_Service behavior on RB4-class platforms by addressing early-boot Bluetooth readiness, expanding firmware filename detection, and fixing testcase result flow.
 
Changes included:
- add reusable bt_wait_ready() in [lib_bluetooth.sh](http://lib_bluetooth.sh/) to wait for   bluetooth.service and HCI availability during early boot
- extend btfwpresent() to detect additional Qualcomm Bluetooth firmware   naming variants used on RB4-class targets, including hpbtfw*/hpnv*   and related patterns
- update BT_FW_KMD_Service/[run.sh](http://run.sh/) to wait for Bluetooth runtime   readiness before evaluating service/HCI state
- update firmware warning text to reflect the expanded filename patterns
- fix final result handling so a missing adapter no longer overwrites   earlier failures with SKIP
 
Why:
- RB4 Bluetooth runtime may come up slightly later in boot, causing the   testcase to run before bluetooth.service and hci0 are ready
- RB4 firmware layouts use additional QCA naming patterns that were not   covered by the previous firmware detection logic
- the previous result flow could incorrectly emit SKIP after already   recording real failuresThis update improves BT_FW_KMD_Service behavior on RB4-class platforms by addressing early-boot Bluetooth readiness, expanding firmware filename detection, and fixing testcase result flow.

Lava job for reference with these changes - https://lava.infra.foundries.io/scheduler/job/184610
 