### PR TITLE
Modify URM Test Runner

### DIFF
--- a/Runner/suites/Performance/userspace-resource-manager/run.sh
+++ b/Runner/suites/Performance/userspace-resource-manager/run.sh
@@ -43,22 +43,34 @@ test_path="$(find_test_case_by_name "$TESTNAME")"
 cd "$test_path" || exit 1
 RES_FILE="./${TESTNAME}.res"
 
+log_info "=== Checking Dependencies ==="
+if ! check_dependencies awk grep pgrep date printf; then
+    log_skip "$TESTNAME SKIP – base tools missing"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
 # ---------- Lock (avoid concurrent runs on same host) ----------
 LOCKFILE="/tmp/${TESTNAME}.lock"
+LOCKDIR="/tmp/${TESTNAME}.lockdir"
+
 if command -v flock >/dev/null 2>&1; then
   exec 9>"$LOCKFILE"
   if ! flock -n 9; then
     log_warn "Another ${TESTNAME} run is active; skipping"
+    log_info "Active URM-related processes:"
+    pgrep -af 'userspace-resource-manager|Urm(Component|Integration)Tests|run.sh' || true
     echo "$TESTNAME SKIP" >"$RES_FILE"
     exit 0
   fi
+  trap 'exec 9>&-' EXIT INT TERM
 else
-  if ! mkdir "$LOCKFILE" 2>/dev/null; then
-    log_warn "Another ${TESTNAME} run is active; skipping"
+  if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    log_warn "Another ${TESTNAME} run is active or stale fallback lockdir exists: $LOCKDIR"
     echo "$TESTNAME SKIP" >"$RES_FILE"
     exit 0
   fi
-  trap 'rmdir "$LOCKFILE" 2>/dev/null || true' EXIT INT TERM
+  trap 'rmdir "$LOCKDIR" 2>/dev/null || true' EXIT INT TERM
 fi
 
 # ---------- Approved list (pinned whitelist) ----------
@@ -147,16 +159,6 @@ suite_requires_base_cfgs() {
     done
     return 1
 }
-parse_and_score_log() {
-    logf="$1"
-    if grep -Eiq '(^|[^a-z])fail(ed)?([^a-z]|$)|Assertion failed|Terminating Suite|Segmentation fault|Backtrace' "$logf"; then
-        return 1
-    fi
-    if grep -Eiq 'Run Successful|executed successfully|Ran Successfully' "$logf"; then
-        return 0
-    fi
-    return 2
-}
 per_suite_timeout() {
     case "$1" in
         UrmComponentTests)
@@ -185,11 +187,6 @@ run_cmd_maybe_timeout() {
 log_info "----------------------------------------------------------------------"
 log_info "------------------- Starting ${TESTNAME} Testcase ----------------------"
 log_info "=== Test Initialization ==="
-if ! check_dependencies awk grep date printf; then
-    log_skip "$TESTNAME SKIP – base tools missing"
-    echo "$TESTNAME SKIP" >"$RES_FILE"
-    exit 0
-fi
 
 # ---------- Logs ----------
 TS="$(date +%Y%m%d-%H%M%S)"
@@ -398,13 +395,7 @@ run_one() {
     run_cmd_maybe_timeout "$bin" >"$tlog" 2>&1
     rc=$?
 
-    parse_and_score_log "$tlog"
-    score=$?
-    if [ $score -eq 2 ] && [ $rc -eq 0 ]; then
-        score=0
-    fi
-
-    case $score in
+    case $rc in
         0)
             log_pass "[TEST] $name PASS"
             echo "PASS" >"$tres"
@@ -417,11 +408,11 @@ run_one() {
             echo "[FAIL] $name (rc=$rc)" >>"$LOGDIR/summary.txt"
             return 1
             ;;
-        2)
-            log_skip "[TEST] $name SKIP"
-            echo "SKIP" >"$tres"
-            echo "[SKIP] $name (rc=$rc)" >>"$LOGDIR/summary.txt"
-            return 2
+        *)
+            log_fail "[TEST] $name UNKNOWN RC=$rc"
+            echo "FAIL" >"$tres"
+            echo "[FAIL] $name (unexpected rc=$rc)" >>"$LOGDIR/summary.txt"
+            return 1
             ;;
     esac
 }


### PR DESCRIPTION
- Add support to delete any stale lock files created in previous runs
- Remove log-based result mapping (parse_and_score_log) and solely rely on the return code (0 or 1). The URM Test Runner already handles the return code, which the script can rely on. Judging pass / fail based on the logs results in some false positives.
- Modify test skip logic, a suite should only be skipped if it is not in the approved list, of if the required configs are not found, or if the test executable itself is absent. Skipping of one or more tests part of the testsuite, should not result in an overall SKIP qualification, it should be either PASS OR FAIL.