### PR TITLE
fastrpc: add Module_Reload_Validation to fastrpc-premerge test plan

### DIFF
--- a/Runner/plans/fastrpc-premerge.yaml
+++ b/Runner/plans/fastrpc-premerge.yaml
@@ -16,4 +16,6 @@ run:
         - cd Runner
         - $PWD/suites/Multimedia/CDSP/fastrpc_test/run.sh || true
         - $PWD/utils/send-to-lava.sh $PWD/suites/Multimedia/CDSP/fastrpc_test/fastrpc_test.res || true
+        - $PWD/suites/Kernel/Baseport/Module_Reload_Validation/run.sh --module fastrpc --iterations 3 --timeout-unload 60 --timeout-load 60 --timeout-settle 20 || true
+        - $PWD/utils/send-to-lava.sh $PWD/suites/Kernel/Baseport/Module_Reload_Validation/Module_Reload_Validation.res || true
         - $PWD/utils/result_parse.sh


### PR DESCRIPTION
## Summary

Extends the `fastrpc-premerge` LAVA test plan to include kernel module
reload validation as part of the fastrpc CI test suite.

## Changes

**`Runner/plans/fastrpc-premerge.yaml`**
- Add `Module_Reload_Validation` test execution with `--module fastrpc` flag
- Add corresponding `send-to-lava.sh` result reporting step

## Why

Adds a second layer of validation — ensuring the `fastrpc` kernel module
can be cleanly unloaded and reloaded, and that dependent services
(`adsprpcd`, `cdsprpcd`) and devices (`/dev/fastrpc-*`) recover correctly
after each reload cycle.

This catches regressions in module lifecycle management that would not be
detected by `fastrpc_test` alone.