### PR TITLE
Ethernet: fail on MAC/PHY bring-up errors and suppress noisy carrier reads

### DIFF
--- a/Runner/suites/Connectivity/Ethernet/run.sh
+++ b/Runner/suites/Connectivity/Ethernet/run.sh
@@ -151,6 +151,33 @@ for iface in $ETH_IFACES; do
         ip link show "$iface" 2>/dev/null | while IFS= read -r l; do [ -n "$l" ] && log_info "[ip-link] $l"; done
         ethtool "$iface" 2>/dev/null | sed -n '1,80p' | while IFS= read -r l; do [ -n "$l" ] && log_info "[ethtool] $l"; done
 
+        eth_dmesg_errors="./${iface}_ethernet_dmesg_errors.log"
+        rm -f ./dmesg_errors.log ./dmesg_snapshot.log ./dmesg_errors_*.log "$eth_dmesg_errors" 2>/dev/null || true
+
+        log_info "$iface: scanning kernel log for Ethernet MAC/PHY/phylink errors before classifying no-link"
+
+        scan_dmesg_errors \
+            "$test_path" \
+            "qcom-ethqos|stmmac|phylink|QCA808|qca808|qca808x|2500base|2500base-x|sgmii|xgmac|dwmac" \
+            "Link is Down|Link down|Link detected: no|carrier lost|no carrier|Network is down|Register MEM_TYPE_PAGE_POOL" || true
+
+        if [ -s ./dmesg_errors.log ]; then
+            cp ./dmesg_errors.log "$eth_dmesg_errors" 2>/dev/null || true
+
+            log_fail "$iface: Ethernet driver/PHY errors detected; not treating as no-cable"
+            log_info "$iface: filtered Ethernet kernel errors follow:"
+            log_info "$iface: source=$eth_dmesg_errors"
+
+            while IFS= read -r line || [ -n "$line" ]; do
+                [ -n "$line" ] || continue
+                log_info "[eth-kernel:$iface] $line"
+            done < ./dmesg_errors.log
+
+            echo "$iface: FAIL (Ethernet MAC/PHY/phylink kernel errors during link bring-up)" >>"$summary_file"
+            any_tested=1
+            continue
+        fi
+
         if [ "$carrier" = "0" ]; then
             log_warn "$iface: no link detected (carrier=0); treating as no-cable and skipping"
             echo "$iface: SKIP (no cable/link; carrier=0)" >>"$summary_file"

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -2579,39 +2579,46 @@ ethLinkDetected() {
 
 ethIsLinkUp() {
     iface=$1
+    carrier=""
+    st=""
+    ld=""
+ 
     [ -n "$iface" ] || return 1
  
-    # 1) If carrier says 1, we are good (fast path)
+    # 1) If carrier says 1, we are good.
+    # Some drivers return EINVAL while MAC/PHY attach is broken or incomplete.
+    # Suppress stderr to avoid noisy LAVA stdout.
     if [ -r "/sys/class/net/$iface/carrier" ]; then
-        [ "$(cat "/sys/class/net/$iface/carrier" 2>/dev/null)" = "1" ] && return 0
-        # If carrier is 0, do NOT return yet — fall through to other hints.
+        carrier="$(cat "/sys/class/net/$iface/carrier" 2>/dev/null || true)"
+        [ "$carrier" = "1" ] && return 0
     fi
  
-    # 2) If helper exists and says up, accept it (but don't fail early)
+    # 2) If helper exists and says up, accept it.
     if command -v is_link_up >/dev/null 2>&1; then
-        is_link_up "$iface" && return 0
+        is_link_up "$iface" >/dev/null 2>&1 && return 0
     fi
  
-    # 3) operstate can sometimes reflect link sooner than carrier in some stacks
+    # 3) operstate can sometimes reflect link sooner than carrier.
     if [ -r "/sys/class/net/$iface/operstate" ]; then
-        st=$(cat "/sys/class/net/$iface/operstate" 2>/dev/null || true)
+        st="$(cat "/sys/class/net/$iface/operstate" 2>/dev/null || true)"
         [ "$st" = "up" ] && return 0
     fi
  
-    # 4) ip link LOWER_UP (physical) is a good signal if ip exists
+    # 4) ip link LOWER_UP is a useful physical-link signal.
     if command -v ip >/dev/null 2>&1; then
         ip link show "$iface" 2>/dev/null | grep -qw "LOWER_UP" && return 0
     fi
  
-    # 5) Last resort: ethtool parse
+    # 5) Last resort: ethtool parse.
     if command -v ethtool >/dev/null 2>&1; then
-        ld=$(ethtool "$iface" 2>/dev/null | awk -F': ' '/^[[:space:]]*Link detected:/ {print $2; exit 0}' || true)
+        ld="$(ethtool "$iface" 2>/dev/null |
+            awk -F': ' '/^[[:space:]]*Link detected:/ {print $2; exit 0}' || true)"
         [ "$ld" = "yes" ] && return 0
     fi
  
     return 1
 }
- 
+
 ethWaitLinkUp() {
     iface=$1
     timeout_s=$2


### PR DESCRIPTION
Improve Ethernet CI diagnostics and result classification.

This change suppresses noisy `/sys/class/net/<iface>/carrier` read errors in `ethIsLinkUp()` and treats unreadable carrier state as unknown so the existing fallback checks can continue.

It also updates the Ethernet test to scan kernel logs for focused MAC/PHY/phylink errors before classifying link bring-up failure as a no-cable skip.

Issue on some platforms. 
Some Ethernet drivers return `EINVAL` when reading the carrier file while MAC/PHY attach is not complete. The resulting `cat` errors pollute LAVA logs.

Also, the test previously treated `carrier=0` or `ethtool Link detected: no` as a no-cable condition even when the kernel showed real errors such as:

```text
qcom-ethqos ... validation of 2500base-x ... failed: -EINVAL
qcom-ethqos ... cannot attach to PHY (error: -EINVAL)
