### PR TITLE
fix: improve WiFi_OnOff diagnostics, config gating, and interface detection

### DIFF
--- a/Runner/suites/Connectivity/WiFi/WiFi_OnOff/run.sh
+++ b/Runner/suites/Connectivity/WiFi/WiFi_OnOff/run.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
+
 # Robustly find and source init_env
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
 INIT_ENV=""
 SEARCH="$SCRIPT_DIR"
+
 while [ "$SEARCH" != "/" ]; do
     if [ -f "$SEARCH/init_env" ]; then
         INIT_ENV="$SEARCH/init_env"
@@ -18,43 +23,187 @@ if [ -z "$INIT_ENV" ]; then
     exit 1
 fi
 
-# Only source if not already loaded (idempotent)
-if [ -z "$__INIT_ENV_LOADED" ]; then
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
     # shellcheck disable=SC1090
     . "$INIT_ENV"
 fi
-# Always source functestlib.sh, using $TOOLS exported by init_env
+
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/lib_connectivity.sh"
 
 TESTNAME="WiFi_OnOff"
-test_path=$(find_test_case_by_name "$TESTNAME")
+test_path="$(find_test_case_by_name "$TESTNAME")"
 cd "$test_path" || exit 1
+
+WIFI_DT_PATTERNS_DEFAULT="$(
+cat <<'EOF'
+qcom,wcn7850
+qcom,wcn6855
+qcom,wcn6750
+qcom,wcn3950
+ath12k
+ath11k
+wifi
+wlan
+qca
+EOF
+)"
+
+WIFI_DRIVER_MODULES_DEFAULT="$(
+cat <<'EOF'
+ath12k_wifi7
+ath12k
+ath11k
+ath11k_pci
+ath10k_pci
+ath10k_snoc
+cfg80211
+mac80211
+mhi
+EOF
+)"
+
+WIFI_WAIT_SECS="${WIFI_WAIT_SECS:-30}"
+WIFI_WAIT_STEP_SECS="${WIFI_WAIT_STEP_SECS:-2}"
+WIFI_PROBE_LOG_DIR="${WIFI_PROBE_LOG_DIR:-./wifi_onoff_dmesg}"
+WIFI_PROBE_LOG_TAG="${WIFI_PROBE_LOG_TAG:-${TESTNAME}/probe}"
+WIFI_DT_PATTERNS="${WIFI_DT_PATTERNS:-$WIFI_DT_PATTERNS_DEFAULT}"
+WIFI_DRIVER_MODULES="${WIFI_DRIVER_MODULES:-$WIFI_DRIVER_MODULES_DEFAULT}"
+
+wifi_iface=""
+
+# Convert a newline-separated config list into normal shell arguments and call
+# the requested helper without needing unquoted expansion in run.sh.
+run_with_line_args() {
+    target_func="$1"
+    list_data="$2"
+
+    set --
+
+    while IFS= read -r entry; do
+        [ -n "$entry" ] || continue
+        set -- "$@" "$entry"
+    done <<EOF
+$list_data
+EOF
+
+    "$target_func" "$@"
+}
 
 log_info "-----------------------------------------------------------------------------------------"
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
 log_info "=== Test Initialization ==="
+log_info "Config: WIFI_WAIT_SECS=${WIFI_WAIT_SECS} WIFI_WAIT_STEP_SECS=${WIFI_WAIT_STEP_SECS}"
+log_info "Config: WIFI_PROBE_LOG_TAG=${WIFI_PROBE_LOG_TAG}"
+
+if [ -n "${WIFI_IFACE:-}" ]; then
+    log_info "Config: WIFI_IFACE override requested: ${WIFI_IFACE}"
+fi
 
 check_dependencies ip iw
 
-wifi_iface="$(get_wifi_interface)"
-if [ -z "$wifi_iface" ]; then
-    log_skip_exit "$TESTNAME" "No WiFi interface found. Skipping." ""
+log_info "=== WiFi Kernel Config Validation ==="
+wifi_required_cfgs="CONFIG_WIRELESS CONFIG_WLAN CONFIG_CFG80211 CONFIG_MAC80211"
+
+if check_kernel_config "$wifi_required_cfgs"; then
+    log_pass "Mandatory WiFi baseline kernel configs are enabled."
+else
+    log_fail_exit "$TESTNAME" "Mandatory WiFi baseline kernel configs are missing." ""
 fi
 
-# Bring WiFi down
+log_info "=== WiFi Optional Kernel Config Visibility ==="
+if check_kernel_config "CONFIG_NL80211_TESTMODE" >/dev/null 2>&1; then
+    log_info "Optional WiFi config present: CONFIG_NL80211_TESTMODE"
+else
+    log_warn "Optional WiFi config not enabled: CONFIG_NL80211_TESTMODE"
+fi
+
+if check_kernel_config "CONFIG_WLAN_VENDOR_ATH" >/dev/null 2>&1; then
+    log_info "Optional WiFi config present: CONFIG_WLAN_VENDOR_ATH"
+else
+    log_warn "Optional WiFi config not enabled: CONFIG_WLAN_VENDOR_ATH"
+fi
+
+log_info "=== WiFi DT Validation ==="
+if run_with_line_args wifi_dt_present "$WIFI_DT_PATTERNS"; then
+    log_pass "WiFi DT entry/compatible matched."
+else
+    log_warn "No WiFi DT entry/compatible matched from configured patterns."
+fi
+
+log_info "=== WiFi Module Visibility ==="
+run_with_line_args wifi_log_module_info "$WIFI_DRIVER_MODULES"
+
+log_info "=== WiFi Driver Kernel Config Validation ==="
+wifi_driver_cfgs="$(infer_wifi_driver_cfgs)"
+if [ -n "$wifi_driver_cfgs" ]; then
+    if check_kernel_config "$wifi_driver_cfgs"; then
+        log_pass "Target-specific WiFi driver kernel configs are enabled."
+    else
+        log_fail_exit "$TESTNAME" "Target-specific WiFi driver kernel configs are missing." ""
+    fi
+else
+    log_warn "No target-specific WiFi driver config requirement inferred from module/runtime evidence."
+fi
+
+log_info "=== WiFi Probe Check ==="
+if wifi_has_probe_failures "$WIFI_PROBE_LOG_DIR" "$WIFI_PROBE_LOG_TAG"; then
+    log_fail_exit "$TESTNAME" "WiFi driver probe/runtime failures detected in kernel log." ""
+else
+    log_pass "[$WIFI_PROBE_LOG_TAG] No WiFi probe/runtime failures detected in kernel log."
+fi
+
+log_info "=== Waiting for WiFi Interface ==="
+wifi_iface="$(wait_for_wifi_interface "$WIFI_WAIT_SECS" "$WIFI_WAIT_STEP_SECS" || true)"
+
+if [ -z "$wifi_iface" ]; then
+    log_info "No WiFi interface detected after wait. Collecting diagnostics..."
+
+    run_with_line_args wifi_dump_debug_info "$WIFI_DT_PATTERNS"
+    run_with_line_args wifi_log_module_info "$WIFI_DRIVER_MODULES"
+    wifi_has_probe_failures "$WIFI_PROBE_LOG_DIR" "$WIFI_PROBE_LOG_TAG" || true
+
+    if wifi_stack_present; then
+        log_fail_exit "$TESTNAME" "WiFi stack present, but no usable WiFi interface was found after retries." ""
+    fi
+
+    log_skip_exit "$TESTNAME" "No WiFi interface found and no WiFi stack was detected. Skipping." ""
+fi
+
+log_pass "Detected WiFi interface: $wifi_iface"
+
+log_info "=== Initial Interface State ==="
+ip link show "$wifi_iface" 2>/dev/null || true
+if command -v iw >/dev/null 2>&1; then
+    iw dev "$wifi_iface" info 2>/dev/null || true
+fi
+
+log_info "=== WiFi Toggle Validation ==="
+
 if bring_interface_up_down "$wifi_iface" down; then
     log_info "Brought $wifi_iface down successfully."
+    ip link show "$wifi_iface" 2>/dev/null || true
 else
+    log_info "Failed while bringing $wifi_iface down. Collecting diagnostics..."
+    wifi_dump_runtime_info
+    wifi_has_probe_failures "$WIFI_PROBE_LOG_DIR" "$WIFI_PROBE_LOG_TAG" || true
     log_fail_exit "$TESTNAME" "Failed to bring $wifi_iface down." ""
 fi
 
 sleep 2
 
-# Bring WiFi up
 if bring_interface_up_down "$wifi_iface" up; then
     log_info "Brought $wifi_iface up successfully."
+    ip link show "$wifi_iface" 2>/dev/null || true
+    if command -v iw >/dev/null 2>&1; then
+        iw dev "$wifi_iface" info 2>/dev/null || true
+    fi
     log_pass_exit "$TESTNAME" "$wifi_iface toggled up/down successfully." ""
 else
+    log_info "Failed while bringing $wifi_iface up. Collecting diagnostics..."
+    wifi_dump_runtime_info
+    wifi_has_probe_failures "$WIFI_PROBE_LOG_DIR" "$WIFI_PROBE_LOG_TAG" || true
     log_fail_exit "$TESTNAME" "Failed to bring $wifi_iface up after down." ""
 fi

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -3281,34 +3281,78 @@ wifi_write_wpa_conf() {
 
 # Find the first available WiFi interface (wl* or wlan0), using 'ip' or 'ifconfig'.
 # Prints the interface name, or returns non-zero if not found.
+# Discover the most likely WiFi netdev using override, iw, sysfs markers,
+# nmcli, and legacy name-based fallbacks while preserving existing behavior.
 get_wifi_interface() {
     WIFI_IF=""
 
-    # Prefer 'ip' if available.
-    if command -v ip >/dev/null 2>&1; then
-        WIFI_IF=$(ip link | awk -F: '/ wl/ {print $2}' | tr -d ' ' | head -n1)
-        if [ -z "$WIFI_IF" ]; then
-            WIFI_IF=$(ip link | awk -F: '/^[0-9]+: wl/ {print $2}' | tr -d ' ' | head -n1)
-        fi
-        if [ -z "$WIFI_IF" ] && ip link show wlan0 >/dev/null 2>&1; then
-            WIFI_IF="wlan0"
-        fi
-    else
-        # Fallback to 'ifconfig' if 'ip' is missing.
-        if command -v ifconfig >/dev/null 2>&1; then
-            WIFI_IF=$(ifconfig -a 2>/dev/null | grep -o '^wl[^:]*' | head -n1)
-            if [ -z "$WIFI_IF" ] && ifconfig wlan0 >/dev/null 2>&1; then
-                WIFI_IF="wlan0"
+    if [ -n "${WIFI_IFACE:-}" ]; then
+        if command -v ip >/dev/null 2>&1; then
+            if ip link show "$WIFI_IFACE" >/dev/null 2>&1; then
+                printf '%s\n' "$WIFI_IFACE"
+                return 0
             fi
         fi
     fi
 
-    if [ -n "$WIFI_IF" ]; then
-        echo "$WIFI_IF"
-        return 0
-    else
-        return 1
+    if command -v iw >/dev/null 2>&1; then
+        WIFI_IF="$(iw dev 2>/dev/null | awk '
+            $1 == "Interface" && $2 !~ /^p2p-dev-/ {
+                print $2
+                exit
+            }
+        ')"
+        if [ -n "$WIFI_IF" ]; then
+            printf '%s\n' "$WIFI_IF"
+            return 0
+        fi
     fi
+
+    for n in /sys/class/net/*; do
+        [ -e "$n" ] || continue
+        WIFI_IF="$(basename "$n")"
+
+        if [ "$WIFI_IF" = "lo" ]; then
+            continue
+        fi
+
+        if [ -d "$n/wireless" ] || [ -e "$n/phy80211" ]; then
+            printf '%s\n' "$WIFI_IF"
+            return 0
+        fi
+    done
+
+    if command -v nmcli >/dev/null 2>&1; then
+        WIFI_IF="$(nmcli -t -f DEVICE,TYPE device status 2>/dev/null | awk -F: '
+            $2 == "wifi" {
+                print $1
+                exit
+            }
+        ')"
+        if [ -n "$WIFI_IF" ]; then
+            printf '%s\n' "$WIFI_IF"
+            return 0
+        fi
+    fi
+
+    if command -v ip >/dev/null 2>&1; then
+        WIFI_IF="$(ip -o link show 2>/dev/null | awk -F': ' '
+            $2 ~ /^wlan[0-9]+$/ { print $2; exit }
+            $2 ~ /^wl[[:alnum:]_.-]*$/ { print $2; exit }
+            $2 ~ /^ath[[:alnum:]_.-]*$/ { print $2; exit }
+        ')"
+        if [ -n "$WIFI_IF" ]; then
+            printf '%s\n' "$WIFI_IF"
+            return 0
+        fi
+
+        if ip link show wlan0 >/dev/null 2>&1; then
+            printf '%s\n' "wlan0"
+            return 0
+        fi
+    fi
+
+    return 1
 }
 
 # Auto-detect eMMC block device (non-removable, not UFS)

--- a/Runner/utils/lib_connectivity.sh
+++ b/Runner/utils/lib_connectivity.sh
@@ -1,0 +1,231 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# Connectivity-specific helper library layered on top of functestlib.sh.
+# Source functestlib.sh before sourcing this file.
+# Best-effort helper to unblock WiFi before discovery or retry loops.
+# Silent success is acceptable on minimal images where rfkill may be absent.
+wifi_unblock_rfkill() {
+    if command -v rfkill >/dev/null 2>&1; then
+        rfkill unblock wifi >/dev/null 2>&1 || true
+        rfkill unblock all >/dev/null 2>&1 || true
+    fi
+}
+
+# Retry WiFi interface discovery for a bounded time while unblocking rfkill.
+# Prints interface name on success and returns non-zero on timeout.
+wait_for_wifi_interface() {
+    max_wait="${1:-30}"
+    sleep_step="${2:-2}"
+    waited=0
+    iface=""
+
+    case "$max_wait" in
+        ''|*[!0-9]*)
+            max_wait=30
+            ;;
+    esac
+
+    case "$sleep_step" in
+        ''|*[!0-9]*)
+            sleep_step=2
+            ;;
+    esac
+
+    if [ "$max_wait" -le 0 ] 2>/dev/null; then
+        max_wait=30
+    fi
+    if [ "$sleep_step" -le 0 ] 2>/dev/null; then
+        sleep_step=2
+    fi
+
+    while [ "$waited" -lt "$max_wait" ]; do
+        wifi_unblock_rfkill
+
+        iface="$(get_wifi_interface 2>/dev/null || true)"
+        if [ -n "$iface" ]; then
+            printf '%s\n' "$iface"
+            return 0
+        fi
+
+        sleep "$sleep_step"
+        waited=$((waited + sleep_step))
+    done
+
+    return 1
+}
+
+# Reuse the existing DT matcher with caller-provided WiFi node/compatible
+# patterns so run.sh stays small and gets built-in logging from functestlib.sh.
+wifi_dt_present() {
+    dt_confirm_node_or_compatible_all "$@"
+}
+
+# Print WiFi-related loaded modules and, when found, the resolved .ko path
+# using existing is_module_loaded() and find_kernel_module() helpers.
+wifi_log_module_info() {
+    mod=""
+    mod_path=""
+
+    for mod in "$@"; do
+        [ -n "$mod" ] || continue
+
+        if is_module_loaded "$mod"; then
+            log_pass "Module loaded: $mod"
+        else
+            log_info "Module not loaded: $mod"
+        fi
+
+        mod_path="$(find_kernel_module "$mod" 2>/dev/null || true)"
+        if [ -n "$mod_path" ]; then
+            log_info "[module-path] $mod -> $mod_path"
+        fi
+    done
+}
+
+# Return success when there is evidence that a WiFi software stack is present,
+# even if no netdev has been created yet. Used to separate FAIL from SKIP.
+wifi_stack_present() {
+    mod=""
+
+    for mod in ath12k_wifi7 ath12k ath11k ath11k_pci ath10k_pci ath10k_snoc cfg80211 mac80211 mhi; do
+        if is_module_loaded "$mod"; then
+            return 0
+        fi
+    done
+
+    if [ -d /sys/class/ieee80211 ]; then
+        if ls /sys/class/ieee80211/* >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    if command -v iw >/dev/null 2>&1; then
+        if iw phy 2>/dev/null | grep . >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+# Infer target-specific WiFi driver configs from loaded modules and kernel log
+# so ATH11K or ATH12K checks are only enforced when relevant on the target.
+infer_wifi_driver_cfgs() {
+    cfgs=""
+
+    if is_module_loaded ath11k || get_kernel_log 2>/dev/null | grep -Eq '(^|[^[:alnum:]_])ath11k([^[:alnum:]_]|$)'; then
+        cfgs="CONFIG_ATH11K"
+    fi
+
+    if is_module_loaded ath12k || is_module_loaded ath12k_wifi7 || get_kernel_log 2>/dev/null | grep -Eq '(^|[^[:alnum:]_])ath12k([^[:alnum:]_]|$)|(^|[^[:alnum:]_])ath12k_wifi7([^[:alnum:]_]|$)'; then
+        if [ -n "$cfgs" ]; then
+            cfgs="$cfgs CONFIG_ATH12K"
+        else
+            cfgs="CONFIG_ATH12K"
+        fi
+    fi
+
+    printf '%s\n' "$cfgs"
+}
+
+# Scan kernel logs for WiFi driver probe/runtime failures and print matched
+# lines to stdout. Returns success when probe failures are present.
+wifi_has_probe_failures() {
+    outdir="$1"
+    tag="${2:-wifi-probe-check}"
+    include_regex="wifi|wlan|ath|cfg80211|mac80211|qca|wcn|firmware|mhi|pci|msi|qmi"
+    exclude_regex="using dummy regulator|Loading compiled-in X.509 certificates for regulatory database"
+    errfile=""
+    failure_file=""
+    tmp_matches=""
+    line=""
+
+    if [ -z "$outdir" ]; then
+        outdir="/tmp/wifi_dmesg"
+    fi
+
+    mkdir -p "$outdir" >/dev/null 2>&1 || true
+    errfile="$outdir/dmesg_errors.log"
+    failure_file="$outdir/wifi_probe_failures.log"
+    : >"$failure_file"
+
+    if command -v scan_dmesg_errors >/dev/null 2>&1; then
+        scan_dmesg_errors "$outdir" "$include_regex" "$exclude_regex" >/dev/null 2>&1 || true
+    fi
+
+    if [ -s "$errfile" ]; then
+        grep -Ei \
+            '(ath|wifi|wlan|qca|wcn).*(probe with driver .* failed|failed to alloc msi|qmi dma allocation failed|failed to create .*wlan|failed to register .*wlan|Direct firmware load .* failed|firmware.*failed|failed to load board data|failed to fetch board data|mhi.*failed)|(probe with driver .* failed|failed to alloc msi|qmi dma allocation failed|failed to create .*wlan|failed to register .*wlan|Direct firmware load .* failed|firmware.*failed|failed to load board data|failed to fetch board data|mhi.*failed).*(ath|wifi|wlan|qca|wcn)' \
+            "$errfile" 2>/dev/null >>"$failure_file" || true
+    fi
+
+    tmp_matches="$(get_kernel_log 2>/dev/null | grep -Ei \
+        '(ath|wifi|wlan|qca|wcn).*(probe with driver .* failed|failed to alloc msi|qmi dma allocation failed|failed to create .*wlan|failed to register .*wlan|Direct firmware load .* failed|firmware.*failed|failed to load board data|failed to fetch board data|mhi.*failed)|(probe with driver .* failed|failed to alloc msi|qmi dma allocation failed|failed to create .*wlan|failed to register .*wlan|Direct firmware load .* failed|firmware.*failed|failed to load board data|failed to fetch board data|mhi.*failed).*(ath|wifi|wlan|qca|wcn)' \
+        || true)"
+
+    if [ -n "$tmp_matches" ]; then
+        printf '%s\n' "$tmp_matches" >>"$failure_file"
+    fi
+
+    if [ -s "$failure_file" ]; then
+        awk '!seen[$0]++' "$failure_file" >"${failure_file}.dedup" 2>/dev/null || cp "$failure_file" "${failure_file}.dedup" 2>/dev/null || true
+
+        log_fail "[$tag] matched WiFi probe/runtime failures:"
+        while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            log_fail "[$tag] $line"
+        done < "${failure_file}.dedup"
+
+        rm -f "${failure_file}.dedup"
+        return 0
+    fi
+
+    return 1
+}
+
+# Print wireless runtime state from iw, sysfs, ip, and rfkill so missing
+# interface cases are diagnosable directly from testcase stdout.
+wifi_dump_runtime_info() {
+    log_info "--- iw dev ---"
+    iw dev 2>/dev/null || true
+
+    log_info "--- iw phy ---"
+    iw phy 2>/dev/null || true
+
+    log_info "--- /sys/class/ieee80211 ---"
+    ls -l /sys/class/ieee80211 2>/dev/null || true
+
+    log_info "--- /sys/class/net ---"
+    ls -l /sys/class/net 2>/dev/null || true
+
+    log_info "--- ip -o link show ---"
+    ip -o link show 2>/dev/null || true
+
+    log_info "--- wireless markers ---"
+    for n in /sys/class/net/*; do
+        [ -e "$n" ] || continue
+        i="$(basename "$n")"
+        marker="$i:"
+
+        if [ -d "$n/wireless" ]; then
+            marker="$marker wireless-dir=yes"
+        fi
+        if [ -e "$n/phy80211" ]; then
+            marker="$marker phy80211=yes"
+        fi
+
+        dev_path="$(readlink -f "$n/device" 2>/dev/null || true)"
+        log_info "[wireless-marker] $marker ${dev_path:-<no-device-path>}"
+    done
+
+    log_info "--- rfkill list ---"
+    rfkill list 2>/dev/null || true
+}
+
+# Emit a compact WiFi debug bundle to stdout using existing DT and runtime
+# helpers so CI logs clearly explain missing interface or probe failures.
+wifi_dump_debug_info() {
+    wifi_dt_present "$@" || true
+    wifi_dump_runtime_info
+}


### PR DESCRIPTION
This update will not fix the #416 WiFi_OnOff as it is a software issue. How ever this PR makes more robust and more diagnosable while preserving the existing WiFi down/up toggle coverage.

Changes included:
- improve get_wifi_interface() in functestlib.sh to detect WiFi   interfaces using override, iw, sysfs wireless markers, nmcli, and
  legacy interface-name fallbacks 
- add lib_connectivity.sh with shared WiFi/connectivity helpers for:   interface wait/retry, rfkill unblock, DT-backed checks, module
  visibility logging, probe-failure reporting, and runtime dumps
- update WiFi_OnOff/run.sh to:
  - validate mandatory WiFi kernel configs
  - report selected optional WiFi config visibility
  - validate target-specific driver configs inferred from ATH11K/ATH12K  runtime evidence
  - show DT, module, probe, and runtime information in stdout
  - fail early when WiFi driver probe/runtime failures are detected
  - wait for interface readiness before deciding fail/skip
  - preserve the original WiFi down/up toggle validation

Why:
- the previous testcase could skip too early when WiFi interface   discovery failed
- probe failures were not obvious from stdout
- interface naming varied across targets
- kernel config requirements were not explicitly validated
- diagnostics needed to be visible directly in CI logs to explain why a
  target failed

Lava job for reference with these changes. https://lava.infra.foundries.io/scheduler/job/186415