### PR TITLE
system: add Kubernetes and Docker kernel config validation with exact config matching

### DIFF
--- a/Runner/suites/System/Docker_Kernel_Config/Docker_Kernel_Config.yaml
+++ b/Runner/suites/System/Docker_Kernel_Config/Docker_Kernel_Config.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: Docker_Kernel_Config
+  format: Lava-Test Test Definition 1.0
+  description: "Validate required kernel configs for Docker support"
+  maintainer:
+    - "Qualcomm Linux Testkit"
+
+params: {}
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/System/Docker_Kernel_Config
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Docker_Kernel_Config.res

--- a/Runner/suites/System/Docker_Kernel_Config/Docker_Kernel_Config_README.md
+++ b/Runner/suites/System/Docker_Kernel_Config/Docker_Kernel_Config_README.md
@@ -1,0 +1,39 @@
+# Docker_Kernel_Config
+
+Validates the required Linux kernel configuration options for Docker support on the target.
+
+## What this test checks
+
+The test verifies that the following kernel configs are present with the exact expected values:
+
+- `CONFIG_CGROUP_FAVOR_DYNMODS=y`
+- `CONFIG_CFS_BANDWIDTH=y`
+- `CONFIG_NETFILTER_XT_MATCH_COMMENT=m`
+- `CONFIG_IP_NF_TARGET_REDIRECT=m`
+
+## Validation method
+
+The test uses the shared `check_kernel_config()` helper from `Runner/utils/functestlib.sh`.
+
+This helper is expected to support exact config checks such as:
+
+- `CONFIG_FOO=y`
+- `CONFIG_BAR=m`
+
+The test fails if any required config is missing or does not match the expected value.
+
+## Result semantics
+
+- `PASS` when all required Docker kernel configs are present with the expected values
+- `FAIL` when any required config is missing or mismatched
+
+## Output
+
+The test writes its final result to:
+
+- `Docker_Kernel_Config.res`
+
+Expected result format:
+
+- `Docker_Kernel_Config PASS`
+- `Docker_Kernel_Config FAIL`

--- a/Runner/suites/System/Docker_Kernel_Config/run.sh
+++ b/Runner/suites/System/Docker_Kernel_Config/run.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env, starting at $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="Docker_Kernel_Config"
+test_path="$(find_test_case_by_name "$TESTNAME")" || {
+    log_fail "$TESTNAME, test directory not found"
+    echo "$TESTNAME FAIL" > "./$TESTNAME.res"
+    exit 1
+}
+
+cd "$test_path" || exit 1
+RES_FILE="./${TESTNAME}.res"
+rm -f "$RES_FILE"
+
+CONFIGS="
+CONFIG_CGROUP_FAVOR_DYNMODS=y
+CONFIG_CFS_BANDWIDTH=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=m
+CONFIG_IP_NF_TARGET_REDIRECT=m
+"
+
+log_info "-----------------------------------------------------------------------------------------"
+log_info "------------------- Starting ${TESTNAME} Testcase ----------------------------"
+log_info "==== Test Initialization ===="
+
+log_info "Checking required Docker kernel configs"
+if ! check_kernel_config "$CONFIGS"; then
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+log_pass "$TESTNAME, all required Docker kernel configs are present with expected values"
+echo "$TESTNAME PASS" > "$RES_FILE"
+log_info "------------------- Completed ${TESTNAME} Testcase ----------------------------"
+exit 0

--- a/Runner/suites/System/Kubernetes_Kernel_Config/Kubernetes_Kernel_Config.yaml
+++ b/Runner/suites/System/Kubernetes_Kernel_Config/Kubernetes_Kernel_Config.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: Kubernetes_Kernel_Config
+  format: Lava-Test Test Definition 1.0
+  description: "Validate required kernel configs for Kubernetes support"
+  maintainer:
+    - "Qualcomm Linux Testkit"
+
+params: {}
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/System/Kubernetes_Kernel_Config
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Kubernetes_Kernel_Config.res

--- a/Runner/suites/System/Kubernetes_Kernel_Config/Kubernetes_Kernel_Config_README.md
+++ b/Runner/suites/System/Kubernetes_Kernel_Config/Kubernetes_Kernel_Config_README.md
@@ -1,0 +1,41 @@
+# Kubernetes_Kernel_Config
+
+Validates the required Linux kernel configuration options for Kubernetes support on the target.
+
+## What this test checks
+
+The test verifies that the following kernel configs are present with the exact expected values:
+
+- `CONFIG_CGROUP_FAVOR_DYNMODS=y`
+- `CONFIG_CFS_BANDWIDTH=y`
+- `CONFIG_CGROUP_HUGETLB=y`
+- `CONFIG_NETFILTER_XT_MATCH_COMMENT=m`
+- `CONFIG_IP_NF_TARGET_REDIRECT=m`
+- `CONFIG_HUGETLBFS=y`
+
+## Validation method
+
+The test uses the shared `check_kernel_config()` helper from `Runner/utils/functestlib.sh`.
+
+This helper is expected to support exact config checks such as:
+
+- `CONFIG_FOO=y`
+- `CONFIG_BAR=m`
+
+The test fails if any required config is missing or does not match the expected value.
+
+## Result semantics
+
+- `PASS` when all required Kubernetes kernel configs are present with the expected values
+- `FAIL` when any required config is missing or mismatched
+
+## Output
+
+The test writes its final result to:
+
+- `Kubernetes_Kernel_Config.res`
+
+Expected result format:
+
+- `Kubernetes_Kernel_Config PASS`
+- `Kubernetes_Kernel_Config FAIL`

--- a/Runner/suites/System/Kubernetes_Kernel_Config/run.sh
+++ b/Runner/suites/System/Kubernetes_Kernel_Config/run.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env, starting at $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1091
+. "$TOOLS/functestlib.sh"
+
+TESTNAME="Kubernetes_Kernel_Config"
+test_path="$(find_test_case_by_name "$TESTNAME")" || {
+    log_fail "$TESTNAME, test directory not found"
+    echo "$TESTNAME FAIL" > "./$TESTNAME.res"
+    exit 1
+}
+
+cd "$test_path" || exit 1
+RES_FILE="./${TESTNAME}.res"
+rm -f "$RES_FILE"
+
+CONFIGS="
+CONFIG_CGROUP_FAVOR_DYNMODS=y
+CONFIG_CFS_BANDWIDTH=y
+CONFIG_CGROUP_HUGETLB=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=m
+CONFIG_IP_NF_TARGET_REDIRECT=m
+CONFIG_HUGETLBFS=y
+"
+
+log_info "-----------------------------------------------------------------------------------------"
+log_info "------------------- Starting ${TESTNAME} Testcase ----------------------------"
+log_info "==== Test Initialization ===="
+
+log_info "Checking required Kubernetes kernel configs"
+if ! check_kernel_config "$CONFIGS"; then
+    echo "$TESTNAME FAIL" > "$RES_FILE"
+    exit 0
+fi
+
+log_pass "$TESTNAME, all required Kubernetes kernel configs are present with expected values"
+echo "$TESTNAME PASS" > "$RES_FILE"
+log_info "------------------- Completed ${TESTNAME} Testcase ----------------------------"
+exit 0

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -198,27 +198,55 @@ find_test_case_script_by_name() {
     find "$base_dir" -type d -iname "$test_name" -print -quit 2>/dev/null
 }
 
-# Check each given kernel config is set to y/m in /proc/config.gz, logs result, returns 0/1.
+# Check each given kernel config in /proc/config.gz.
+# Supported inputs:
+# CONFIG_FOO
+# passes when CONFIG_FOO is enabled as y or m
+# CONFIG_BAR=y
+# CONFIG_BAZ=m
+# passes only when the exact expected value matches
+# Logs PASS or FAIL for each config and returns 0 on success, 1 on first mismatch.
 check_kernel_config() {
     cfgs=$1
-    for config_key in $cfgs; do
+
+    if [ ! -r /proc/config.gz ]; then
+        log_fail "Kernel config source /proc/config.gz is not available"
+        return 1
+    fi
+
+    for cfg in $cfgs; do
+        [ -n "$cfg" ] || continue
+
+        case "$cfg" in
+            *=*)
+                pattern="^${cfg}$"
+                pass_msg="Kernel config matches expected value, $cfg"
+                fail_msg="Kernel config does not match expected value, required $cfg"
+                ;;
+            *)
+                pattern="^${cfg}=(y|m)$"
+                pass_msg="Kernel config $cfg is enabled"
+                fail_msg="Kernel config $cfg is missing or not enabled"
+                ;;
+        esac
+
         if command -v zgrep >/dev/null 2>&1; then
-            if zgrep -qE "^${config_key}=(y|m)" /proc/config.gz 2>/dev/null; then
-                log_pass "Kernel config $config_key is enabled"
+            if zgrep -qE "$pattern" /proc/config.gz 2>/dev/null; then
+                log_pass "$pass_msg"
             else
-                log_fail "Kernel config $config_key is missing or not enabled"
+                log_fail "$fail_msg"
                 return 1
             fi
         else
-            # Fallback if zgrep is unavailable
-            if gzip -dc /proc/config.gz 2>/dev/null | grep -qE "^${config_key}=(y|m)"; then
-                log_pass "Kernel config $config_key is enabled"
+            if gzip -dc /proc/config.gz 2>/dev/null | grep -qE "$pattern"; then
+                log_pass "$pass_msg"
             else
-                log_fail "Kernel config $config_key is missing or not enabled"
+                log_fail "$fail_msg"
                 return 1
             fi
         fi
     done
+
     return 0
 }
 


### PR DESCRIPTION
This PR extends kernel config validation in the testkit and adds two new System testcases for container-related kernel requirements.
 
Why this change is needed:
The existing check_kernel_config helper only verified that a config was enabled as either y or m. That was not sufficient for these use cases, because several container-related configs require an exact value, for example module-only
settings such as CONFIG_NETFILTER_XT_MATCH_COMMENT=m and CONFIG_IP_NF_TARGET_REDIRECT=m. With the old behavior, a mismatched exact value could still pass.
 
What this PR changes:
- extends Runner/utils/[functestlib.sh](http://functestlib.sh/) so check_kernel_config supports both
  existing key-only checks and exact value checks such as CONFIG_FOO=y or   CONFIG_BAR=m
- adds Runner/suites/System/Kubernetes_Kernel_Config to validate the required   kernel configuration for Kubernetes support
- adds Runner/suites/System/Docker_Kernel_Config to validate the required   kernel configuration for Docker support
- adds the corresponding YAML and README files for both tests
 