### PR TITLE
hotplug: defer transient EBUSY CPUs before failing

### DIFF
--- a/Runner/suites/Kernel/Baseport/hotplug/run.sh
+++ b/Runner/suites/Kernel/Baseport/hotplug/run.sh
@@ -47,9 +47,14 @@ res_file="./$TESTNAME.res"
 out_dir="./out"
 
 HOTPLUG_BOOT_SETTLE_SECONDS="${HOTPLUG_BOOT_SETTLE_SECONDS:-10}"
-HOTPLUG_RETRIES=3
-HOTPLUG_RETRY_DELAY_SECONDS=5
-HOTPLUG_RESTORE_DELAY_SECONDS=1
+HOTPLUG_RETRIES="${HOTPLUG_RETRIES:-3}"
+HOTPLUG_RETRY_DELAY_SECONDS="${HOTPLUG_RETRY_DELAY_SECONDS:-5}"
+HOTPLUG_RESTORE_DELAY_SECONDS="${HOTPLUG_RESTORE_DELAY_SECONDS:-1}"
+
+# If a CPU returns persistent EBUSY during the first pass, do not fail
+# immediately. Continue with other CPUs and retry EBUSY CPUs at the end.
+HOTPLUG_DEFER_EBUSY="${HOTPLUG_DEFER_EBUSY:-1}"
+HOTPLUG_DEFER_PASSES="${HOTPLUG_DEFER_PASSES:-1}"
 
 # Optional debug-only override. Empty means runtime-discover all online CPUs.
 HOTPLUG_CPU_LIST="${HOTPLUG_CPU_LIST:-}"
@@ -64,7 +69,7 @@ log_info "----------------------------------------------------------------------
 log_info "-------------------Starting $TESTNAME Testcase----------------------------"
 log_info "=== Test Initialization ==="
 log_info "Policy, runtime-discovered CPU hotplug validation"
-log_info "Config, BOOT_SETTLE=${HOTPLUG_BOOT_SETTLE_SECONDS}s RETRIES=$HOTPLUG_RETRIES RETRY_DELAY=${HOTPLUG_RETRY_DELAY_SECONDS}s RESTORE_DELAY=${HOTPLUG_RESTORE_DELAY_SECONDS}s"
+log_info "Config, BOOT_SETTLE=${HOTPLUG_BOOT_SETTLE_SECONDS}s RETRIES=$HOTPLUG_RETRIES RETRY_DELAY=${HOTPLUG_RETRY_DELAY_SECONDS}s RESTORE_DELAY=${HOTPLUG_RESTORE_DELAY_SECONDS}s DEFER_EBUSY=$HOTPLUG_DEFER_EBUSY DEFER_PASSES=$HOTPLUG_DEFER_PASSES"
 
 if [ -n "$HOTPLUG_CPU_LIST" ]; then
     log_info "CPU selection override, HOTPLUG_CPU_LIST=$HOTPLUG_CPU_LIST"
@@ -95,6 +100,12 @@ fi
 
 if ! check_kernel_config "CONFIG_HOTPLUG_CPU"; then
     log_fail "CONFIG_HOTPLUG_CPU is required for CPU hotplug validation"
+    echo "$TESTNAME FAIL" > "$res_file"
+    exit 1
+fi
+
+if ! command -v cpu_hotplug_validate_cpu_once >/dev/null 2>&1; then
+    log_fail "cpu_hotplug_validate_cpu_once helper is missing from functestlib.sh"
     echo "$TESTNAME FAIL" > "$res_file"
     exit 1
 fi
@@ -139,127 +150,102 @@ tested=0
 passed=0
 failed=0
 skipped=0
+deferred=0
+deferred_cpus=""
 
+case "$HOTPLUG_RETRIES" in
+    ''|*[!0-9]*)
+        HOTPLUG_RETRIES=3
+        ;;
+esac
+
+case "$HOTPLUG_RETRY_DELAY_SECONDS" in
+    ''|*[!0-9]*)
+        HOTPLUG_RETRY_DELAY_SECONDS=5
+        ;;
+esac
+
+case "$HOTPLUG_RESTORE_DELAY_SECONDS" in
+    ''|*[!0-9]*)
+        HOTPLUG_RESTORE_DELAY_SECONDS=1
+        ;;
+esac
+
+case "$HOTPLUG_DEFER_PASSES" in
+    ''|*[!0-9]*)
+        HOTPLUG_DEFER_PASSES=1
+        ;;
+esac
+
+if [ "$HOTPLUG_DEFER_PASSES" -lt 1 ] 2>/dev/null; then
+    HOTPLUG_DEFER_PASSES=1
+fi
+
+# Primary pass:
+# Test all selected CPUs once. CPUs that return persistent EBUSY are not failed
+# immediately when deferral is enabled; they are retried after the other CPUs.
 for cpu_index in $selected_cpus; do
-    log_info "----- Testing CPU$cpu_index -----"
+    cpu_hotplug_validate_cpu_once \
+        "$cpu_index" \
+        "primary" \
+        "$HOTPLUG_RETRIES" \
+        "$HOTPLUG_RETRY_DELAY_SECONDS" \
+        "$HOTPLUG_RESTORE_DELAY_SECONDS" \
+        "$out_dir"
 
-    if ! cpu_hotplug_in_online_mask "$cpu_index"; then
-        log_skip "CPU$cpu_index is not present in the current online CPU mask"
-        skipped=$((skipped + 1))
-        continue
+    cpu_rc=$?
+
+    if [ "$cpu_rc" -eq 2 ]; then
+        if [ "$HOTPLUG_DEFER_EBUSY" = "1" ]; then
+            log_warn "CPU$cpu_index EBUSY persisted during primary pass; deferring until after other CPUs"
+            deferred_cpus="${deferred_cpus} ${cpu_index}"
+            deferred=$((deferred + 1))
+        else
+            log_fail "CPU$cpu_index failed due to persistent EBUSY and deferral is disabled"
+            failed=$((failed + 1))
+        fi
     fi
+done
 
-    online_file="$(cpu_hotplug_control_file "$cpu_index")"
+# Deferred pass:
+# Retry only CPUs that were busy in the primary pass. This handles early boot
+# transient EBUSY without hiding real persistent hotplug failures.
+defer_pass=1
+while [ -n "$deferred_cpus" ] && [ "$defer_pass" -le "$HOTPLUG_DEFER_PASSES" ]; do
+    retry_cpus="$deferred_cpus"
+    deferred_cpus=""
 
-    if [ ! -e "$online_file" ]; then
-        log_skip "CPU$cpu_index has no online control file; not hotplug-controllable on this platform"
-        skipped=$((skipped + 1))
-        continue
-    fi
+    log_info "Retrying EBUSY-deferred CPUs, deferred pass ${defer_pass}/${HOTPLUG_DEFER_PASSES}:$retry_cpus"
 
-    if [ ! -w "$online_file" ]; then
-        log_skip "CPU$cpu_index online control file is not writable; not hotplug-controllable in this environment"
-        skipped=$((skipped + 1))
-        continue
-    fi
+    for cpu_index in $retry_cpus; do
+        cpu_hotplug_validate_cpu_once \
+            "$cpu_index" \
+            "deferred-${defer_pass}" \
+            "$HOTPLUG_RETRIES" \
+            "$HOTPLUG_RETRY_DELAY_SECONDS" \
+            "$HOTPLUG_RESTORE_DELAY_SECONDS" \
+            "$out_dir"
 
-    controllable=$((controllable + 1))
+        cpu_rc=$?
 
-    cpu_is_schedulable "$cpu_index"
-    sched_rc=$?
+        if [ "$cpu_rc" -eq 2 ]; then
+            if [ "$defer_pass" -lt "$HOTPLUG_DEFER_PASSES" ]; then
+                log_warn "CPU$cpu_index still EBUSY; keeping for another deferred pass"
+                deferred_cpus="${deferred_cpus} ${cpu_index}"
+            else
+                log_fail "CPU$cpu_index remained EBUSY after deferred retry handling"
+                failed=$((failed + 1))
+            fi
+        fi
+    done
 
-    if [ "$sched_rc" -eq 2 ]; then
-        log_fail "taskset is not available during CPU$cpu_index schedulability check"
-        failed=$((failed + 1))
-        continue
-    fi
-
-    if [ "$sched_rc" -ne 0 ]; then
-        log_fail "CPU$cpu_index is not schedulable before hotplug"
-        failed=$((failed + 1))
-        continue
-    fi
-
-    cpu_hotplug_try_offline_with_retry "$cpu_index" "$HOTPLUG_RETRIES" "$HOTPLUG_RETRY_DELAY_SECONDS" "$out_dir"
-    offline_rc=$?
-
-    if [ "$offline_rc" -ne 0 ]; then
-        log_fail "CPU$cpu_index failed to offline after robust retry handling"
-        failed=$((failed + 1))
-        continue
-    fi
-
-    cpu_hotplug_record_offlined_cpu "$cpu_index"
-    tested=$((tested + 1))
-
-    sleep "$HOTPLUG_RESTORE_DELAY_SECONDS"
-
-    cpu_state="$(cpu_hotplug_read_state "$cpu_index")"
-
-    if [ "$cpu_state" != "0" ]; then
-        log_fail "CPU$cpu_index online state is '${cpu_state:-<empty>}' after offline request, expected 0"
-        failed=$((failed + 1))
-        cpu_hotplug_restore_best_effort "$cpu_index"
-        continue
-    fi
-
-    if cpu_hotplug_in_online_mask "$cpu_index"; then
-        log_fail "CPU$cpu_index still appears in online mask after offline request"
-        failed=$((failed + 1))
-        cpu_hotplug_restore_best_effort "$cpu_index"
-        continue
-    fi
-
-    if cpu_is_schedulable "$cpu_index"; then
-        log_fail "CPU$cpu_index is still schedulable after being offlined"
-        failed=$((failed + 1))
-        cpu_hotplug_restore_best_effort "$cpu_index"
-        continue
-    fi
-
-    log_pass "CPU$cpu_index successfully offlined"
-
-    log_info "Attempting to online CPU$cpu_index"
-    online_output="$(cpu_hotplug_write_state "$cpu_index" 1 "online" "$out_dir" 2>&1)"
-    online_rc=$?
-
-    if [ "$online_rc" -ne 0 ]; then
-        log_fail "CPU$cpu_index failed to online rc=$online_rc output=${online_output:-<none>}"
-        cpu_hotplug_log_dmesg_tail "$cpu_index" "online_error" "$out_dir"
-        failed=$((failed + 1))
-        continue
-    fi
-
-    sleep "$HOTPLUG_RESTORE_DELAY_SECONDS"
-
-    cpu_state="$(cpu_hotplug_read_state "$cpu_index")"
-
-    if [ "$cpu_state" != "1" ]; then
-        log_fail "CPU$cpu_index online state is '${cpu_state:-<empty>}' after online request, expected 1"
-        failed=$((failed + 1))
-        continue
-    fi
-
-    if ! cpu_hotplug_in_online_mask "$cpu_index"; then
-        log_fail "CPU$cpu_index not present in online mask after online request"
-        failed=$((failed + 1))
-        continue
-    fi
-
-    if ! cpu_is_schedulable "$cpu_index"; then
-        log_fail "CPU$cpu_index is not schedulable after online request"
-        failed=$((failed + 1))
-        continue
-    fi
-
-    log_pass "CPU$cpu_index successfully restored online"
-    passed=$((passed + 1))
+    defer_pass=$((defer_pass + 1))
 done
 
 cpu_hotplug_log_topology
 
 log_info "=== CPU hotplug Summary ==="
-log_info "HOTPLUG_SUMMARY: online=$online_count selected=$selected_count controllable=$controllable tested=$tested passed=$passed failed=$failed skipped=$skipped"
+log_info "HOTPLUG_SUMMARY: online=$online_count selected=$selected_count controllable=$controllable tested=$tested passed=$passed failed=$failed skipped=$skipped deferred_ebusy=$deferred"
 
 if [ "$failed" -gt 0 ]; then
     log_fail "$TESTNAME : Test Failed"
@@ -276,4 +262,3 @@ fi
 log_pass "$TESTNAME : Test Passed"
 echo "$TESTNAME PASS" > "$res_file"
 exit 0
-

--- a/Runner/utils/functestlib.sh
+++ b/Runner/utils/functestlib.sh
@@ -6171,7 +6171,8 @@ cpu_hotplug_cleanup_registered() {
 #
 # Return:
 # 0 - offline request accepted
-# 1 - offline failed after retry/evidence collection
+# 1 - offline failed with non-EBUSY error
+# 2 - offline returned EBUSY after retries; caller may defer and retry later
 # shellcheck disable=SC2317
 cpu_hotplug_try_offline_with_retry() {
     cpu_index="$1"
@@ -6179,20 +6180,20 @@ cpu_hotplug_try_offline_with_retry() {
     retry_delay="$3"
     out_dir="$4"
     attempt=1
-
+ 
     while [ "$attempt" -le "$retries" ]; do
         log_info "CPU$cpu_index offline attempt $attempt/$retries"
-
+ 
         offline_output="$(cpu_hotplug_write_state "$cpu_index" 0 "offline_attempt${attempt}" "$out_dir" 2>&1)"
         offline_rc=$?
-
+ 
         if [ "$offline_rc" -eq 0 ]; then
             log_info "CPU$cpu_index offline request accepted on attempt $attempt"
             return 0
         fi
-
+ 
         log_warn "CPU$cpu_index offline attempt $attempt failed: ${offline_output:-<no stderr>}"
-
+ 
         if printf '%s\n' "$offline_output" | grep -qi 'Device or resource busy'; then
             log_warn "CPU$cpu_index offline returned EBUSY"
             cpu_hotplug_log_dmesg_tail "$cpu_index" "offline_ebusy_attempt${attempt}" "$out_dir"
@@ -6201,18 +6202,182 @@ cpu_hotplug_try_offline_with_retry() {
             cpu_hotplug_log_dmesg_tail "$cpu_index" "offline_error_attempt${attempt}" "$out_dir"
             return 1
         fi
-
+ 
         attempt=$((attempt + 1))
-
+ 
         if [ "$attempt" -le "$retries" ]; then
             log_info "Waiting ${retry_delay}s before retrying CPU$cpu_index offline"
             sleep "$retry_delay"
         fi
     done
+ 
+    log_warn "CPU$cpu_index offline returned EBUSY after $retries attempts; caller may defer retry"
+    return 2
+}
 
-    log_fail "CPU$cpu_index offline returned EBUSY after $retries attempts"
-    log_fail "CI requires runtime-discovered hotplug-controllable CPUs to support offline/online transition"
-    return 1
+# Validate offline/online hotplug flow for one CPU.
+#
+# Arguments:
+# $1 - CPU index
+# $2 - pass name: primary, deferred-1, etc.
+# $3 - retry count
+# $4 - retry delay seconds
+# $5 - restore delay seconds
+# $6 - output directory
+#
+# Return:
+# 0 - CPU hotplug validation passed
+# 1 - hard failure
+# 2 - persistent EBUSY; caller may defer/retry later
+# 3 - skipped/not applicable
+# shellcheck disable=SC2317
+cpu_hotplug_validate_cpu_once() {
+    cpu_index="$1"
+    pass_name="${2:-primary}"
+    retries="$3"
+    retry_delay="$4"
+    restore_delay="$5"
+    out_dir="$6"
+
+    log_info "----- Testing CPU$cpu_index ($pass_name pass) -----"
+
+    if ! cpu_hotplug_in_online_mask "$cpu_index"; then
+        if [ "$pass_name" = "primary" ]; then
+            log_skip "CPU$cpu_index is not present in the current online CPU mask"
+            skipped=$((skipped + 1))
+            return 3
+        fi
+
+        log_fail "CPU$cpu_index is not online during deferred retry"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    online_file="$(cpu_hotplug_control_file "$cpu_index")"
+
+    if [ ! -e "$online_file" ]; then
+        if [ "$pass_name" = "primary" ]; then
+            log_skip "CPU$cpu_index has no online control file; not hotplug-controllable on this platform"
+            skipped=$((skipped + 1))
+            return 3
+        fi
+
+        log_fail "CPU$cpu_index lost online control file during deferred retry"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    if [ ! -w "$online_file" ]; then
+        if [ "$pass_name" = "primary" ]; then
+            log_skip "CPU$cpu_index online control file is not writable; not hotplug-controllable in this environment"
+            skipped=$((skipped + 1))
+            return 3
+        fi
+
+        log_fail "CPU$cpu_index online control file is not writable during deferred retry"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    if [ "$pass_name" = "primary" ]; then
+        controllable=$((controllable + 1))
+    fi
+
+    cpu_is_schedulable "$cpu_index"
+    sched_rc=$?
+
+    if [ "$sched_rc" -eq 2 ]; then
+        log_fail "taskset is not available during CPU$cpu_index schedulability check"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    if [ "$sched_rc" -ne 0 ]; then
+        log_fail "CPU$cpu_index is not schedulable before hotplug"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    cpu_hotplug_try_offline_with_retry "$cpu_index" "$retries" "$retry_delay" "$out_dir"
+    offline_rc=$?
+
+    if [ "$offline_rc" -eq 2 ]; then
+        log_warn "CPU$cpu_index still returned EBUSY during $pass_name pass"
+        return 2
+    fi
+
+    if [ "$offline_rc" -ne 0 ]; then
+        log_fail "CPU$cpu_index failed to offline after retry handling"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    cpu_hotplug_record_offlined_cpu "$cpu_index"
+    tested=$((tested + 1))
+
+    sleep "$restore_delay"
+
+    cpu_state="$(cpu_hotplug_read_state "$cpu_index")"
+
+    if [ "$cpu_state" != "0" ]; then
+        log_fail "CPU$cpu_index online state is '${cpu_state:-<empty>}' after offline request, expected 0"
+        failed=$((failed + 1))
+        cpu_hotplug_restore_best_effort "$cpu_index"
+        return 1
+    fi
+
+    if cpu_hotplug_in_online_mask "$cpu_index"; then
+        log_fail "CPU$cpu_index still appears in online mask after offline request"
+        failed=$((failed + 1))
+        cpu_hotplug_restore_best_effort "$cpu_index"
+        return 1
+    fi
+
+    if cpu_is_schedulable "$cpu_index"; then
+        log_fail "CPU$cpu_index is still schedulable after being offlined"
+        failed=$((failed + 1))
+        cpu_hotplug_restore_best_effort "$cpu_index"
+        return 1
+    fi
+
+    log_pass "CPU$cpu_index successfully offlined"
+
+    log_info "Attempting to online CPU$cpu_index"
+    online_output="$(cpu_hotplug_write_state "$cpu_index" 1 "online" "$out_dir" 2>&1)"
+    online_rc=$?
+
+    if [ "$online_rc" -ne 0 ]; then
+        log_fail "CPU$cpu_index failed to online rc=$online_rc output=${online_output:-<none>}"
+        cpu_hotplug_log_dmesg_tail "$cpu_index" "online_error" "$out_dir"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    sleep "$restore_delay"
+
+    cpu_state="$(cpu_hotplug_read_state "$cpu_index")"
+
+    if [ "$cpu_state" != "1" ]; then
+        log_fail "CPU$cpu_index online state is '${cpu_state:-<empty>}' after online request, expected 1"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    if ! cpu_hotplug_in_online_mask "$cpu_index"; then
+        log_fail "CPU$cpu_index not present in online mask after online request"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    if ! cpu_is_schedulable "$cpu_index"; then
+        log_fail "CPU$cpu_index is not schedulable after online request"
+        failed=$((failed + 1))
+        return 1
+    fi
+
+    log_pass "CPU$cpu_index successfully restored online"
+    passed=$((passed + 1))
+    return 0
 }
 
 # Log topology details for one CPU.


### PR DESCRIPTION
Improve CPU hotplug test robustness when the test runs immediately after boot.
 
Some platforms can return EBUSY when trying to offline a CPU very early after boot, while kernel/device initialization work is still active. The same CPU can pass later in the same boot, so treating the first persistent EBUSY window as an immediate hard failure makes hotplug-only jobs and random test ordering fragile.
 
This change updates the hotplug flow to distinguish EBUSY from hard hotplug errors.
 
Changes:
- Make cpu_hotplug_try_offline_with_retry() return a separate status for persistent EBUSY.
- Add cpu_hotplug_validate_cpu_once() in [functestlib.sh](http://functestlib.sh/) for the common per-CPU offline/online validation flow.
- Keep hotplug/[run.sh](http://run.sh/) focused on orchestration.
- Defer CPUs that return EBUSY during the primary pass.
- Continue testing the remaining CPUs.
- Retry deferred EBUSY CPUs at the end.
- Fail only if the CPU still returns EBUSY during the deferred retry.
 
This avoids adding a larger fixed boot delay and avoids skipping CPU0 coverage. Real hotplug failures are still reported as failures if the CPU cannot be offlined after deferred retry handling.

Sample lava job for reference with the patches in the PR - https://lava.infra.foundries.io/scheduler/job/280587

This job clearly demonstrated the changes, as CPU 0 was deferred initially and later, at the end, it was retried and successfully passed.
 https://lava.infra.foundries.io/scheduler/job/280651