### PR TITLE
Camera_Tests: remove unnecessary quotes from shell command

### DIFF
--- a/Runner/suites/Multimedia/GSTreamer/Camera/Camera_Tests/Camera_Tests.yaml
+++ b/Runner/suites/Multimedia/GSTreamer/Camera/Camera_Tests/Camera_Tests.yaml
@@ -29,4 +29,4 @@ run:
     - cd "$REPO_PATH/Runner/suites/Multimedia/GSTreamer/Camera/Camera_Tests"
     - export CAMERA_ID CAMERA_PLUGIN CAMERA_TEST_MODES CAMERA_FORMATS CAMERA_RESOLUTIONS CAMERA_FRAMERATE CAMERA_DURATION CAMERA_GST_DEBUG
     - ./run.sh --lava-testcase-id "${LAVA_TESTCASE_ID}" || true
-    - "$REPO_PATH/Runner/utils/send-to-lava.sh" Camera_Tests.res
+    - $REPO_PATH/Runner/utils/send-to-lava.sh Camera_Tests.res


### PR DESCRIPTION
With quotes the job is failing. 

FAILED Job: https://lava.infra.foundries.io/scheduler/job/306603
Job with testcase executed: https://lava.infra.foundries.io/scheduler/job/306612

Signed-off-by: Anil Yadav <anilyada@qti.qualcomm.com>