### PR TITLE
system: harden EFI variable validation for platform differences

### DIFF
--- a/Runner/suites/System/EFI_Variable_Validation/run.sh
+++ b/Runner/suites/System/EFI_Variable_Validation/run.sh
@@ -31,14 +31,19 @@ fi
 # shellcheck disable=SC1091
 . "$TOOLS/functestlib.sh"
 
+# shellcheck disable=SC1091
+. "$TOOLS/lib_system.sh"
+
 TESTNAME="EFI_Variable_Validation"
-test_path="$(find_test_case_by_name "$TESTNAME")" || {
+
+test_path="$(find_test_case_by_name "$TESTNAME")"
+if [ -n "$test_path" ]; then
+    cd "$test_path" || exit 1
+else
     log_fail "$TESTNAME, test directory not found"
     echo "$TESTNAME FAIL" > "./$TESTNAME.res"
     exit 1
-}
-
-cd "$test_path" || exit 1
+fi
 
 RES_FILE="./${TESTNAME}.res"
 EFI_LIST_LOG="./efi_vars.list"
@@ -46,13 +51,15 @@ EFI_WRITE_LOG="./efi_var_write.log"
 EFI_TRIAL_PRINT_LOG="./efi_trial_boot_status_print.log"
 EFI_IND_PRINT_LOG="./efi_os_indications_supported_print.log"
 EFI_DATA_FILE="./efi_trial_boot_status.bin"
+EFI_REMOUNT_LOG="./efi_efivarfs_remount.log"
 
 rm -f "$RES_FILE" \
       "$EFI_LIST_LOG" \
       "$EFI_WRITE_LOG" \
       "$EFI_TRIAL_PRINT_LOG" \
       "$EFI_IND_PRINT_LOG" \
-      "$EFI_DATA_FILE"
+      "$EFI_DATA_FILE" \
+      "$EFI_REMOUNT_LOG"
 
 CONFIGS="
 CONFIG_EFI=y
@@ -60,95 +67,32 @@ CONFIG_EFI_ESRT=y
 CONFIG_EFIVAR_FS=y
 "
 
-EFI_GLOBAL_GUID="8be4df61-93ca-11d2-aa0d-00e098032b8c"
-OS_TRIAL_BOOT_STATUS_VAR="${EFI_GLOBAL_GUID}-OsTrialBootStatus"
-OS_INDICATIONS_SUPPORTED_VAR="${EFI_GLOBAL_GUID}-OsIndicationsSupported"
-
-write_trial_boot_status_payload() {
-    # 01 77 01 00 00 00 00 00
-    : > "$EFI_DATA_FILE" || return 1
-    printf '\001\167\001\000\000\000\000\000' > "$EFI_DATA_FILE" || return 1
-    return 0
-}
-
-log_file_excerpt() {
-    log_prefix="$1"
-    log_file="$2"
-    log_lines="${3:-40}"
-
-    sed -n "1,${log_lines}p" "$log_file" | while IFS= read -r line; do
-        [ -n "$line" ] || continue
-        log_info "[${log_prefix}] $line"
-    done
-}
-
-require_grep_in_file() {
-    pattern="$1"
-    file_path="$2"
-    fail_msg="$3"
-
-    if grep -Fq "$pattern" "$file_path"; then
-        return 0
-    fi
-
-    log_fail "$fail_msg"
-    return 1
-}
-
-require_hex_payload_in_file() {
-    file_path="$1"
-    expected_desc="$2"
-
-    if grep -Eq '01[[:space:]]+77[[:space:]]+01[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00' "$file_path"; then
-        return 0
-    fi
-
-    log_fail "EFI variable payload does not match expected value, required ${expected_desc}"
-    return 1
-}
-
-require_os_indications_supported_value() {
-    file_path="$1"
-
-    if grep -Eq '04[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00' "$file_path"; then
-        return 0
-    fi
-
-    log_fail "OsIndicationsSupported value does not match expected value, required 04 00 00 00 00 00 00 00"
-    return 1
-}
+efi_install_restore_trap
 
 log_info "-----------------------------------------------------------------------------------------"
 log_info "------------------- Starting ${TESTNAME} Testcase ----------------------------"
 log_info "==== Test Initialization ===="
 
-if ! CHECK_DEPS_NO_EXIT=1 check_dependencies efivar grep sed awk printf; then
-    log_skip "$TESTNAME SKIP, missing required dependencies"
-    echo "$TESTNAME SKIP" > "$RES_FILE"
-    exit 0
+if ! CHECK_DEPS_NO_EXIT=1 check_dependencies efivar grep sed awk printf mount wc; then
+    system_write_result_and_exit "SKIP" "$TESTNAME SKIP, missing required dependencies"
 fi
 
 log_info "Checking required EFI kernel configs"
 if ! check_kernel_config "$CONFIGS"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, required EFI kernel configs are missing"
 fi
 
 log_info "Checking EFI runtime directory"
 if [ ! -d /sys/firmware/efi ]; then
-    log_fail "/sys/firmware/efi is not present"
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+    system_write_result_and_exit "FAIL" "/sys/firmware/efi is not present"
 fi
 log_pass "/sys/firmware/efi is present"
 
 log_info "Checking efivarfs directory"
-if [ ! -d /sys/firmware/efi/efivars ]; then
-    log_fail "/sys/firmware/efi/efivars is not present"
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+if [ ! -d "$EFIVARFS_PATH" ]; then
+    system_write_result_and_exit "FAIL" "$EFIVARFS_PATH is not present"
 fi
-log_pass "/sys/firmware/efi/efivars is present"
+log_pass "$EFIVARFS_PATH is present"
 
 log_info "Checking ESRT runtime directory"
 if [ -d /sys/firmware/efi/esrt ]; then
@@ -159,116 +103,146 @@ fi
 
 log_info "Listing EFI variables with efivar -l"
 if ! efivar -l > "$EFI_LIST_LOG" 2>&1; then
-    log_fail "efivar -l failed"
-    log_file_excerpt "efivar-list" "$EFI_LIST_LOG" 40
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+    system_log_file_excerpt "efivar-list" "$EFI_LIST_LOG" 40
+
+    if efi_error_is_unsupported "$EFI_LIST_LOG"; then
+        system_write_result_and_exit "SKIP" "$TESTNAME SKIP, EFI variable runtime service is not implemented by firmware"
+    fi
+
+    system_write_result_and_exit "FAIL" "efivar -l failed"
 fi
 
 efi_var_count="$(grep -c '.' "$EFI_LIST_LOG" 2>/dev/null || echo 0)"
 if [ "$efi_var_count" -le 0 ]; then
-    log_fail "efivar -l returned no EFI variables"
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+    system_write_result_and_exit "SKIP" "$TESTNAME SKIP, efivar -l returned no EFI variables"
 fi
 log_pass "efivar -l returned ${efi_var_count} EFI variables"
 
 log_info "Showing first EFI variables, capped at 20 lines"
-log_file_excerpt "efi-var" "$EFI_LIST_LOG" 20
+system_log_file_excerpt "efi-var" "$EFI_LIST_LOG" 20
 
 log_info "Preparing payload for ${OS_TRIAL_BOOT_STATUS_VAR}"
-if ! write_trial_boot_status_payload; then
-    log_fail "Could not prepare OsTrialBootStatus payload file"
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+if ! efi_write_trial_boot_status_payload; then
+    system_write_result_and_exit "FAIL" "Could not prepare OsTrialBootStatus payload file"
 fi
 
 payload_size="$(wc -c < "$EFI_DATA_FILE" 2>/dev/null || echo 0)"
 if [ "$payload_size" -ne 8 ]; then
-    log_fail "OsTrialBootStatus payload size is invalid, expected 8 bytes, got ${payload_size}"
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+    system_write_result_and_exit "FAIL" "OsTrialBootStatus payload size is invalid, expected 8 bytes, got ${payload_size}"
 fi
 log_pass "OsTrialBootStatus payload prepared, size ${payload_size} bytes"
 
+log_info "Checking efivarfs write access"
+if ! efi_mount_is_rw; then
+    if ! efi_try_remount_rw; then
+        system_write_result_and_exit "SKIP" "$TESTNAME SKIP, efivarfs is read-only and could not be remounted read-write"
+    fi
+fi
+
 log_info "Writing EFI variable, ${OS_TRIAL_BOOT_STATUS_VAR}"
 if ! efivar -n "$OS_TRIAL_BOOT_STATUS_VAR" -f "$EFI_DATA_FILE" -w > "$EFI_WRITE_LOG" 2>&1; then
-    log_fail "Write failed for ${OS_TRIAL_BOOT_STATUS_VAR}"
-    log_file_excerpt "efivar-write" "$EFI_WRITE_LOG" 40
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+    system_log_file_excerpt "efivar-write" "$EFI_WRITE_LOG" 40
+
+    if efi_error_is_write_restricted "$EFI_WRITE_LOG"; then
+        system_write_result_and_exit "SKIP" "$TESTNAME SKIP, EFI variable write is restricted on this platform"
+    fi
+
+    system_write_result_and_exit "FAIL" "Write failed for ${OS_TRIAL_BOOT_STATUS_VAR}"
 fi
 log_pass "Write succeeded for ${OS_TRIAL_BOOT_STATUS_VAR}"
 
 log_info "Printing EFI variable, ${OS_TRIAL_BOOT_STATUS_VAR}"
 if ! efivar -n "$OS_TRIAL_BOOT_STATUS_VAR" -p > "$EFI_TRIAL_PRINT_LOG" 2>&1; then
-    log_fail "Print failed for ${OS_TRIAL_BOOT_STATUS_VAR}"
-    log_file_excerpt "efivar-trial-print" "$EFI_TRIAL_PRINT_LOG" 40
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+    system_log_file_excerpt "efivar-trial-print" "$EFI_TRIAL_PRINT_LOG" 40
+    system_write_result_and_exit "FAIL" "Print failed for ${OS_TRIAL_BOOT_STATUS_VAR}"
 fi
 
-log_file_excerpt "efivar-trial-print" "$EFI_TRIAL_PRINT_LOG" 40
+system_log_file_excerpt "efivar-trial-print" "$EFI_TRIAL_PRINT_LOG" 40
 
-if ! require_grep_in_file "GUID: ${EFI_GLOBAL_GUID}" "$EFI_TRIAL_PRINT_LOG" "OsTrialBootStatus GUID does not match expected value"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+if ! system_require_grep_in_file "GUID: ${EFI_GLOBAL_GUID}" \
+        "$EFI_TRIAL_PRINT_LOG" \
+        "OsTrialBootStatus GUID does not match expected value"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsTrialBootStatus GUID validation failed"
 fi
-if ! require_grep_in_file 'Name: "OsTrialBootStatus"' "$EFI_TRIAL_PRINT_LOG" "OsTrialBootStatus name is missing in print output"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+
+if ! system_require_grep_in_file 'Name: "OsTrialBootStatus"' \
+        "$EFI_TRIAL_PRINT_LOG" \
+        "OsTrialBootStatus name is missing in print output"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsTrialBootStatus name validation failed"
 fi
-if ! require_grep_in_file "Non-Volatile" "$EFI_TRIAL_PRINT_LOG" "OsTrialBootStatus is missing Non-Volatile attribute"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+
+if ! system_require_grep_in_file "Non-Volatile" \
+        "$EFI_TRIAL_PRINT_LOG" \
+        "OsTrialBootStatus is missing Non-Volatile attribute"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsTrialBootStatus Non-Volatile attribute validation failed"
 fi
-if ! require_grep_in_file "Boot Service Access" "$EFI_TRIAL_PRINT_LOG" "OsTrialBootStatus is missing Boot Service Access attribute"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+
+if ! system_require_grep_in_file "Boot Service Access" \
+        "$EFI_TRIAL_PRINT_LOG" \
+        "OsTrialBootStatus is missing Boot Service Access attribute"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsTrialBootStatus Boot Service Access attribute validation failed"
 fi
-if ! require_grep_in_file "Runtime Service Access" "$EFI_TRIAL_PRINT_LOG" "OsTrialBootStatus is missing Runtime Service Access attribute"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+
+if ! system_require_grep_in_file "Runtime Service Access" \
+        "$EFI_TRIAL_PRINT_LOG" \
+        "OsTrialBootStatus is missing Runtime Service Access attribute"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsTrialBootStatus Runtime Service Access attribute validation failed"
 fi
-if ! require_hex_payload_in_file "$EFI_TRIAL_PRINT_LOG" "01 77 01 00 00 00 00 00"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+
+if ! efi_require_trial_boot_status_payload \
+        "$EFI_TRIAL_PRINT_LOG" \
+        "01 77 01 00 00 00 00 00"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsTrialBootStatus payload validation failed"
 fi
 log_pass "OsTrialBootStatus attributes and payload match expected values"
 
+if ! efi_variable_list_contains "$OS_INDICATIONS_SUPPORTED_VAR"; then
+    log_warn "${OS_INDICATIONS_SUPPORTED_VAR} is not present, skipping optional OsIndicationsSupported validation"
+    system_finish_pass "$TESTNAME, EFI kernel config and OsTrialBootStatus write/read validation passed"
+fi
+
 log_info "Printing EFI variable, ${OS_INDICATIONS_SUPPORTED_VAR}"
 if ! efivar -n "$OS_INDICATIONS_SUPPORTED_VAR" -p > "$EFI_IND_PRINT_LOG" 2>&1; then
-    log_fail "Print failed for ${OS_INDICATIONS_SUPPORTED_VAR}"
-    log_file_excerpt "efivar-indications-print" "$EFI_IND_PRINT_LOG" 40
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+    system_log_file_excerpt "efivar-indications-print" "$EFI_IND_PRINT_LOG" 40
+
+    if grep -Eiq 'No such file or directory' "$EFI_IND_PRINT_LOG"; then
+        log_warn "${OS_INDICATIONS_SUPPORTED_VAR} is not exposed, skipping optional OsIndicationsSupported validation"
+        system_finish_pass "$TESTNAME, EFI kernel config and OsTrialBootStatus write/read validation passed"
+    fi
+
+    system_write_result_and_exit "FAIL" "Print failed for ${OS_INDICATIONS_SUPPORTED_VAR}"
 fi
 
-log_file_excerpt "efivar-indications-print" "$EFI_IND_PRINT_LOG" 40
+system_log_file_excerpt "efivar-indications-print" "$EFI_IND_PRINT_LOG" 40
 
-if ! require_grep_in_file "GUID: ${EFI_GLOBAL_GUID}" "$EFI_IND_PRINT_LOG" "OsIndicationsSupported GUID does not match expected value"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
+if ! system_require_grep_in_file "GUID: ${EFI_GLOBAL_GUID}" \
+        "$EFI_IND_PRINT_LOG" \
+        "OsIndicationsSupported GUID does not match expected value"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsIndicationsSupported GUID validation failed"
 fi
-if ! require_grep_in_file 'Name: "OsIndicationsSupported"' "$EFI_IND_PRINT_LOG" "OsIndicationsSupported name is missing in print output"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
-fi
-if ! require_grep_in_file "Boot Service Access" "$EFI_IND_PRINT_LOG" "OsIndicationsSupported is missing Boot Service Access attribute"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
-fi
-if ! require_grep_in_file "Runtime Service Access" "$EFI_IND_PRINT_LOG" "OsIndicationsSupported is missing Runtime Service Access attribute"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
-fi
-if ! require_os_indications_supported_value "$EFI_IND_PRINT_LOG"; then
-    echo "$TESTNAME FAIL" > "$RES_FILE"
-    exit 0
-fi
-log_pass "OsIndicationsSupported attributes and value match expected values"
 
-log_pass "$TESTNAME, EFI kernel config, write read validation, and EFI variable attribute checks passed"
-echo "$TESTNAME PASS" > "$RES_FILE"
-log_info "------------------- Completed ${TESTNAME} Testcase ----------------------------"
-exit 0
+if ! system_require_grep_in_file 'Name: "OsIndicationsSupported"' \
+        "$EFI_IND_PRINT_LOG" \
+        "OsIndicationsSupported name is missing in print output"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsIndicationsSupported name validation failed"
+fi
+
+if ! system_require_grep_in_file "Boot Service Access" \
+        "$EFI_IND_PRINT_LOG" \
+        "OsIndicationsSupported is missing Boot Service Access attribute"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsIndicationsSupported Boot Service Access attribute validation failed"
+fi
+
+if ! system_require_grep_in_file "Runtime Service Access" \
+        "$EFI_IND_PRINT_LOG" \
+        "OsIndicationsSupported is missing Runtime Service Access attribute"; then
+    system_write_result_and_exit "FAIL" "$TESTNAME FAIL, OsIndicationsSupported Runtime Service Access attribute validation failed"
+fi
+
+if efi_require_os_indications_supported_value "$EFI_IND_PRINT_LOG"; then
+    log_pass "OsIndicationsSupported attributes and value match expected values"
+else
+    log_warn "OsIndicationsSupported value is firmware-specific, continuing without failing"
+fi
+
+system_finish_pass "$TESTNAME, EFI kernel config, write/read validation, and EFI variable attribute checks passed"

--- a/Runner/utils/lib_system.sh
+++ b/Runner/utils/lib_system.sh
@@ -1,0 +1,369 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Common helpers for System/Yocto userspace validation tests.
+#
+# This library intentionally keeps framework-level helpers in functestlib.sh
+# and provides System-suite specific helpers here. Current users include
+# EFI_Variable_Validation.
+
+# ---------------------------------------------------------------------------
+# Default EFI constants
+# ---------------------------------------------------------------------------
+
+: "${EFI_GLOBAL_GUID:=8be4df61-93ca-11d2-aa0d-00e098032b8c}"
+: "${OS_TRIAL_BOOT_STATUS_VAR:=${EFI_GLOBAL_GUID}-OsTrialBootStatus}"
+: "${OS_INDICATIONS_SUPPORTED_VAR:=${EFI_GLOBAL_GUID}-OsIndicationsSupported}"
+: "${EFIVARFS_PATH:=/sys/firmware/efi/efivars}"
+: "${EFIVARFS_RESTORE_RO:=0}"
+
+# ---------------------------------------------------------------------------
+# Generic System-suite result helpers
+# ---------------------------------------------------------------------------
+
+# Return the active result file path.
+# Prefer RES_FILE from the testcase; fallback to TESTNAME.res when available.
+system_result_file() {
+    if [ -n "${RES_FILE:-}" ]; then
+        printf '%s\n' "$RES_FILE"
+        return 0
+    fi
+
+    if [ -n "${TESTNAME:-}" ]; then
+        printf './%s.res\n' "$TESTNAME"
+        return 0
+    fi
+
+    printf './UnknownTest.res\n'
+    return 0
+}
+
+# Write the final testcase result and exit cleanly.
+# This keeps PASS/FAIL/SKIP exits consistent across System-suite tests.
+system_write_result_and_exit() {
+    result="$1"
+    message="$2"
+    result_file="$(system_result_file)"
+
+    case "$result" in
+        PASS)
+            log_pass "$message"
+            ;;
+        FAIL)
+            log_fail "$message"
+            ;;
+        SKIP)
+            log_skip "$message"
+            ;;
+        *)
+            log_fail "${TESTNAME:-UnknownTest}, invalid result requested: $result"
+            result="FAIL"
+            ;;
+    esac
+
+    echo "${TESTNAME:-UnknownTest} $result" > "$result_file"
+    exit 0
+}
+
+# Complete the test as PASS with the common completion log.
+# Used when mandatory validation passed and only optional platform-specific
+# checks are unavailable.
+system_finish_pass() {
+    message="$1"
+    result_file="$(system_result_file)"
+
+    log_pass "$message"
+    echo "${TESTNAME:-UnknownTest} PASS" > "$result_file"
+
+    if [ -n "${TESTNAME:-}" ]; then
+        log_info "------------------- Completed ${TESTNAME} Testcase ----------------------------"
+    fi
+
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Generic System-suite log helpers
+# ---------------------------------------------------------------------------
+
+# Return success when the given value is an unsigned integer.
+system_is_uint() {
+    case "$1" in
+        ""|*[!0-9]*)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# Log the first N lines from a file with a stable prefix.
+# Usage:
+# system_log_file_excerpt "efivar-list" "./efi_vars.list" 40
+system_log_file_excerpt() {
+    log_prefix="$1"
+    log_file="$2"
+    log_lines="${3:-40}"
+
+    if ! system_is_uint "$log_lines"; then
+        log_lines=40
+    fi
+
+    if [ ! -f "$log_file" ]; then
+        log_warn "Log file not found for excerpt: $log_file"
+        return 1
+    fi
+
+    sed -n "1,${log_lines}p" "$log_file" | while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        log_info "[${log_prefix}] $line"
+    done
+
+    return 0
+}
+
+# Require a fixed string to be present in a file.
+system_require_grep_in_file() {
+    pattern="$1"
+    file_path="$2"
+    fail_msg="$3"
+
+    if grep -Fq "$pattern" "$file_path"; then
+        return 0
+    fi
+
+    log_fail "$fail_msg"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# EFI variable validation helpers
+# ---------------------------------------------------------------------------
+
+# Prepare OsTrialBootStatus payload.
+# Expected payload:
+# 01 77 01 00 00 00 00 00
+#
+# Caller must define:
+# EFI_DATA_FILE
+efi_write_trial_boot_status_payload() {
+    if [ -z "${EFI_DATA_FILE:-}" ]; then
+        log_fail "EFI_DATA_FILE is not set"
+        return 1
+    fi
+
+    : > "$EFI_DATA_FILE" || return 1
+    printf '\001\167\001\000\000\000\000\000' > "$EFI_DATA_FILE" || return 1
+
+    return 0
+}
+
+# Require OsTrialBootStatus payload bytes in efivar print output.
+efi_require_trial_boot_status_payload() {
+    file_path="$1"
+    expected_desc="$2"
+
+    if grep -Eq '01[[:space:]]+77[[:space:]]+01[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00' "$file_path"; then
+        return 0
+    fi
+
+    log_fail "EFI variable payload does not match expected value, required ${expected_desc}"
+    return 1
+}
+
+# Require OsIndicationsSupported expected value.
+# Current expected value:
+# 04 00 00 00 00 00 00 00
+#
+# This helper returns failure but does not write testcase result. Callers can
+# decide whether a mismatch is fatal or only a warning.
+efi_require_os_indications_supported_value() {
+    file_path="$1"
+
+    if grep -Eq '04[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00[[:space:]]+00' "$file_path"; then
+        return 0
+    fi
+
+    log_fail "OsIndicationsSupported value does not match expected value, required 04 00 00 00 00 00 00 00"
+    return 1
+}
+
+# Detect efivar command failures that indicate firmware/runtime EFI variable
+# services are not implemented or not supported on this platform.
+efi_error_is_unsupported() {
+    log_file="$1"
+
+    grep -Eiq \
+        'Function not implemented|Operation not supported|not supported|Invalid argument' \
+        "$log_file"
+}
+
+# Detect efivar write failures that indicate the platform exposes EFI variables
+# in read-only or write-restricted mode.
+efi_error_is_write_restricted() {
+    log_file="$1"
+
+    grep -Eiq \
+        'Read-only file system|Permission denied|Operation not permitted|write protected' \
+        "$log_file"
+}
+
+# Check whether efivarfs is currently mounted.
+# Prefer partition_mount_exists from functestlib.sh when available, with a
+# /proc/mounts fallback.
+efi_mount_exists() {
+    if command -v partition_mount_exists >/dev/null 2>&1; then
+        partition_mount_exists "$EFIVARFS_PATH"
+        return $?
+    fi
+
+    awk -v p="$EFIVARFS_PATH" '
+        $2 == p { found=1; exit }
+        END { exit(found ? 0 : 1) }
+    ' /proc/mounts 2>/dev/null
+}
+
+# Return efivarfs mount options.
+# Prefer partition_get_mount_options from functestlib.sh when available.
+efi_mount_options() {
+    opts=""
+
+    if command -v partition_get_mount_options >/dev/null 2>&1; then
+        opts="$(partition_get_mount_options "$EFIVARFS_PATH" 2>/dev/null || true)"
+    fi
+
+    if [ -z "$opts" ]; then
+        opts="$(
+            awk -v p="$EFIVARFS_PATH" '$2 == p { print $4; exit }' /proc/mounts 2>/dev/null
+        )"
+    fi
+
+    printf '%s\n' "$opts"
+}
+
+# Check whether efivarfs is mounted read-write.
+efi_mount_is_rw() {
+    opts="$(efi_mount_options)"
+
+    printf '%s\n' "$opts" | grep -Eq '(^|,)rw(,|$)'
+}
+
+# Restore efivarfs to read-only when this test temporarily remounted it
+# read-write. This prevents leaving the target in a different mount state.
+efi_restore_efivarfs_ro() {
+    if [ "$EFIVARFS_RESTORE_RO" != "1" ]; then
+        return 0
+    fi
+
+    log_info "Restoring efivarfs mount to read-only"
+
+    if mount -o remount,ro "$EFIVARFS_PATH" >/dev/null 2>&1; then
+        log_info "efivarfs restored to read-only"
+        EFIVARFS_RESTORE_RO=0
+        return 0
+    fi
+
+    if mount -t efivarfs -o remount,ro efivarfs "$EFIVARFS_PATH" >/dev/null 2>&1; then
+        log_info "efivarfs restored to read-only"
+        EFIVARFS_RESTORE_RO=0
+        return 0
+    fi
+
+    log_warn "Could not restore efivarfs to read-only"
+    return 1
+}
+
+# Install cleanup trap for efivarfs remount restore.
+# Call this from EFI tests before attempting temporary remount,rw.
+efi_install_restore_trap() {
+    trap efi_restore_efivarfs_ro EXIT HUP INT TERM
+}
+
+# Try to temporarily remount efivarfs read-write.
+#
+# Return 0 only if efivarfs becomes read-write.
+# If this function changes efivarfs from ro to rw, it sets EFIVARFS_RESTORE_RO=1
+# so efi_restore_efivarfs_ro can restore the original read-only state.
+#
+# Caller may define:
+# EFI_REMOUNT_LOG
+efi_try_remount_rw() {
+    remount_log="${EFI_REMOUNT_LOG:-./efi_efivarfs_remount.log}"
+
+    : > "$remount_log" 2>/dev/null || true
+
+    if efi_mount_is_rw; then
+        log_info "efivarfs is already mounted read-write"
+        return 0
+    fi
+
+    if ! efi_mount_exists; then
+        log_warn "efivarfs is not listed as a mounted filesystem"
+        return 1
+    fi
+
+    log_warn "efivarfs is mounted read-only, attempting temporary remount as read-write"
+
+    if mount -o remount,rw "$EFIVARFS_PATH" > "$remount_log" 2>&1; then
+        if efi_mount_is_rw; then
+            EFIVARFS_RESTORE_RO=1
+            log_pass "efivarfs remounted read-write"
+            return 0
+        fi
+    fi
+
+    if mount -t efivarfs -o remount,rw efivarfs "$EFIVARFS_PATH" >> "$remount_log" 2>&1; then
+        if efi_mount_is_rw; then
+            EFIVARFS_RESTORE_RO=1
+            log_pass "efivarfs remounted read-write"
+            return 0
+        fi
+    fi
+
+    log_warn "efivarfs remount read-write failed"
+    system_log_file_excerpt "efivarfs-remount" "$remount_log" 40
+    return 1
+}
+
+# Check whether an EFI variable was reported by efivar -l.
+#
+# Caller must define:
+# EFI_LIST_LOG
+efi_variable_list_contains() {
+    var_name="$1"
+
+    if [ -z "${EFI_LIST_LOG:-}" ]; then
+        log_warn "EFI_LIST_LOG is not set"
+        return 1
+    fi
+
+    grep -Fxq "$var_name" "$EFI_LIST_LOG" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Compatibility wrappers for existing EFI_Variable_Validation/run.sh names
+# ---------------------------------------------------------------------------
+# These wrappers let existing tests move helpers to lib_system.sh with minimal
+# run.sh churn. New callers should prefer the prefixed function names above.
+
+write_trial_boot_status_payload() {
+    efi_write_trial_boot_status_payload "$@"
+}
+
+log_file_excerpt() {
+    system_log_file_excerpt "$@"
+}
+
+require_grep_in_file() {
+    system_require_grep_in_file "$@"
+}
+
+require_hex_payload_in_file() {
+    efi_require_trial_boot_status_payload "$@"
+}
+
+require_os_indications_supported_value() {
+    efi_require_os_indications_supported_value "$@"
+}


### PR DESCRIPTION
This PR improves `EFI_Variable_Validation` to handle platform-specific EFI runtime behavior more robustly and introduces a reusable System-suite helper library.
 
The change adds:
 
- `Runner/utils/[lib_system.sh](http://lib_system.sh/)`
- Updated `Runner/suites/System/EFI_Variable_Validation/[run.sh](http://run.sh/)`
 
## Why this PR is needed
 
EFI variable behavior is firmware and platform dependent. In LAVA runs, the current EFI validation test can fail even when the kernel EFI configuration and EFI runtime filesystem are present.
 
Observed failures include:
 
```text
efivar: error listing variables: Function not implemented