### PR TITLE
OpenCV: add bounded smoke binary list for CI

### DIFF
--- a/Runner/suites/Multimedia/OpenCV/OpenCV.yaml
+++ b/Runner/suites/Multimedia/OpenCV/OpenCV.yaml
@@ -9,22 +9,23 @@ metadata:
 
 params:
   BIN_PATH: "" # --bin <path|name>
+  BIN_LIST: "opencv_test_sfm" # --bin-list "bin1 bin2 ..."
   BUILD_DIR: "." # --build-dir
   CWD: "." # --cwd
-  TESTDATA_PATH: "" # --testdata
+  TESTDATA_PATH: "/var/testdata" # --testdata
   EXTRA_ARGS: "" # --args "..."
-  TIMEOUT_SECS: "" # --timeout N
+  TIMEOUT_SECS: "120" # --timeout N
   SUITE: "all" # --suite accuracy|performance|all
   LIST_ONLY: 0 # --list
   REPEAT: "" # --repeat N
   SHUFFLE: 0 # --shuffle
   SEED: "" # --seed N
-  PERF_ARGS: "" # --perf-args "<common perf args>"
-  PERF_TO_TESTS: 0 # --perf-to-tests (apply PERF_ARGS to opencv_test_* too)
+  PERF_ARGS: "--perf_min_samples=10 --perf_force_samples=10" # --perf-args "<common perf args>"
+  PERF_TO_TESTS: 1 # --perf-to-tests, apply PERF_ARGS to opencv_test_* too
 
 run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/OpenCV
-    - ./run.sh --bin "${BIN_PATH}" --build-dir "${BUILD_DIR}" --cwd "${CWD}" --testdata "${TESTDATA_PATH}" --args "${EXTRA_ARGS}" --timeout "${TIMEOUT_SECS}" --suite "${SUITE}" $( [ "${LIST_ONLY}" = "1" ] && printf '%s' "--list" ) --repeat "${REPEAT}" $( [ "${SHUFFLE}" = "1" ] && printf '%s' "--shuffle" ) $( [ -n "${SEED}" ] && printf '%s %s' "--seed" "${SEED}" ) --perf-args "${PERF_ARGS}" $( [ "${PERF_TO_TESTS}" = "1" ] && printf '%s' "--perf-to-tests" ) || true
+    - ./run.sh --bin "${BIN_PATH}" --bin-list "${BIN_LIST}" --build-dir "${BUILD_DIR}" --cwd "${CWD}" --testdata "${TESTDATA_PATH}" --args "${EXTRA_ARGS}" --timeout "${TIMEOUT_SECS}" --suite "${SUITE}" $( [ "${LIST_ONLY}" = "1" ] && printf '%s' "--list" ) --repeat "${REPEAT}" $( [ "${SHUFFLE}" = "1" ] && printf '%s' "--shuffle" ) $( [ -n "${SEED}" ] && printf '%s %s' "--seed" "${SEED}" ) --perf-args "${PERF_ARGS}" $( [ "${PERF_TO_TESTS}" = "1" ] && printf '%s' "--perf-to-tests" ) || true
     - $REPO_PATH/Runner/utils/send-to-lava.sh OpenCV.res || true

--- a/Runner/suites/Multimedia/OpenCV/run.sh
+++ b/Runner/suites/Multimedia/OpenCV/run.sh
@@ -50,6 +50,7 @@ DEFAULT_FILTER="-tracking_GOTURN.GOTURN/*"
 CLI_FILTER=""
 
 BIN_PATH="" # --bin <path|name>
+BIN_LIST="" # --bin-list "bin1 bin2 ..."
 BUILD_DIR="." # --build-dir
 CWD="." # --cwd
 TESTDATA_PATH="" # --testdata
@@ -67,6 +68,7 @@ print_usage() {
     cat <<EOF
 Usage: $0 [options]
   --bin <path|name> Run a single OpenCV gtest/perf binary (overrides --suite)
+  --bin-list "<bin1 bin2 ...>" Run selected OpenCV binaries and aggregate result
   --build-dir <path> Root to search for binaries (default: .)
   --suite <name> accuracy | performance | all (default: all)
   --filter <pattern> gtest filter for all runs (default from env or "-tracking_GOTURN.GOTURN/*")
@@ -90,6 +92,7 @@ EOF
 while [ $# -gt 0 ]; do
     case "$1" in
         --bin) BIN_PATH="$2"; shift 2 ;;
+	--bin-list) BIN_LIST="$2"; shift 2 ;;
         --build-dir) BUILD_DIR="$2"; shift 2 ;;
         --suite) SUITE="$2"; shift 2 ;;
         --filter) CLI_FILTER="$2"; shift 2 ;;
@@ -260,7 +263,15 @@ run_one() {
         fi
     ) >"$run_log" 2>&1
     rc=$?
-    [ "$rc" -eq 124 ] && rc=1 # timeout => fail
+    timed_out=0
+
+    case "$rc" in
+        124|137|143)
+            if [ -n "$TIMEOUT_SECS" ]; then
+                timed_out=1
+            fi
+            ;;
+    esac
 
     if [ "$rc" -eq 0 ] && parse_zero_tests_as_skip "$run_log"; then
         log_skip "$bin_short : No tests executed — SKIP"
@@ -276,13 +287,18 @@ run_one() {
         append_summary "$bin_short" "PASS" "$run_log"
         log_info "----- END $bin_short (rc=0, PASS) @ $(date '+%Y-%m-%d %H:%M:%S') -----"
         return 0
+    fi
+
+    if [ "$timed_out" -eq 1 ]; then
+        log_fail "$bin_short : FAIL/TIMEOUT after ${TIMEOUT_SECS}s (exit=$rc). See: $run_log"
     else
         log_fail "$bin_short : FAIL (exit=$rc). See: $run_log"
-        echo "$bin_short FAIL" >> "$RESLIST_FILE"
-        append_summary "$bin_short" "FAIL" "$run_log"
-        log_info "----- END $bin_short (rc=$rc, FAIL) @ $(date '+%Y-%m-%d %H:%M:%S') -----"
-        return 1
     fi
+
+    echo "$bin_short FAIL" >> "$RESLIST_FILE"
+    append_summary "$bin_short" "FAIL" "$run_log"
+    log_info "----- END $bin_short (rc=$rc, FAIL) @ $(date '+%Y-%m-%d %H:%M:%S') -----"
+    return 1 
 }
 
 discover_bins() {
@@ -351,6 +367,53 @@ if [ -n "$BIN_PATH" ]; then
         2) echo "$TESTNAME SKIP" > "$RES_FILE"; exit 2 ;;
         *) echo "$TESTNAME FAIL" > "$RES_FILE"; exit 1 ;;
     esac
+fi
+
+# ----- selected binary list mode: bounded CI smoke set -----
+if [ -n "$BIN_LIST" ]; then
+    PASS=0
+    FAIL=0
+    SKIP=0
+
+    for BIN_SHORT in $BIN_LIST; do
+        [ -n "$BIN_SHORT" ] || continue
+
+        run_one "$BIN_SHORT" ""
+        rc=$?
+
+        if [ "$rc" -eq 0 ]; then
+            PASS=$((PASS + 1))
+        elif [ "$rc" -eq 2 ]; then
+            SKIP=$((SKIP + 1))
+        else
+            FAIL=$((FAIL + 1))
+        fi
+    done
+
+    echo ""
+    echo "========= OpenCV Suite Summary ========="
+    printf "%-32s %-4s %s\n" "TEST" "RES" "LOG"
+    cat "$SUMMARY_FILE"
+    echo "----------------------------------------"
+    echo "Totals: PASS=$PASS FAIL=$FAIL SKIP=$SKIP"
+
+    if [ "$FAIL" -gt 0 ]; then
+        echo "$TESTNAME FAIL" > "$RES_FILE"
+        exit 1
+    fi
+
+    if [ "$PASS" -gt 0 ]; then
+        echo "$TESTNAME PASS" > "$RES_FILE"
+        exit 0
+    fi
+
+    if [ "$SKIP" -gt 0 ]; then
+        echo "$TESTNAME SKIP" > "$RES_FILE"
+        exit 2
+    fi
+
+    echo "$TESTNAME SKIP" > "$RES_FILE"
+    exit 2
 fi
 
 # ----- build suite selection -----


### PR DESCRIPTION
Limit the default OpenCV CI execution to a bounded smoke set instead of running the full discovered OpenCV suite.
 
The OpenCV YAML currently defaults to:
 
- `BIN_PATH=""`
- `SUITE=all`
 
This causes `[run.sh](http://run.sh/)` to discover and run all `opencv_test_*` and `opencv_perf_*` binaries. In LAVA jobs with a shared `lava-test-shell` timeout, the full OpenCV suite can consume the shell timeout before `OpenCV.res` is written. When that happens, LAVA marks OpenCV and all following test definitions as missing failures.
 
This change adds a repo-standard `--bin-list` mode in `OpenCV/[run.sh](http://run.sh/)` and keeps the YAML run steps simple.
 
Default CI smoke binaries:
 
- `opencv_test_core`
- `opencv_test_sfm`

Reference job with the current patch - https://lava.infra.foundries.io/scheduler/job/255904