### PR TITLE
ci: fix ShellCheck PR workflow merge-base resolution

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -33,9 +33,9 @@ jobs:
           set -eu
 
           BASE_BRANCH="${{ github.base_ref }}"
-          git fetch origin "${BASE_BRANCH}" --depth=1
+          git fetch --no-tags origin "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
 
-          MERGE_BASE="$(git merge-base HEAD "origin/${BASE_BRANCH}")"
+          MERGE_BASE="$(git merge-base HEAD "refs/remotes/origin/${BASE_BRANCH}")"
           FILES="$(git diff --diff-filter=d --name-only "${MERGE_BASE}"...HEAD -- '*.sh')"
 
           if [ -n "$FILES" ]; then


### PR DESCRIPTION
Fix the PR ShellCheck workflow so it no longer fails before linting starts.
 
Changes
 
- use full checkout history
- fetch the base branch with an explicit remote-tracking refspec
- compute merge-base against `refs/remotes/origin/<base-branch>`
 
Why
 
The previous workflow could fail at `git merge-base` because `origin/<base>` was not reliably populated by the fetch step. That caused the job to exit before ShellCheck ran, so no lint issues were displayed.
 
Result
 
ShellCheck now runs correctly on changed `.sh` files in pull requests.