### PR TITLE
test: temporarily disable OpenCV in premerge CI

### DIFF
--- a/Runner/plans/qcom-next-ci-premerge.yaml
+++ b/Runner/plans/qcom-next-ci-premerge.yaml
@@ -76,6 +76,4 @@ run:
         - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/Baseport/watchdog/watchdog.res || true
         - $PWD/suites/Multimedia/DSP_AudioPD/run.sh || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/DSP_AudioPD/DSP_AudioPD.res || true
-        - $PWD/suites/Multimedia/OpenCV/run.sh || true
-        - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/OpenCV/OpenCV.res || true
         - $PWD/utils/result_parse.sh


### PR DESCRIPTION
Temporarily disable OpenCV execution in the qcom-next premerge plan a
 
Why this is needed:
- The OpenCV standalone YAML path and the direct premerge [run.sh](http://run.sh/) path are not  currently equivalent.
- OpenCV.yaml was passing boolean flags such as --list and --shuffle as   key/value arguments, which can accidentally enable list-only behavior instead   of running the real tests.
- The premerge plan calls OpenCV/[run.sh](http://run.sh/) directly, so it executes the actual  default suite and can fail while the YAML path appears to pass.
- To avoid unstable or misleading premerge failures, OpenCV is temporarily disabled
 
