### PR TITLE
AudioRecord: skip when no real capture source is available

### DIFF
--- a/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
+++ b/Runner/suites/Multimedia/Audio/AudioRecord/run.sh
@@ -511,10 +511,34 @@ case "$AUDIO_BACKEND:$SRC_CHOICE" in
 esac
 
 # ---- Dynamic fallback when mic is missing on the chosen backend ----
-# Stay on PipeWire even if SRC_ID is empty; pw-record can use the default source.
+# For real mic capture, do not allow PipeWire to record from an implicit
+# default source when no concrete source was discovered. On systems without
+# a real capture source, this can record from dummy/null/default paths or fail
+# after creating empty files.
+if [ -z "$SRC_ID" ] && [ "$SRC_CHOICE" = "mic" ] && [ "$AUDIO_BACKEND" = "pipewire" ]; then
+  log_warn "$TESTNAME: no concrete PipeWire mic source found; probing direct ALSA capture path"
+ 
+  if audio_probe_alsa_capture_profile; then
+    ALSA_CAPTURE_PROBED=1
+    AUDIO_BACKEND="alsa"
+    AUDIO_SYSTEMD_MANAGED=0
+    export AUDIO_SYSTEMD_MANAGED
+ 
+    SRC_ID="$AUDIO_ALSA_CAPTURE_DEVICE"
+    SRC_LABEL="$SRC_ID"
+ 
+    log_warn "$TESTNAME: falling back to direct ALSA capture device: $SRC_ID"
+  else
+    log_skip "$TESTNAME SKIP - no real capture source available; PipeWire mic source missing and ALSA capture probe failed: ${AUDIO_ALSA_CAPTURE_REASON:-capture path unavailable}"
+    echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
+    exit 0
+  fi
+fi
+ 
 if [ -z "$SRC_ID" ] && [ "$SRC_CHOICE" = "mic" ] && [ "$AUDIO_BACKEND" != "pipewire" ]; then
   for b in $BACKENDS_TO_TRY; do
     [ "$b" = "$AUDIO_BACKEND" ] && continue
+ 
     case "$b" in
       pipewire)
         cand="$(pw_default_mic)"
@@ -535,16 +559,27 @@ if [ -z "$SRC_ID" ] && [ "$SRC_CHOICE" = "mic" ] && [ "$AUDIO_BACKEND" != "pipew
         fi
         ;;
       alsa)
-        cand="$(alsa_pick_capture)"
-        if [ -n "$cand" ]; then
+        if audio_probe_alsa_capture_profile; then
+          ALSA_CAPTURE_PROBED=1
           AUDIO_BACKEND="alsa"
-          SRC_ID="$cand"
+          AUDIO_SYSTEMD_MANAGED=0
+          export AUDIO_SYSTEMD_MANAGED
+ 
+          SRC_ID="$AUDIO_ALSA_CAPTURE_DEVICE"
+          SRC_LABEL="$SRC_ID"
+ 
           log_info "Falling back to backend: alsa (device=$SRC_ID)"
           break
         fi
         ;;
     esac
   done
+fi
+ 
+if [ -z "$SRC_ID" ]; then
+  log_skip "$TESTNAME SKIP - requested source '$SRC_CHOICE' not available on any backend (${BACKENDS_TO_TRY:-unknown})"
+  echo "$RESULT_TESTNAME SKIP" > "$RES_FILE"
+  exit 0
 fi
 
 # Only skip if no source AND not on PipeWire.
@@ -592,7 +627,7 @@ fi
 if [ "$AUDIO_BACKEND" = "pipewire" ]; then
   if [ -n "$SRC_ID" ]; then
     SRC_LABEL="$(pw_source_label_safe "$SRC_ID")"
-    wpctl set-default "$SRC_ID" >/dev/null 2>&1 || true
+    pw_set_default_source "$SRC_ID" >/dev/null 2>&1 || true
     [ -z "$SRC_LABEL" ] && SRC_LABEL="unknown"
     log_info "Routing to source: id/name=$SRC_ID label='$SRC_LABEL' choice=$SRC_CHOICE"
   else


### PR DESCRIPTION
Update AudioRecord to avoid running PipeWire mic recording through an implicit default source when no concrete PipeWire capture source is discovered.
The previous flow allowed --source mic to continue with backend=pipewire even when SRC_ID was empty. In that case, the test attempted pw-record against the default source and then fell back to arecord -D pipewire. On systems with no real capture source, this can lead to empty recordings and false CI failures. This fixes the issue on qualcomm-linux/meta-qcom#2127

Why
Some platforms may boot with PipeWire/WirePlumber running but without a real audio capture source exposed. In that case, recording from an implicit PipeWire default source is not a valid mic capture test.
The updated behavior makes the test capability-aware:

- real PipeWire capture source available: run PipeWire recording
- PipeWire source missing but ALSA capture works: run direct ALSA recording
- no real capture path available: skip instead of fail

This avoids treating missing capture hardware or missing capture exposure as a PipeWire recording regression.