### PR TITLE
fix: select connected DRM card for KMSCube  

### DIFF
--- a/Runner/suites/Multimedia/Graphics/KMSCube/run.sh
+++ b/Runner/suites/Multimedia/Graphics/KMSCube/run.sh
@@ -43,6 +43,8 @@ cd "$test_path" || exit 1
 
 RES_FILE="./$TESTNAME.res"
 LOG_FILE="./${TESTNAME}_run.log"
+KMSCUBE_DRM_CONNECTOR=""
+KMSCUBE_DRM_DEV=""
 rm -f "$RES_FILE" "$LOG_FILE"
 
 log_info "-------------------------------------------------------------------"
@@ -81,6 +83,40 @@ if [ "$have_connector" -eq 0 ]; then
     exit 0
 fi
 
+# Select the DRM card that owns the connected display.
+# This avoids kmscube auto-selecting the wrong card on multi-DRM-card systems.
+if command -v display_select_primary_connector >/dev/null 2>&1; then
+    if KMSCUBE_DRM_CONNECTOR="$(display_select_primary_connector)"; then
+        if [ -z "$KMSCUBE_DRM_CONNECTOR" ]; then
+            log_warn "display_select_primary_connector returned empty output."
+        fi
+    else
+        KMSCUBE_DRM_CONNECTOR=""
+        log_warn "display_select_primary_connector failed; connected display mapping may be unavailable."
+    fi
+else
+    log_warn "display_select_primary_connector helper not found; connected display mapping may be unavailable."
+fi
+
+if command -v display_select_primary_drm_device >/dev/null 2>&1; then
+    if KMSCUBE_DRM_DEV="$(display_select_primary_drm_device)"; then
+        if [ -z "$KMSCUBE_DRM_DEV" ]; then
+            log_warn "display_select_primary_drm_device returned empty output; kmscube will use default DRM device selection."
+        fi
+    else
+        KMSCUBE_DRM_DEV=""
+        log_warn "display_select_primary_drm_device failed; kmscube will use default DRM device selection."
+    fi
+else
+    log_warn "display_select_primary_drm_device helper not found; kmscube will use default DRM device selection."
+fi
+
+if [ -n "$KMSCUBE_DRM_DEV" ]; then
+    log_info "Selected KMS connector: ${KMSCUBE_DRM_CONNECTOR:-<unknown>}"
+    log_info "Selected KMS DRM device: $KMSCUBE_DRM_DEV"
+else
+    log_warn "Could not map connected display to a DRM card; kmscube will use default device selection."
+fi
 # --- Basic DRM availability guard -------------------------------------------
 set -- /dev/dri/card* 2>/dev/null
 if [ ! -e "$1" ]; then
@@ -88,6 +124,7 @@ if [ ! -e "$1" ]; then
     echo "$TESTNAME SKIP" >"$RES_FILE"
     exit 0
 fi
+
 # --- Dependencies ------------------------------------------------------------
 # With patched check_dependencies(): ask for return code instead of exit
 if ! CHECK_DEPS_NO_EXIT=1 check_dependencies kmscube; then
@@ -101,6 +138,7 @@ log_info "Using kmscube: ${KMSCUBE_BIN:-<not found>}"
 
 # --- Track whether this test stopped Weston ----------------------------------
 weston_stopped_by_test=0
+
 # --- GPU acceleration gating (avoid auto/Wayland for kmscube) ----------------
 # KMSCube is a DRM/KMS test. Using "auto" can start/adopt Weston and steal DRM master.
 if command -v display_is_cpu_renderer >/dev/null 2>&1; then
@@ -147,9 +185,19 @@ unset WAYLAND_DISPLAY
 EGL_PLATFORM_SAVED="${EGL_PLATFORM:-}"
 export EGL_PLATFORM=gbm
 
-log_info "Running kmscube with --count=${FRAME_COUNT} ..."
-if kmscube --count="${FRAME_COUNT}" >"$LOG_FILE" 2>&1; then :; else
+rc=0
+
+if [ -n "$KMSCUBE_DRM_DEV" ]; then
+    log_info "Running kmscube on $KMSCUBE_DRM_DEV with --count=${FRAME_COUNT} ..."
+    kmscube -D "$KMSCUBE_DRM_DEV" --count="${FRAME_COUNT}" >"$LOG_FILE" 2>&1
     rc=$?
+else
+    log_info "Running kmscube with default DRM device selection and --count=${FRAME_COUNT} ..."
+    kmscube --count="${FRAME_COUNT}" >"$LOG_FILE" 2>&1
+    rc=$?
+fi
+
+if [ "$rc" -ne 0 ]; then
     log_fail "$TESTNAME : Execution failed (rc=$rc) — see $LOG_FILE"
     cat "$LOG_FILE"
     echo "$TESTNAME FAIL" >"$RES_FILE"

--- a/Runner/utils/lib_display.sh
+++ b/Runner/utils/lib_display.sh
@@ -381,6 +381,46 @@ display_select_primary_connector() {
     return 0
 }
 
+# Select the DRM card device that owns the preferred connected display.
+# Prints /dev/dri/cardN when a real connected connector is available.
+display_select_primary_drm_device() {
+    connector=""
+    card_idx=""
+    card_dev=""
+
+    if connector="$(display_select_primary_connector)"; then
+        if [ -z "$connector" ]; then
+            log_warn "display_select_primary_drm_device: display_select_primary_connector returned empty output" >&2
+            return 1
+        fi
+    else
+        log_warn "display_select_primary_drm_device: display_select_primary_connector failed" >&2
+        return 1
+    fi
+
+    if card_idx="$(display__drm_idx_from_sysfs_connector "$connector")"; then
+        :
+    else
+        log_warn "display_select_primary_drm_device: failed to extract DRM card index from connector '$connector'" >&2
+        return 1
+    fi
+
+    case "$card_idx" in
+        ""|*[!0-9]*)
+            log_warn "display_select_primary_drm_device: invalid DRM card index '$card_idx' from connector '$connector'" >&2
+            return 1
+            ;;
+    esac
+
+    card_dev="/dev/dri/card$card_idx"
+    if [ ! -e "$card_dev" ]; then
+        log_warn "display_select_primary_drm_device: selected DRM device '$card_dev' does not exist for connector '$connector'" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$card_dev"
+    return 0
+}
 ###############################################################################
 # Weston weston.ini helpers
 ###############################################################################


### PR DESCRIPTION
Fixes #420
 
This PR fixes KMSCube failures on multi-DRM-card platforms where a valid display is connected but kmscube still fails with:
 
  no connected connector!
  failed to initialize legacy DRM
 
Why this PR is needed:
- On affected platforms such as Lemans RideSX, sysfs reports a connected and   enabled display on a specific DRM card, for example card1-DP-3.
- The existing KMSCube test only checked that some display was connected, but   then ran kmscube without specifying the DRM device.
- On systems with multiple DRM cards, kmscube may auto-open a different card   that has no connected connector, causing a false test failure even though a   monitor is attached and valid.
- This is especially visible when kmscube falls back to legacy DRM modesetting,   where correct DRM card selection is required.