### PR TITLE
fix: select usable HCI adapter in BT_ON_OFF

### DIFF
--- a/Runner/suites/Connectivity/Bluetooth/BT_ON_OFF/run.sh
+++ b/Runner/suites/Connectivity/Bluetooth/BT_ON_OFF/run.sh
@@ -97,20 +97,24 @@ fi
 if [ -n "$BT_ADAPTER" ]; then
     ADAPTER="$BT_ADAPTER"
     log_info "Using adapter from BT_ADAPTER/CLI: $ADAPTER"
-elif findhcisysfs >/dev/null 2>&1; then
-    ADAPTER="$(findhcisysfs 2>/dev/null || true)"
+ 
+    if command -v bt_adapter_is_usable >/dev/null 2>&1; then
+        if ! bt_adapter_is_usable "$ADAPTER"; then
+            log_warn "Requested adapter '$ADAPTER' is not currently UP/RUNNING with a valid BD address."
+            bt_log_hci_candidates || true
+        fi
+    fi
 else
-    ADAPTER=""
+    bt_log_hci_candidates || true
+ 
+    if command -v bt_select_usable_adapter >/dev/null 2>&1; then
+        ADAPTER="$(bt_select_usable_adapter 2>/dev/null || true)"
+    elif findhcisysfs >/dev/null 2>&1; then
+        ADAPTER="$(findhcisysfs 2>/dev/null || true)"
+    else
+        ADAPTER=""
+    fi
 fi
-
-if [ -n "$ADAPTER" ]; then
-    log_info "Using adapter: $ADAPTER"
-else
-    log_warn "No HCI adapter found; skipping test."
-    echo "$TESTNAME SKIP" > "./$TESTNAME.res"
-    exit 0
-fi
-
 # --- NEW: warn/diag if non-interactive "bluetoothctl list" is empty (non-fatal) ---
 btwarniflistempty "$ADAPTER" || true
 

--- a/Runner/utils/lib_bluetooth.sh
+++ b/Runner/utils/lib_bluetooth.sh
@@ -2235,3 +2235,137 @@ bt_scan_poll_off() {
     log_warn "Discovering did not settle to 'no' within scan OFF polling window."
     return 1
 }
+
+# Return BD address for a given HCI adapter using hciconfig.
+# Prints empty output if the adapter is missing or address cannot be parsed.
+bt_hci_bdaddr() {
+    adapter="$1"
+
+    [ -n "$adapter" ] || return 1
+
+    if ! command -v hciconfig >/dev/null 2>&1; then
+        return 1
+    fi
+
+    hciconfig "$adapter" 2>/dev/null | awk '
+        /BD Address:/ {
+            for (i = 1; i <= NF; i++) {
+                if ($i == "Address:") {
+                    print $(i + 1)
+                    exit
+                }
+            }
+        }
+    '
+}
+
+# Check whether an HCI adapter is usable for BT_ON_OFF.
+# Requires UP RUNNING state and a non-zero BD address.
+bt_adapter_is_usable() {
+    adapter="$1"
+    out=""
+    addr=""
+
+    [ -n "$adapter" ] || return 1
+
+    if ! command -v hciconfig >/dev/null 2>&1; then
+        return 1
+    fi
+
+    out="$(hciconfig "$adapter" 2>/dev/null || true)"
+    [ -n "$out" ] || return 1
+
+    addr="$(bt_hci_bdaddr "$adapter" 2>/dev/null || true)"
+    case "$addr" in
+        ""|"00:00:00:00:00:00")
+            return 1
+            ;;
+    esac
+
+    if printf '%s\n' "$out" | grep -q 'UP RUNNING'; then
+        return 0
+    fi
+
+    return 1
+}
+
+# Select the best available Bluetooth adapter.
+# Prefer UP/RUNNING + non-zero BD address, then fallback to non-zero BD only.
+bt_select_usable_adapter() {
+    adapters=""
+    adapter=""
+    addr=""
+
+    if command -v hciconfig >/dev/null 2>&1; then
+        adapters="$(hciconfig 2>/dev/null | awk -F: '/^hci[0-9]+:/ { print $1 }')"
+
+        for adapter in $adapters; do
+            if bt_adapter_is_usable "$adapter"; then
+                printf '%s\n' "$adapter"
+                return 0
+            fi
+        done
+
+        for adapter in $adapters; do
+            addr="$(bt_hci_bdaddr "$adapter" 2>/dev/null || true)"
+            case "$addr" in
+                ""|"00:00:00:00:00:00")
+                    continue
+                    ;;
+                *)
+                    printf '%s\n' "$adapter"
+                    return 0
+                    ;;
+            esac
+        done
+    fi
+
+    if command -v findhcisysfs >/dev/null 2>&1; then
+        findhcisysfs 2>/dev/null || true
+        return 0
+    fi
+
+    return 1
+}
+
+# Log all HCI candidates with address/state details for CI/LAVA debug.
+# This helps explain why one adapter was selected or ignored.
+bt_log_hci_candidates() {
+    adapters=""
+    adapter=""
+    out=""
+    addr=""
+    state=""
+    usable="no"
+
+    if ! command -v hciconfig >/dev/null 2>&1; then
+        log_warn "hciconfig not available; cannot log HCI adapter candidates."
+        return 0
+    fi
+
+    adapters="$(hciconfig 2>/dev/null | awk -F: '/^hci[0-9]+:/ { print $1 }')"
+    if [ -z "$adapters" ]; then
+        log_warn "No HCI adapters reported by hciconfig."
+        return 0
+    fi
+
+    for adapter in $adapters; do
+        out="$(hciconfig "$adapter" 2>/dev/null || true)"
+        addr="$(bt_hci_bdaddr "$adapter" 2>/dev/null || true)"
+        state="$(printf '%s\n' "$out" | awk '/UP|DOWN|RUNNING/ {
+            gsub(/^[ \t]+|[ \t]+$/, "")
+            print
+            exit
+        }')"
+
+        [ -n "$addr" ] || addr="unknown"
+        [ -n "$state" ] || state="unknown"
+
+        usable="no"
+        if bt_adapter_is_usable "$adapter"; then
+            usable="yes"
+        fi
+
+        log_info "[bt-adapter] $adapter addr=$addr state='$state' usable=$usable"
+    done
+}


### PR DESCRIPTION
Fixes #427
 
This PR fixes BT_ON_OFF adapter selection on platforms with multiple HCI controllers.
 
Issue:
- On iq-x7181-evk/Hamao, hci0 is a UART controller that can be DOWN and   uninitialized with BD address 00:00:00:00:00:00.
- hci1 is a USB controller that is UP/RUNNING with a valid BD address.
- The existing test selected hci0 by default and skipped, even though hci1 was   usable.
 
Changes:
- Add reusable Bluetooth helper logic to identify usable HCI adapters.
- Prefer adapters that are UP/RUNNING and have a valid non-zero BD address.
- Avoid selecting DOWN or uninitialized controllers with   00:00:00:00:00:00.
- Keep explicit BT_ADAPTER / --adapter override support.
- Log all detected HCI candidates to make LAVA/CI failures easier to debug.
- Fix the BT_ON_OFF YAML description typo.
 
Expected result:
- BT_ON_OFF now auto-selects hci1 on Hamao when hci0 is DOWN/uninitialized.
- The test only skips when no usable Bluetooth adapter is available.

```
root@iq-x7181-evk:/tmp/Runner/suites/Connectivity/Bluetooth/BT_ON_OFF# ./run.sh
[INFO] 2026-04-27 17:11:25 - ------------------------------------------------------------
[INFO] 2026-04-27 17:11:25 - Starting BT_ON_OFF Testcase
[INFO] 2026-04-27 17:11:25 - Checking dependency: bluetoothctl
[INFO] 2026-04-27 17:11:25 - Checking if bluetoothd is running...
[INFO] 2026-04-27 17:11:25 - bluetoothd is running
[INFO] 2026-04-27 17:11:25 - [bt-adapter] hci1 addr=8C:FD:F0:58:50:86 state='UP RUNNING' usable=yes
[INFO] 2026-04-27 17:11:25 - [bt-adapter] hci0 addr=00:00:00:00:00:00 state='DOWN' usable=no
[WARN] 2026-04-27 17:11:25 - bluetoothctl list returned no controllers in non-interactive mode.
[WARN] 2026-04-27 17:11:25 - On minimal/ramdisk images this can be normal; interactive bluetoothctl may still work.
[INFO] 2026-04-27 17:11:25 - Proceeding with interactive bluetoothctl for controller queries (non-interactive output incomplete on some images).
[WARN] 2026-04-27 17:11:25 - Bluetooth diagnostics: controller visibility is inconsistent
[WARN] 2026-04-27 17:11:25 - Adapter: hci1
[WARN] 2026-04-27 17:11:25 - hciconfig output:
[BT-DIAG] hci1: Type: Primary  Bus: USB
[BT-DIAG]       BD Address: 8C:FD:F0:58:50:86  ACL MTU: 1024:7  SCO MTU: 240:8
[BT-DIAG]       UP RUNNING
[BT-DIAG]       RX bytes:1902 acl:0 sco:0 events:149 errors:0
[BT-DIAG]       TX bytes:6113 acl:0 sco:0 commands:149 errors:0
[BT-DIAG]
[BT-DIAG] hci0: Type: Primary  Bus: UART
[BT-DIAG]       BD Address: 00:00:00:00:00:00  ACL MTU: 0:0  SCO MTU: 0:0
[BT-DIAG]       DOWN
[BT-DIAG]       RX bytes:0 acl:0 sco:0 events:0 errors:0
[BT-DIAG]       TX bytes:20 acl:0 sco:0 commands:4 errors:0
[WARN] 2026-04-27 17:11:25 - systemctl status bluetooth:
[BT-DIAG] * bluetooth.service - Bluetooth service
[BT-DIAG]      Loaded: loaded (/usr/lib/systemd/system/bluetooth.service; enabled; preset: enabled)
[BT-DIAG]      Active: active (running) since Sun 1980-01-06 00:19:59 UTC; 46 years 3 months ago
[BT-DIAG]  Invocation: 3550d1ec30284240943717d1b0346333
[BT-DIAG]        Docs: man:bluetoothd(8)
[BT-DIAG]    Main PID: 876 (bluetoothd)
[BT-DIAG]      Status: "Running"
[BT-DIAG]       Tasks: 1 (limit: 76204)
[BT-DIAG]      Memory: 2.8M (peak: 3.8M)
[BT-DIAG]         CPU: 28ms
[BT-DIAG]      CGroup: /system.slice/bluetooth.service
[BT-DIAG]              `-876 /usr/libexec/bluetooth/bluetoothd
[BT-DIAG]
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx_ll_0
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx_ll_duplex_1
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx_ll_duplex_0
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/faststream
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/faststream_duplex
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSink/opus_05
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/opus_05
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSink/opus_05_duplex
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/opus_05_duplex
[BT-DIAG] Jan 06 00:19:59 iq-x7181-evk systemd[1]: Started Bluetooth service.
[WARN] 2026-04-27 17:11:25 - journalctl -u bluetooth -b (tail):
[BT-DIAG] Jan 06 00:19:57 iq-x7181-evk systemd[1]: Starting Bluetooth service...
[BT-DIAG] Jan 06 00:19:57 iq-x7181-evk (bluetoothd)[876]: bluetooth.service: ConfigurationDirectory 'bluetooth' already exists but the mode is different. (File system: 755 ConfigurationDirectoryMode: 555)
[BT-DIAG] Jan 06 00:19:57 iq-x7181-evk bluetoothd[876]: Bluetooth daemon 5.86
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Starting SDP server
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Bluetooth management interface 1.23 initialized
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Battery Provider Manager created
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Failed to set default system config for hci1
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: /usr/src/debug/bluez5/5.86/src/profile.c:register_profile() :1.8 tried to register 0000111e-0000-1000-8000-00805f9b34fb which is already registered
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSink/aptx_hd
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx_hd
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSink/aptx
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSink/opus_g
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/opus_g
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSink/sbc
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/sbc
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx_ll_1
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx_ll_0
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx_ll_duplex_1
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/aptx_ll_duplex_0
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/faststream
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/faststream_duplex
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSink/opus_05
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/opus_05
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSink/opus_05_duplex
[BT-DIAG] Jan 06 00:19:58 iq-x7181-evk bluetoothd[876]: Endpoint registered: sender=:1.8 path=/MediaEndpoint/A2DPSource/opus_05_duplex
[BT-DIAG] Jan 06 00:19:59 iq-x7181-evk systemd[1]: Started Bluetooth service.
[WARN] 2026-04-27 17:11:25 - bluetoothctl list returned no controllers in non-interactive mode.
[WARN] 2026-04-27 17:11:25 - On minimal/ramdisk images this can be normal; interactive bluetoothctl may still work.
[INFO] 2026-04-27 17:11:25 - Proceeding with interactive bluetoothctl for controller queries (non-interactive output incomplete on some images).
[INFO] 2026-04-27 17:11:27 - Initial Powered = yes
[INFO] 2026-04-27 17:11:27 - Powering OFF...
[INFO] 2026-04-27 17:11:28 - btpower: requesting 'off' on hci1 (current=yes)
[INFO] 2026-04-27 17:11:31 - btpower: hci1 Powered=no after request.
[PASS] 2026-04-27 17:11:32 - Post-OFF verification: Powered=no (as expected).
[INFO] 2026-04-27 17:11:32 - Powering ON...
[INFO] 2026-04-27 17:11:33 - btpower: requesting 'on' on hci1 (current=no)
[INFO] 2026-04-27 17:11:36 - btpower: hci1 Powered=yes after request.
[PASS] 2026-04-27 17:11:37 - Post-ON verification: Powered=yes (as expected).
root@iq-x7181-evk:/tmp/Runner/suites/Connectivity/Bluetooth/BT_ON_OFF# cat BT_ON_OFF.res
BT_ON_OFF PASS
root@iq-x7181-evk:/tmp/Runner/suites/Connectivity/Bluetooth/BT_ON_OFF#
``` 