### PR TITLE
ci: keep ShellCheck strict for all shell files

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -61,31 +61,11 @@ jobs:
           tr '\0' '\n' < "$files_list"
 
           xargs -0 -r sh -c '
-            is_functestlib() {
-              lint_file_path="$1"
-
-              case "$lint_file_path" in
-                ./Runner/utils/functestlib.sh|Runner/utils/functestlib.sh)
-                  return 0
-                  ;;
-              esac
-
-              return 1
-            }
-
             run_shellcheck() {
               lint_file_path="$1"
-              base_excludes="SC1091,SC2230,SC3043"
-              lint_excludes="$base_excludes"
 
-              if is_functestlib "$lint_file_path"; then
-                lint_excludes="${base_excludes},SC2317"
-                echo "ShellCheck functestlib mode: $lint_file_path"
-              else
-                echo "ShellCheck strict mode: $lint_file_path"
-              fi
-
-              shellcheck -s sh -e "$lint_excludes" -- "$lint_file_path"
+              echo "ShellCheck strict mode: $lint_file_path"
+              shellcheck -s sh -e SC1091,SC2230,SC3043 -- "$lint_file_path"
             }
 
             rc=0
@@ -116,31 +96,11 @@ jobs:
           fi
 
           xargs -0 -r sh -c '
-            is_functestlib() {
-              lint_file_path="$1"
-
-              case "$lint_file_path" in
-                ./Runner/utils/functestlib.sh|Runner/utils/functestlib.sh)
-                  return 0
-                  ;;
-              esac
-
-              return 1
-            }
-
             run_shellcheck() {
               lint_file_path="$1"
-              base_excludes="SC1091,SC2230,SC3043"
-              lint_excludes="$base_excludes"
 
-              if is_functestlib "$lint_file_path"; then
-                lint_excludes="${base_excludes},SC2317"
-                echo "ShellCheck functestlib mode: $lint_file_path"
-              else
-                echo "ShellCheck strict mode: $lint_file_path"
-              fi
-
-              shellcheck -s sh -e "$lint_excludes" -- "$lint_file_path"
+              echo "ShellCheck strict mode: $lint_file_path"
+              shellcheck -s sh -e SC1091,SC2230,SC3043 -- "$lint_file_path"
             }
 
             rc=0
@@ -153,3 +113,4 @@ jobs:
 
             exit "$rc"
           ' sh < "$files_list"
+


### PR DESCRIPTION
Remove the `[functestlib.sh](http://functestlib.sh/)`-specific `SC2317` exception from the ShellCheck workflow and keep ShellCheck strict for all shell files.
 
## Why
 
The earlier `SC2317` failures in `Runner/utils/[functestlib.sh](http://functestlib.sh/)` were caused by duplicate helper entries, not because the workflow needed a permanent exception for `[functestlib.sh](http://functestlib.sh/)`.
 
Since the duplicate entries have been addressed, `[functestlib.sh](http://functestlib.sh/)` should be linted with the same ShellCheck policy as the rest of the repository.