### PR TITLE
Add modular X11 graphics validation support

### DIFF
--- a/Runner/config/pkg_command_map.conf
+++ b/Runner/config/pkg_command_map.conf
@@ -44,6 +44,55 @@ apt:gst-inspect-1.0=gstreamer1.0-tools
 apt:efivar=efivar
 
 # ---------------------------------------------------------------------------
+# X11 graphics validation package sets.
+#
+# These sets are intentionally split by capability so the runner installs only
+# what the selected subtests require.
+# ---------------------------------------------------------------------------
+
+# X11 display inspection and session validation.
+debian:package-set:graphics-x11-display=x11-utils x11-xserver-utils
+apt:package-set:graphics-x11-display=x11-utils x11-xserver-utils
+
+# Optional external fullscreen window handling.
+debian:package-set:graphics-x11-fullscreen=xdotool wmctrl
+apt:package-set:graphics-x11-fullscreen=xdotool wmctrl
+
+# Mesa GLX, EGL and OpenGL ES utilities.
+debian:package-set:graphics-x11-mesa=mesa-utils
+apt:package-set:graphics-x11-mesa=mesa-utils
+
+# X11 OpenGL and OpenGL ES glmark2 binaries.
+debian:package-set:graphics-x11-glmark2=glmark2-x11 glmark2-es2-x11
+apt:package-set:graphics-x11-glmark2=glmark2-x11 glmark2-es2-x11
+
+# GStreamer X11, XVideo and EGL/OpenGL display support.
+debian:package-set:graphics-x11-gstreamer=gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-x gstreamer1.0-gl
+apt:package-set:graphics-x11-gstreamer=gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-x gstreamer1.0-gl
+
+# Test-specific command recovery where the Debian package name differs from the
+# executable name.
+debian:X11_Glmark2:glmark2=glmark2-x11
+debian:X11_Glmark2:glmark2-es2=glmark2-es2-x11
+
+# Common X11 and Mesa command recovery for apt-based images.
+apt:xdpyinfo=x11-utils
+apt:xwininfo=x11-utils
+apt:xprop=x11-utils
+apt:xvinfo=x11-utils
+apt:xrandr=x11-xserver-utils
+apt:glxinfo=mesa-utils
+apt:glxgears=mesa-utils
+apt:eglinfo=mesa-utils
+apt:es2_info=mesa-utils
+apt:es2gears_x11=mesa-utils
+apt:eglgears_x11=mesa-utils
+apt:egltri_x11=mesa-utils
+apt:xdotool=xdotool
+apt:xwininfo=x11-utils
+apt:wmctrl=wmctrl
+
+# ---------------------------------------------------------------------------
 # Common rpm provider mappings.
 # Applies to Yocto+dNF/RPM, Red Hat, CentOS, Fedora, etc.
 # ---------------------------------------------------------------------------

--- a/Runner/suites/Multimedia/Graphics/X11_Display_Validation/README.md
+++ b/Runner/suites/Multimedia/Graphics/X11_Display_Validation/README.md
@@ -1,0 +1,20 @@
+# X11 Display Validation
+
+Dynamically validates the active X11 server, authority, connected output, current XRandR mode and root-window state.
+
+## Runtime policy
+
+- Intended for upstream MSM DRM/KMS plus Mesa/freedreno on Xorg.
+- Dynamically discovers `DISPLAY`, `XAUTHORITY`, session type, active output and refresh.
+- Returns `SKIP` on a detected KGSL/proprietary Adreno boot; use Weston/Wayland tests for that stack.
+- Does not stop LightDM/Xorg, start Weston, switch graphics packages, or modify the active display mode.
+- Uses `lib_pkg_provider.sh` package sets rather than embedding package-manager commands.
+
+## Run
+
+```sh
+./run.sh --help
+./run.sh
+```
+
+The runner writes `X11_Display_Validation.res` and an `X11_Display_Validation_out/` evidence directory when applicable.

--- a/Runner/suites/Multimedia/Graphics/X11_Display_Validation/X11_Display_Validation.yaml
+++ b/Runner/suites/Multimedia/Graphics/X11_Display_Validation/X11_Display_Validation.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: X11_Display_Validation
+  format: "Lava-Test Test Definition 1.0"
+  description: "Dynamically validates the active X11 server, authority, connected output, current XRandR mode and root-window state."
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Multimedia/Graphics/X11_Display_Validation
+    - ./run.sh || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh X11_Display_Validation.res || true

--- a/Runner/suites/Multimedia/Graphics/X11_Display_Validation/run.sh
+++ b/Runner/suites/Multimedia/Graphics/X11_Display_Validation/run.sh
@@ -1,0 +1,239 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# Validate the active X11 display, output mode, and root window.
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+
+TESTNAME="X11_Display_Validation"
+RES_FILE="$SCRIPT_DIR/${TESTNAME}.res"
+
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/lib_display.sh"
+
+if [ -r "$TOOLS/lib_pkg_provider.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_pkg_provider.sh"
+fi
+
+if [ -r "$TOOLS/lib_module_reload.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_module_reload.sh"
+fi
+
+LC_ALL=C
+export LC_ALL
+
+test_path="$(find_test_case_by_name "$TESTNAME" 2>/dev/null || true)"
+
+if [ -z "$test_path" ] || [ ! -d "$test_path" ]; then
+    log_skip "$TESTNAME SKIP - test path not found"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if ! cd "$test_path"; then
+    log_skip "$TESTNAME SKIP - cannot cd into $test_path"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+RES_FILE="./${TESTNAME}.res"
+LOG_DIR="./logs"
+OUTDIR="$LOG_DIR/$TESTNAME"
+
+REQUIRE_XFCE="${REQUIRE_XFCE:-0}"
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --require-xfce           Require a real XFCE session
+  -h, --help               Show this help
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --require-xfce)
+            REQUIRE_XFCE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_skip "$TESTNAME SKIP - unknown option: $1"
+            usage
+            echo "$TESTNAME SKIP" >"$RES_FILE"
+            exit 0
+            ;;
+    esac
+done
+
+case "$REQUIRE_XFCE" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - REQUIRE_XFCE must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+rm -f "$RES_FILE"
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+log_info "-------------------------------------------------------------------"
+log_info "---------------- Starting $TESTNAME testcase ----------------"
+
+GPU_BOOT_MODE="unknown"
+
+if command -v mrv_qcom_gpu_boot_mode >/dev/null 2>&1; then
+    GPU_BOOT_MODE="$(mrv_qcom_gpu_boot_mode 2>/dev/null || true)"
+    [ -n "$GPU_BOOT_MODE" ] || GPU_BOOT_MODE="unknown"
+fi
+
+log_info "Detected Qualcomm GPU boot mode: $GPU_BOOT_MODE"
+
+if [ "$GPU_BOOT_MODE" = "kgsl" ]; then
+    log_skip "$TESTNAME SKIP - KGSL/proprietary Adreno boot mode requires the Weston/Wayland validation path"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v pkg_ensure_required_package_set_present >/dev/null 2>&1; then
+    if ! pkg_ensure_required_package_set_present graphics-x11-display; then
+        log_skip "$TESTNAME SKIP - failed to ensure the X11 display package set"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+    fi
+fi
+
+hash -r 2>/dev/null || true
+
+deps="xdpyinfo xrandr xwininfo xprop awk sed grep tr"
+check_dependencies "$deps"
+
+if ! command -v display_x11_resolve_env >/dev/null 2>&1; then
+    log_fail "$TESTNAME FAIL - display_x11_resolve_env helper is unavailable"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if ! display_x11_resolve_env \
+    "${DISPLAY:-}" \
+    "${XAUTHORITY:-}"; then
+    log_skip "$TESTNAME SKIP - no usable X11 display and Xauthority pair could be discovered"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_info "Resolved X11 runtime:"
+log_info " DISPLAY=$DISPLAY"
+log_info " XAUTHORITY=${XAUTHORITY:-<unset>}"
+log_info " server_pid=${DISPLAY_X11_SERVER_PID:-unknown}"
+log_info " session=${DISPLAY_X11_SESSION_KIND:-unknown}"
+
+if [ "$REQUIRE_XFCE" -eq 1 ] &&
+   [ "${DISPLAY_X11_SESSION_KIND:-unknown}" != "xfce" ]; then
+    log_skip "$TESTNAME SKIP - real XFCE session required; detected ${DISPLAY_X11_SESSION_KIND:-unknown}"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v display_debug_snapshot >/dev/null 2>&1; then
+    display_debug_snapshot "$TESTNAME"
+fi
+
+connected_summary="$(display_connected_summary 2>/dev/null || true)"
+
+if [ -z "$connected_summary" ] || [ "$connected_summary" = "none" ]; then
+    log_skip "$TESTNAME SKIP - no connected DRM display was discovered"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_info "Connected DRM displays: $connected_summary"
+
+if ! display_x11_get_active_output; then
+    log_fail "$TESTNAME FAIL - could not resolve an active XRandR output"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if ! display_x11_get_root_geometry; then
+    log_fail "$TESTNAME FAIL - could not read the X11 root-window geometry"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+xrandr \
+    --current \
+    >"$OUTDIR/xrandr-current.log" 2>&1 || true
+
+xwininfo \
+    -root \
+    >"$OUTDIR/xwininfo-root.log" 2>&1 || true
+
+xprop \
+    -root \
+    >"$OUTDIR/xprop-root.log" 2>&1 || true
+
+case "$DISPLAY_X11_REFRESH_HZ" in
+    ''|*[!0-9.]*)
+        log_fail "$TESTNAME FAIL - active XRandR refresh is invalid: ${DISPLAY_X11_REFRESH_HZ:-<empty>}"
+        echo "$TESTNAME FAIL" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+case "$DISPLAY_X11_ROOT_WIDTH:$DISPLAY_X11_ROOT_HEIGHT" in
+    *[!0-9:]*|:*|*:)
+        log_fail "$TESTNAME FAIL - root-window dimensions are invalid"
+        echo "$TESTNAME FAIL" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+if [ "$DISPLAY_X11_ROOT_MAP_STATE" != "IsViewable" ]; then
+    log_fail "$TESTNAME FAIL - X11 root window is not viewable"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+log_pass "$TESTNAME PASS - session=${DISPLAY_X11_SESSION_KIND}; output=${DISPLAY_X11_OUTPUT}; mode=${DISPLAY_X11_MODE}; refresh=${DISPLAY_X11_REFRESH_HZ}Hz; root=${DISPLAY_X11_ROOT_WIDTH}x${DISPLAY_X11_ROOT_HEIGHT}"
+echo "$TESTNAME PASS" >"$RES_FILE"
+exit 0

--- a/Runner/suites/Multimedia/Graphics/X11_EGL_GLES/README.md
+++ b/Runner/suites/Multimedia/Graphics/X11_EGL_GLES/README.md
@@ -1,0 +1,48 @@
+# X11 EGL/GLES
+
+Validates the strict X11 EGL platform and available X11 EGL/GLES clients without accepting unrelated GBM, Wayland, surfaceless, device, or software-renderer results.
+
+## Coverage
+
+- Dynamically discovers the usable `DISPLAY` and `XAUTHORITY` pair.
+- Uses `display_print_eglinfo_pipeline x11` from `lib_display.sh`.
+- Requires the selected platform to remain `x11` and the pipeline to classify as hardware GPU rendering.
+- Records the selected X11 EGL vendor, version, API version, driver, GL vendor, and renderer.
+- Runs available `es2gears_x11`, `eglgears_x11`, and `egltri_x11` clients for a bounded duration.
+- Runs client windows fullscreen by default through the shared X11 watcher.
+- Discovers the client window by exact before/after window and PID snapshots, then reapplies fullscreen while the client remains alive.
+- Returns `SKIP` on KGSL/proprietary Adreno boot mode.
+
+## Options
+
+```sh
+./run.sh --help
+./run.sh
+./run.sh --fullscreen --duration 12
+./run.sh --windowed --duration 12
+./run.sh --apps es2gears_x11,egltri_x11
+./run.sh --require-xfce
+```
+
+`--fullscreen` is the default. The shared helper checks installed fullscreen commands first. Package recovery is attempted only when a required command is missing; rendering validation continues with a warning when external fullscreen support is unavailable.
+
+## Required shared EGL cache
+
+The current `lib_display.sh` implementation must populate:
+
+- `EGLI_LAST_PLATFORM`
+- `EGLI_LAST_EGL_VENDOR`
+- `EGLI_LAST_EGL_VERSION`
+- `EGLI_LAST_EGL_API_VERSION`
+- `EGLI_LAST_DRIVER`
+- `EGLI_LAST_GL_VENDOR`
+- `EGLI_LAST_GL_RENDERER`
+- `EGLI_LAST_PIPE_KIND`
+- `EGLI_LAST_OUT`
+
+## Evidence
+
+- `X11_EGL_GLES.res`
+- `logs/X11_EGL_GLES/eglinfo-x11.log`
+- `logs/X11_EGL_GLES/es2-info.log`
+- Per-client logs and fullscreen status files under `logs/X11_EGL_GLES/`

--- a/Runner/suites/Multimedia/Graphics/X11_EGL_GLES/X11_EGL_GLES.yaml
+++ b/Runner/suites/Multimedia/Graphics/X11_EGL_GLES/X11_EGL_GLES.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: X11_EGL_GLES
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validates strict hardware X11 EGL/GLES and bounded X11 clients with exact-window fullscreen control."
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Multimedia/Graphics/X11_EGL_GLES
+    - ./run.sh --fullscreen || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh X11_EGL_GLES.res || true

--- a/Runner/suites/Multimedia/Graphics/X11_EGL_GLES/run.sh
+++ b/Runner/suites/Multimedia/Graphics/X11_EGL_GLES/run.sh
@@ -1,0 +1,434 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# Validate the X11 EGL pipeline and available GLES client applications.
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+
+TESTNAME="X11_EGL_GLES"
+RES_FILE="$SCRIPT_DIR/${TESTNAME}.res"
+
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/lib_display.sh"
+
+if [ -r "$TOOLS/lib_pkg_provider.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_pkg_provider.sh"
+fi
+
+if [ -r "$TOOLS/lib_module_reload.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_module_reload.sh"
+fi
+
+LC_ALL=C
+export LC_ALL
+
+test_path="$(find_test_case_by_name "$TESTNAME" 2>/dev/null || true)"
+
+if [ -z "$test_path" ] || [ ! -d "$test_path" ]; then
+    log_skip "$TESTNAME SKIP - test path not found"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if ! cd "$test_path"; then
+    log_skip "$TESTNAME SKIP - cannot cd into $test_path"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+RES_FILE="./${TESTNAME}.res"
+LOG_DIR="./logs"
+OUTDIR="$LOG_DIR/$TESTNAME"
+
+DURATION_SECONDS="${DURATION_SECONDS:-12}"
+GLES_APPS="${GLES_APPS:-auto}"
+REQUIRE_XFCE="${REQUIRE_XFCE:-0}"
+X11_FULLSCREEN="${X11_FULLSCREEN:-1}"
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+FULLSCREEN_WATCH_AVAILABLE=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --duration <seconds>     Runtime for each EGL/GLES client
+  --apps <list>            auto or comma-separated client commands
+  --fullscreen             Run visual clients fullscreen; default
+  --windowed               Keep each client's native window size
+  --require-xfce           Require a real XFCE session
+  -h, --help               Show this help
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --duration)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --duration"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            DURATION_SECONDS="$2"
+            shift 2
+            ;;
+        --duration=*)
+            DURATION_SECONDS=${1#*=}
+            shift
+            ;;
+        --apps|--gles-apps)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --apps"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            GLES_APPS="$2"
+            shift 2
+            ;;
+        --apps=*|--gles-apps=*)
+            GLES_APPS=${1#*=}
+            shift
+            ;;
+        --fullscreen)
+            X11_FULLSCREEN=1
+            shift
+            ;;
+        --windowed)
+            X11_FULLSCREEN=0
+            shift
+            ;;
+        --require-xfce)
+            REQUIRE_XFCE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_skip "$TESTNAME SKIP - unknown option: $1"
+            usage
+            echo "$TESTNAME SKIP" >"$RES_FILE"
+            exit 0
+            ;;
+    esac
+done
+
+case "$DURATION_SECONDS" in
+    ''|*[!0-9]*|0)
+        log_skip "$TESTNAME SKIP - duration must be a positive integer"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+case "$REQUIRE_XFCE" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - REQUIRE_XFCE must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+case "$X11_FULLSCREEN" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - X11_FULLSCREEN must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+rm -f "$RES_FILE"
+rm -rf "$OUTDIR"
+
+if ! mkdir -p "$OUTDIR"; then
+    log_skip "$TESTNAME SKIP - could not create output directory: $OUTDIR"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+EGLINFO_LOG="$OUTDIR/eglinfo-x11.log"
+
+log_info "-------------------------------------------------------------------"
+log_info "---------------- Starting $TESTNAME testcase ----------------"
+log_info "DURATION_SECONDS=$DURATION_SECONDS"
+log_info "GLES_APPS=$GLES_APPS"
+log_info "X11_FULLSCREEN=$X11_FULLSCREEN"
+
+GPU_BOOT_MODE="unknown"
+
+if command -v mrv_qcom_gpu_boot_mode >/dev/null 2>&1; then
+    GPU_BOOT_MODE="$(mrv_qcom_gpu_boot_mode 2>/dev/null || true)"
+    [ -n "$GPU_BOOT_MODE" ] || GPU_BOOT_MODE="unknown"
+fi
+
+log_info "Detected Qualcomm GPU boot mode: $GPU_BOOT_MODE"
+
+if [ "$GPU_BOOT_MODE" = "kgsl" ]; then
+    log_skip "$TESTNAME SKIP - KGSL/proprietary Adreno boot mode requires the Weston/Wayland validation path"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v pkg_ensure_required_package_set_present >/dev/null 2>&1; then
+    if ! pkg_ensure_required_package_set_present graphics-x11-display ||
+       ! pkg_ensure_required_package_set_present graphics-x11-mesa; then
+        log_skip "$TESTNAME SKIP - failed to ensure the X11 Mesa package sets"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+    fi
+
+fi
+
+hash -r 2>/dev/null || true
+
+deps="xdpyinfo xrandr eglinfo awk sed grep tr date"
+
+if [ "$X11_FULLSCREEN" -eq 1 ]; then
+    if command -v display_x11_prepare_fullscreen_support >/dev/null 2>&1 &&
+       display_x11_prepare_fullscreen_support &&
+       command -v display_x11_fullscreen_watch_start >/dev/null 2>&1 &&
+       command -v display_x11_fullscreen_watch_finish >/dev/null 2>&1; then
+        FULLSCREEN_WATCH_AVAILABLE=1
+    else
+        log_warn "Shared X11 fullscreen watcher is unavailable; EGL/GLES clients may remain windowed"
+    fi
+fi
+
+check_dependencies "$deps"
+
+if ! command -v display_x11_resolve_env >/dev/null 2>&1; then
+    log_fail "$TESTNAME FAIL - display_x11_resolve_env helper is unavailable"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if ! display_x11_resolve_env \
+    "${DISPLAY:-}" \
+    "${XAUTHORITY:-}"; then
+    log_skip "$TESTNAME SKIP - no usable X11 display and Xauthority pair could be discovered"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_info "Resolved X11 runtime:"
+log_info " DISPLAY=$DISPLAY"
+log_info " XAUTHORITY=${XAUTHORITY:-<unset>}"
+log_info " server_pid=${DISPLAY_X11_SERVER_PID:-unknown}"
+log_info " session=${DISPLAY_X11_SESSION_KIND:-unknown}"
+
+if [ "$REQUIRE_XFCE" -eq 1 ] &&
+   [ "${DISPLAY_X11_SESSION_KIND:-unknown}" != "xfce" ]; then
+    log_skip "$TESTNAME SKIP - real XFCE session required; detected ${DISPLAY_X11_SESSION_KIND:-unknown}"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v ensure_xdg_runtime_dir >/dev/null 2>&1; then
+    ensure_xdg_runtime_dir
+fi
+
+EGLINFO_CACHE_OUTPUT=1
+export EGLINFO_CACHE_OUTPUT
+
+if ! display_print_eglinfo_pipeline \
+    x11; then
+    log_fail "$TESTNAME FAIL - selected X11 EGL platform did not initialize"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if [ -n "${EGLI_LAST_OUT:-}" ]; then
+    if ! printf '%s\n' \
+        "$EGLI_LAST_OUT" \
+        >"$EGLINFO_LOG"; then
+        log_warn "Failed to save selected X11 eglinfo output: $EGLINFO_LOG"
+    fi
+else
+    log_warn "Selected X11 eglinfo output was not cached"
+fi
+
+log_info "Selected X11 EGL pipeline:"
+log_info " platform=${EGLI_LAST_PLATFORM:-unknown}"
+log_info " EGL vendor=${EGLI_LAST_EGL_VENDOR:-unknown}"
+log_info " EGL version=${EGLI_LAST_EGL_VERSION:-unknown}"
+log_info " EGL API version=${EGLI_LAST_EGL_API_VERSION:-unknown}"
+log_info " EGL driver=${EGLI_LAST_DRIVER:-unknown}"
+log_info " GL vendor=${EGLI_LAST_GL_VENDOR:-unknown}"
+log_info " GL renderer=${EGLI_LAST_GL_RENDERER:-unknown}"
+log_info " pipeline type=${EGLI_LAST_PIPE_KIND:-unknown}"
+
+if [ "${EGLI_LAST_PLATFORM:-}" != "x11" ]; then
+    log_fail "$TESTNAME FAIL - unexpected EGL platform: ${EGLI_LAST_PLATFORM:-unknown}"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+case "${EGLI_LAST_PIPE_KIND:-}" in
+    CPU*)
+        log_fail "$TESTNAME FAIL - software X11 EGL renderer detected: ${EGLI_LAST_GL_RENDERER:-unknown}"
+        echo "$TESTNAME FAIL" >"$RES_FILE"
+        exit 0
+        ;;
+    GPU*)
+        ;;
+    *)
+        log_fail "$TESTNAME FAIL - X11 EGL pipeline type could not be classified: ${EGLI_LAST_PIPE_KIND:-unknown}"
+        echo "$TESTNAME FAIL" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+if [ -z "${EGLI_LAST_EGL_VENDOR:-}" ] ||
+   [ "$EGLI_LAST_EGL_VENDOR" = "unknown" ] ||
+   [ -z "${EGLI_LAST_EGL_VERSION:-}" ] ||
+   [ "$EGLI_LAST_EGL_VERSION" = "unknown" ] ||
+   [ -z "${EGLI_LAST_EGL_API_VERSION:-}" ] ||
+   [ "$EGLI_LAST_EGL_API_VERSION" = "unknown" ] ||
+   [ -z "${EGLI_LAST_DRIVER:-}" ] ||
+   [ "$EGLI_LAST_DRIVER" = "unknown" ] ||
+   [ -z "${EGLI_LAST_GL_VENDOR:-}" ] ||
+   [ "$EGLI_LAST_GL_VENDOR" = "unknown" ] ||
+   [ -z "${EGLI_LAST_GL_RENDERER:-}" ] ||
+   [ "$EGLI_LAST_GL_RENDERER" = "unknown" ]; then
+    log_fail "$TESTNAME FAIL - X11 EGL vendor, version, API version, driver, or renderer could not be identified"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v es2_info >/dev/null 2>&1; then
+    if es2_info >"$OUTDIR/es2-info.log" 2>&1; then
+        cat "$OUTDIR/es2-info.log"
+        log_pass "es2_info initialized on the selected X11 display"
+    else
+        cat "$OUTDIR/es2-info.log"
+        log_fail "$TESTNAME FAIL - es2_info failed on the selected X11 display"
+        echo "$TESTNAME FAIL" >"$RES_FILE"
+        exit 0
+    fi
+else
+    log_warn "es2_info is unavailable; continuing with the X11 EGL clients"
+fi
+
+requested_apps="$(printf '%s\n' "$GLES_APPS" | tr ',' ' ')"
+
+if [ "$requested_apps" = "auto" ]; then
+    requested_apps="es2gears_x11 eglgears_x11 egltri_x11"
+fi
+
+for app in $requested_apps; do
+    [ -n "$app" ] || continue
+
+    if ! command -v "$app" >/dev/null 2>&1; then
+        log_skip "$app SKIP - client is unavailable"
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        continue
+    fi
+
+    app_name="$(basename "$app")"
+    app_log="$OUTDIR/${app_name}.log"
+
+    if [ "$FULLSCREEN_WATCH_AVAILABLE" -eq 1 ]; then
+        display_x11_fullscreen_watch_start \
+            "$DURATION_SECONDS" \
+            "$app_name" \
+            "$OUTDIR/${app_name}-fullscreen.status" ||
+            true
+    fi
+
+    app_start="$(date +%s 2>/dev/null || echo 0)"
+
+    run_with_timeout \
+        "${DURATION_SECONDS}s" \
+        "$app" \
+        >"$app_log" 2>&1
+
+    app_rc=$?
+    app_end="$(date +%s 2>/dev/null || echo 0)"
+    app_elapsed=$((app_end - app_start))
+
+    if [ "$FULLSCREEN_WATCH_AVAILABLE" -eq 1 ]; then
+        display_x11_fullscreen_watch_finish ||
+            true
+    fi
+
+    cat "$app_log"
+
+    case "$app_rc" in
+        0|124|130|137|143)
+            minimum_elapsed=$((DURATION_SECONDS - 1))
+
+            if [ "$app_elapsed" -lt "$minimum_elapsed" ]; then
+                log_fail "$app FAIL - exited too early: elapsed=${app_elapsed}s requested=${DURATION_SECONDS}s rc=$app_rc"
+                FAIL_COUNT=$((FAIL_COUNT + 1))
+            else
+                log_pass "$app PASS - remained active for ${app_elapsed}s rc=$app_rc"
+                PASS_COUNT=$((PASS_COUNT + 1))
+            fi
+            ;;
+        *)
+            log_fail "$app FAIL - unexpected return code: $app_rc"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            ;;
+    esac
+done
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    log_fail "$TESTNAME FAIL - $FAIL_COUNT client(s) failed; $PASS_COUNT passed; $SKIP_COUNT skipped"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if [ "$PASS_COUNT" -eq 0 ]; then
+    log_skip "$TESTNAME SKIP - no EGL/GLES client completed; $SKIP_COUNT skipped"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_pass "$TESTNAME PASS - \
+egl=${EGLI_LAST_EGL_VERSION:-unknown}; \
+driver=${EGLI_LAST_DRIVER:-unknown}; \
+vendor=${EGLI_LAST_GL_VENDOR:-unknown}; \
+renderer=${EGLI_LAST_GL_RENDERER:-unknown}; \
+clients=$PASS_COUNT"
+echo "$TESTNAME PASS" >"$RES_FILE"
+exit 0

--- a/Runner/suites/Multimedia/Graphics/X11_GLX/README.md
+++ b/Runner/suites/Multimedia/Graphics/X11_GLX/README.md
@@ -1,0 +1,30 @@
+# X11 GLX
+
+Validates hardware-accelerated GLX and bounded `glxgears` frame progress against the active XRandR refresh.
+
+## Coverage
+
+- Dynamically discovers the usable `DISPLAY` and `XAUTHORITY` pair.
+- Uses the shared `display_x11_print_glx_pipeline()` parser from `lib_display.sh` and rejects indirect, unaccelerated, or software GLX rendering.
+- Captures the active XRandR refresh before starting the benchmark.
+- Runs `glxgears` for a bounded duration and parses decimal interval output such as `5.0 seconds`.
+- Uses the native `glxgears -fullscreen` option; no external window watcher is needed.
+- Returns `SKIP` on KGSL/proprietary Adreno boot mode.
+
+## Options
+
+```sh
+./run.sh --help
+./run.sh
+./run.sh --fullscreen --duration 12
+./run.sh --windowed --duration 12
+./run.sh --require-xfce
+```
+
+`--fullscreen` is the default. Expected FPS is derived dynamically from the active XRandR mode and is never hardcoded to 60 Hz.
+
+## Evidence
+
+- `X11_GLX.res`
+- `logs/X11_GLX/glxinfo-B.log`
+- `logs/X11_GLX/glxgears.log`

--- a/Runner/suites/Multimedia/Graphics/X11_GLX/X11_GLX.yaml
+++ b/Runner/suites/Multimedia/Graphics/X11_GLX/X11_GLX.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: X11_GLX
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validates hardware GLX and refresh-synchronised glxgears frame progress using native fullscreen X11 mode."
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Multimedia/Graphics/X11_GLX
+    - ./run.sh --fullscreen || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh X11_GLX.res || true

--- a/Runner/suites/Multimedia/Graphics/X11_GLX/run.sh
+++ b/Runner/suites/Multimedia/Graphics/X11_GLX/run.sh
@@ -1,0 +1,376 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# Validate GLX hardware rendering and refresh-synchronised frame progress.
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+
+TESTNAME="X11_GLX"
+RES_FILE="$SCRIPT_DIR/${TESTNAME}.res"
+
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/lib_display.sh"
+
+if [ -r "$TOOLS/lib_pkg_provider.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_pkg_provider.sh"
+fi
+
+if [ -r "$TOOLS/lib_module_reload.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_module_reload.sh"
+fi
+
+LC_ALL=C
+export LC_ALL
+
+test_path="$(find_test_case_by_name "$TESTNAME" 2>/dev/null || true)"
+
+if [ -z "$test_path" ] || [ ! -d "$test_path" ]; then
+    log_skip "$TESTNAME SKIP - test path not found"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if ! cd "$test_path"; then
+    log_skip "$TESTNAME SKIP - cannot cd into $test_path"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+RES_FILE="./${TESTNAME}.res"
+LOG_DIR="./logs"
+OUTDIR="$LOG_DIR/$TESTNAME"
+
+DURATION_SECONDS="${DURATION_SECONDS:-12}"
+REQUIRE_XFCE="${REQUIRE_XFCE:-0}"
+X11_FULLSCREEN="${X11_FULLSCREEN:-1}"
+FAILURES=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --duration <seconds>     glxgears runtime; minimum 6 seconds
+  --fullscreen             Run glxgears fullscreen; default
+  --windowed               Keep the native glxgears window size
+  --require-xfce           Require a real XFCE session
+  -h, --help              Show this help
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --duration)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --duration"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            DURATION_SECONDS="$2"
+            shift 2
+            ;;
+        --duration=*)
+            DURATION_SECONDS=${1#*=}
+            shift
+            ;;
+        --fullscreen)
+            X11_FULLSCREEN=1
+            shift
+            ;;
+        --windowed)
+            X11_FULLSCREEN=0
+            shift
+            ;;
+        --require-xfce)
+            REQUIRE_XFCE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_skip "$TESTNAME SKIP - unknown option: $1"
+            usage
+            echo "$TESTNAME SKIP" >"$RES_FILE"
+            exit 0
+            ;;
+    esac
+done
+
+case "$DURATION_SECONDS" in
+    ''|*[!0-9]*|0)
+        log_skip "$TESTNAME SKIP - duration must be a positive integer"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+if [ "$DURATION_SECONDS" -lt 6 ]; then
+    log_skip "$TESTNAME SKIP - duration must be at least 6 seconds for FPS collection"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+case "$REQUIRE_XFCE" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - REQUIRE_XFCE must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+case "$X11_FULLSCREEN" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - X11_FULLSCREEN must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+rm -f "$RES_FILE"
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+GLXINFO_LOG="$OUTDIR/glxinfo-B.log"
+GLXGEARS_LOG="$OUTDIR/glxgears.log"
+
+log_info "-------------------------------------------------------------------"
+log_info "---------------- Starting $TESTNAME testcase ----------------"
+log_info "DURATION_SECONDS=$DURATION_SECONDS"
+log_info "X11_FULLSCREEN=$X11_FULLSCREEN"
+
+GPU_BOOT_MODE="unknown"
+
+if command -v mrv_qcom_gpu_boot_mode >/dev/null 2>&1; then
+    GPU_BOOT_MODE="$(mrv_qcom_gpu_boot_mode 2>/dev/null || true)"
+    [ -n "$GPU_BOOT_MODE" ] || GPU_BOOT_MODE="unknown"
+fi
+
+log_info "Detected Qualcomm GPU boot mode: $GPU_BOOT_MODE"
+
+if [ "$GPU_BOOT_MODE" = "kgsl" ]; then
+    log_skip "$TESTNAME SKIP - KGSL/proprietary Adreno boot mode requires the Weston/Wayland validation path"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v pkg_ensure_required_package_set_present >/dev/null 2>&1; then
+    if ! pkg_ensure_required_package_set_present graphics-x11-display ||
+       ! pkg_ensure_required_package_set_present graphics-x11-mesa; then
+        log_skip "$TESTNAME SKIP - failed to ensure the X11 Mesa package sets"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+    fi
+fi
+
+hash -r 2>/dev/null || true
+
+deps="xdpyinfo xrandr glxinfo glxgears awk sed grep tr date"
+check_dependencies "$deps"
+
+if ! command -v display_x11_resolve_env >/dev/null 2>&1; then
+    log_fail "$TESTNAME FAIL - display_x11_resolve_env helper is unavailable"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if ! display_x11_resolve_env \
+    "${DISPLAY:-}" \
+    "${XAUTHORITY:-}"; then
+    log_skip "$TESTNAME SKIP - no usable X11 display and Xauthority pair could be discovered"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_info "Resolved X11 runtime:"
+log_info " DISPLAY=$DISPLAY"
+log_info " XAUTHORITY=${XAUTHORITY:-<unset>}"
+log_info " server_pid=${DISPLAY_X11_SERVER_PID:-unknown}"
+log_info " session=${DISPLAY_X11_SESSION_KIND:-unknown}"
+
+if [ "$REQUIRE_XFCE" -eq 1 ] &&
+   [ "${DISPLAY_X11_SESSION_KIND:-unknown}" != "xfce" ]; then
+    log_skip "$TESTNAME SKIP - real XFCE session required; detected ${DISPLAY_X11_SESSION_KIND:-unknown}"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+GLX_REFRESH_HZ=""
+
+if command -v display_get_primary_refresh_hz >/dev/null 2>&1; then
+    GLX_REFRESH_HZ="$(display_get_primary_refresh_hz x11 2>/dev/null || true)"
+fi
+
+case "$GLX_REFRESH_HZ" in
+    ''|*[!0-9.]*)
+        GLX_REFRESH_HZ=""
+        log_warn "Could not capture the active XRandR refresh before glxgears"
+        ;;
+    *)
+        log_info "Captured active XRandR refresh before glxgears: ${GLX_REFRESH_HZ}Hz"
+        ;;
+esac
+
+if ! command -v display_x11_print_glx_pipeline >/dev/null 2>&1; then
+    log_fail "$TESTNAME FAIL - shared display_x11_print_glx_pipeline helper is unavailable in lib_display.sh"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if ! display_x11_print_glx_pipeline >"$GLXINFO_LOG" 2>&1; then
+    cat "$GLXINFO_LOG"
+    log_fail "$TESTNAME FAIL - glxinfo could not initialize the selected X11 display"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+cat "$GLXINFO_LOG"
+
+case "$(printf '%s\n' "${DISPLAY_GLX_DIRECT:-}" | tr '[:upper:]' '[:lower:]')" in
+    yes)
+        ;;
+    *)
+        log_fail "Direct rendering is not enabled"
+        FAILURES=$((FAILURES + 1))
+        ;;
+esac
+
+case "$(printf '%s\n' "${DISPLAY_GLX_ACCELERATED:-}" | tr '[:upper:]' '[:lower:]')" in
+    no)
+        log_fail "GLX reports an unaccelerated renderer"
+        FAILURES=$((FAILURES + 1))
+        ;;
+esac
+
+case "${DISPLAY_GLX_PIPE_KIND:-}" in
+    CPU*)
+        log_fail "Software GLX renderer detected: ${DISPLAY_GLX_RENDERER:-unknown}"
+        FAILURES=$((FAILURES + 1))
+        ;;
+esac
+
+if [ "${DISPLAY_GLX_RENDERER:-unknown}" = "unknown" ]; then
+    log_fail "GLX renderer could not be identified"
+    FAILURES=$((FAILURES + 1))
+fi
+
+set -- \
+    glxgears
+
+if [ "$X11_FULLSCREEN" -eq 1 ]; then
+    set -- \
+        "$@" \
+        -fullscreen
+fi
+
+
+glxgears_start="$(date +%s 2>/dev/null || echo 0)"
+
+run_with_timeout \
+    "${DURATION_SECONDS}s" \
+    "$@" \
+    >"$GLXGEARS_LOG" 2>&1
+
+glxgears_rc=$?
+glxgears_end="$(date +%s 2>/dev/null || echo 0)"
+glxgears_elapsed=$((glxgears_end - glxgears_start))
+
+
+cat "$GLXGEARS_LOG"
+
+case "$glxgears_rc" in
+    0|124|130|137|143)
+        ;;
+    *)
+        log_fail "glxgears failed with rc=$glxgears_rc"
+        FAILURES=$((FAILURES + 1))
+        ;;
+esac
+
+if [ "$glxgears_elapsed" -lt $((DURATION_SECONDS - 1)) ] 2>/dev/null; then
+    log_fail "glxgears exited too early: elapsed=${glxgears_elapsed}s requested=${DURATION_SECONDS}s rc=$glxgears_rc"
+    FAILURES=$((FAILURES + 1))
+else
+    log_info "glxgears bounded runtime: elapsed=${glxgears_elapsed}s rc=$glxgears_rc"
+fi
+
+DISPLAY_FPS_BACKEND=x11
+
+if [ -n "${EXPECT_FPS:-}" ]; then
+    FPS_EXPECT_MODE="${FPS_EXPECT_MODE:-fixed}"
+elif [ -n "$GLX_REFRESH_HZ" ]; then
+    EXPECT_FPS="$GLX_REFRESH_HZ"
+    FPS_EXPECT_MODE="fixed"
+    log_info "Using captured XRandR refresh for FPS policy: ${EXPECT_FPS}Hz"
+else
+    FPS_EXPECT_MODE="${FPS_EXPECT_MODE:-detected}"
+fi
+
+export DISPLAY_FPS_BACKEND FPS_EXPECT_MODE EXPECT_FPS
+
+if ! display_resolve_fps_policy; then
+    log_fail "Could not derive FPS policy from the active XRandR refresh"
+    FAILURES=$((FAILURES + 1))
+elif ! display_parse_fps_log "$GLXGEARS_LOG"; then
+    log_fail "No glxgears FPS sample was parsed"
+    FAILURES=$((FAILURES + 1))
+elif ! display_fps_gate_avg \
+    "$DISPLAY_FPS_AVG" \
+    "$DISPLAY_FPS_COUNT"; then
+    FAILURES=$((FAILURES + 1))
+else
+    log_pass "glxgears FPS: avg=$DISPLAY_FPS_AVG min=$DISPLAY_FPS_MIN max=$DISPLAY_FPS_MAX samples=$DISPLAY_FPS_COUNT"
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+    log_fail "$TESTNAME FAIL - $FAILURES GLX validation check(s) failed"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+log_pass "$TESTNAME PASS - \
+direct=${DISPLAY_GLX_DIRECT:-unknown}; \
+accelerated=${DISPLAY_GLX_ACCELERATED:-unknown}; \
+vendor=${DISPLAY_GLX_VENDOR:-unknown}; \
+renderer=${DISPLAY_GLX_RENDERER:-unknown}; \
+refresh=${GLX_REFRESH_HZ:-${DISPLAY_X11_REFRESH_HZ:-unknown}}Hz; \
+avg_fps=${DISPLAY_FPS_AVG:-unknown}"
+echo "$TESTNAME PASS" >"$RES_FILE"
+exit 0

--- a/Runner/suites/Multimedia/Graphics/X11_GStreamer_Display/README.md
+++ b/Runner/suites/Multimedia/Graphics/X11_GStreamer_Display/README.md
@@ -1,0 +1,39 @@
+# X11 GStreamer Display
+
+Validates available GStreamer X11 video sinks with a live bounded pipeline.
+
+## Coverage
+
+- Dynamically discovers the usable X11 runtime.
+- Tests `ximagesink` and `glimagesink` by default.
+- Adds `xvimagesink` automatically when the active X server exposes an XVideo adaptor.
+- Requires the pipeline to reach PLAYING, remain active for the requested duration, and report no GStreamer error.
+- Forces the GL sink to the X11/EGL path.
+- Runs sink windows fullscreen by default using the shared X11 watcher.
+- Discovers each new sink window through exact before/after snapshots, avoiding the root, greeter, desktop, and stale windows.
+- Returns `SKIP` on KGSL/proprietary Adreno boot mode.
+
+## Options
+
+```sh
+./run.sh --help
+./run.sh
+./run.sh --fullscreen --duration 10
+./run.sh --windowed --duration 10
+./run.sh --sink ximagesink
+./run.sh --sink ximagesink,glimagesink,xvimagesink
+./run.sh --require-xfce
+```
+
+The pipeline remains live and bounded:
+
+```text
+videotestsrc is-live=true ! videoconvert ! <sink> sync=true
+```
+
+Fullscreen is a visual policy only. A fullscreen warning does not convert a valid rendering pipeline into a failure. Installed fullscreen commands are reused directly. The `graphics-x11-fullscreen` package set is consulted only when a required command is missing.
+
+## Evidence
+
+- `X11_GStreamer_Display.res`
+- Per-sink logs and fullscreen status files under `logs/X11_GStreamer_Display/`

--- a/Runner/suites/Multimedia/Graphics/X11_GStreamer_Display/X11_GStreamer_Display.yaml
+++ b/Runner/suites/Multimedia/Graphics/X11_GStreamer_Display/X11_GStreamer_Display.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: X11_GStreamer_Display
+  format: "Lava-Test Test Definition 1.0"
+  description: "Validates live GStreamer X11 sinks in bounded mode with exact-window fullscreen control."
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Multimedia/Graphics/X11_GStreamer_Display
+    - ./run.sh --fullscreen || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh X11_GStreamer_Display.res || true

--- a/Runner/suites/Multimedia/Graphics/X11_GStreamer_Display/run.sh
+++ b/Runner/suites/Multimedia/Graphics/X11_GStreamer_Display/run.sh
@@ -1,0 +1,426 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# Validate X11 video presentation using available GStreamer display sinks.
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+
+TESTNAME="X11_GStreamer_Display"
+RES_FILE="$SCRIPT_DIR/${TESTNAME}.res"
+
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/lib_display.sh"
+
+if [ -r "$TOOLS/lib_pkg_provider.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_pkg_provider.sh"
+fi
+
+if [ -r "$TOOLS/lib_module_reload.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_module_reload.sh"
+fi
+
+LC_ALL=C
+export LC_ALL
+
+test_path="$(find_test_case_by_name "$TESTNAME" 2>/dev/null || true)"
+
+if [ -z "$test_path" ] || [ ! -d "$test_path" ]; then
+    log_skip "$TESTNAME SKIP - test path not found"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if ! cd "$test_path"; then
+    log_skip "$TESTNAME SKIP - cannot cd into $test_path"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+RES_FILE="./${TESTNAME}.res"
+LOG_DIR="./logs"
+OUTDIR="$LOG_DIR/$TESTNAME"
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/lib_gstreamer.sh"
+
+DURATION_SECONDS="${DURATION_SECONDS:-10}"
+GST_SINK_MODE="${GST_SINK_MODE:-auto}"
+REQUIRE_XFCE="${REQUIRE_XFCE:-0}"
+X11_FULLSCREEN="${X11_FULLSCREEN:-1}"
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+SELECTED_COUNT=0
+FULLSCREEN_WATCH_AVAILABLE=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --duration <seconds>     Runtime for each selected pipeline
+  --sink <mode>            auto, all, or comma-separated sink elements
+  --fullscreen             Run sink windows fullscreen; default
+  --windowed               Keep each sink window at its native size
+  --require-xfce           Require a real XFCE session
+  -h, --help              Show this help
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --duration)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --duration"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            DURATION_SECONDS="$2"
+            shift 2
+            ;;
+        --duration=*)
+            DURATION_SECONDS=${1#*=}
+            shift
+            ;;
+        --sink|--gst-sink)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --sink"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            GST_SINK_MODE="$2"
+            shift 2
+            ;;
+        --sink=*|--gst-sink=*)
+            GST_SINK_MODE=${1#*=}
+            shift
+            ;;
+        --fullscreen)
+            X11_FULLSCREEN=1
+            shift
+            ;;
+        --windowed)
+            X11_FULLSCREEN=0
+            shift
+            ;;
+        --require-xfce)
+            REQUIRE_XFCE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_skip "$TESTNAME SKIP - unknown option: $1"
+            usage
+            echo "$TESTNAME SKIP" >"$RES_FILE"
+            exit 0
+            ;;
+    esac
+done
+
+case "$DURATION_SECONDS" in
+    ''|*[!0-9]*|0)
+        log_skip "$TESTNAME SKIP - duration must be a positive integer"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+case "$REQUIRE_XFCE" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - REQUIRE_XFCE must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+case "$X11_FULLSCREEN" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - X11_FULLSCREEN must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+rm -f "$RES_FILE"
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+log_info "-------------------------------------------------------------------"
+log_info "---------------- Starting $TESTNAME testcase ----------------"
+log_info "DURATION_SECONDS=$DURATION_SECONDS GST_SINK_MODE=$GST_SINK_MODE"
+log_info "X11_FULLSCREEN=$X11_FULLSCREEN"
+
+GPU_BOOT_MODE="unknown"
+
+if command -v mrv_qcom_gpu_boot_mode >/dev/null 2>&1; then
+    GPU_BOOT_MODE="$(mrv_qcom_gpu_boot_mode 2>/dev/null || true)"
+    [ -n "$GPU_BOOT_MODE" ] || GPU_BOOT_MODE="unknown"
+fi
+
+log_info "Detected Qualcomm GPU boot mode: $GPU_BOOT_MODE"
+
+if [ "$GPU_BOOT_MODE" = "kgsl" ]; then
+    log_skip "$TESTNAME SKIP - KGSL/proprietary Adreno boot mode requires the Weston/Wayland validation path"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v pkg_ensure_required_package_set_present >/dev/null 2>&1; then
+    if ! pkg_ensure_required_package_set_present graphics-x11-display ||
+       ! pkg_ensure_required_package_set_present graphics-x11-gstreamer; then
+        log_skip "$TESTNAME SKIP - failed to ensure the GStreamer X11 package sets"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+    fi
+
+fi
+
+hash -r 2>/dev/null || true
+
+deps="xdpyinfo xrandr gst-launch-1.0 gst-inspect-1.0 awk sed grep tr date"
+
+if [ "$X11_FULLSCREEN" -eq 1 ]; then
+    if command -v display_x11_prepare_fullscreen_support >/dev/null 2>&1 &&
+       display_x11_prepare_fullscreen_support &&
+       command -v display_x11_fullscreen_watch_start >/dev/null 2>&1 &&
+       command -v display_x11_fullscreen_watch_finish >/dev/null 2>&1; then
+        FULLSCREEN_WATCH_AVAILABLE=1
+    else
+        log_warn "Shared X11 fullscreen watcher is unavailable; GStreamer sink windows may remain windowed"
+    fi
+fi
+
+check_dependencies "$deps"
+
+if ! command -v display_x11_resolve_env >/dev/null 2>&1; then
+    log_fail "$TESTNAME FAIL - display_x11_resolve_env helper is unavailable"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if ! display_x11_resolve_env \
+    "${DISPLAY:-}" \
+    "${XAUTHORITY:-}"; then
+    log_skip "$TESTNAME SKIP - no usable X11 display and Xauthority pair could be discovered"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_info "Resolved X11 runtime:"
+log_info " DISPLAY=$DISPLAY"
+log_info " XAUTHORITY=${XAUTHORITY:-<unset>}"
+log_info " server_pid=${DISPLAY_X11_SERVER_PID:-unknown}"
+log_info " session=${DISPLAY_X11_SESSION_KIND:-unknown}"
+
+if [ "$REQUIRE_XFCE" -eq 1 ] &&
+   [ "${DISPLAY_X11_SESSION_KIND:-unknown}" != "xfce" ]; then
+    log_skip "$TESTNAME SKIP - real XFCE session required; detected ${DISPLAY_X11_SESSION_KIND:-unknown}"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v ensure_xdg_runtime_dir >/dev/null 2>&1; then
+    ensure_xdg_runtime_dir
+fi
+
+if [ -z "${XDG_RUNTIME_DIR:-}" ] || [ ! -d "$XDG_RUNTIME_DIR" ]; then
+    log_fail "$TESTNAME FAIL - could not prepare XDG_RUNTIME_DIR"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+case "$GST_SINK_MODE" in
+    auto)
+        requested_sinks="ximagesink glimagesink"
+
+        if display_x11_xvideo_available; then
+            requested_sinks="$requested_sinks xvimagesink"
+        fi
+        ;;
+    all)
+        requested_sinks="ximagesink glimagesink xvimagesink"
+        ;;
+    *)
+        requested_sinks="$(printf '%s\n' "$GST_SINK_MODE" | tr ',' ' ')"
+        ;;
+esac
+
+for sink in $requested_sinks; do
+    [ -n "$sink" ] || continue
+    SELECTED_COUNT=$((SELECTED_COUNT + 1))
+
+    if ! has_element "$sink"; then
+        log_skip "$sink SKIP - GStreamer element is unavailable"
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        continue
+    fi
+
+    if [ "$sink" = "xvimagesink" ] &&
+       ! display_x11_xvideo_available; then
+        log_skip "$sink SKIP - active X server exposes no XVideo adaptor"
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        continue
+    fi
+
+    pipeline="videotestsrc is-live=true ! videoconvert ! ${sink} sync=true"
+    sink_log="$OUTDIR/${sink}.log"
+
+    old_gst_gl_window="${GST_GL_WINDOW:-}"
+    old_gst_gl_platform="${GST_GL_PLATFORM:-}"
+    old_gst_gl_api="${GST_GL_API:-}"
+    had_gst_gl_window=0
+    had_gst_gl_platform=0
+    had_gst_gl_api=0
+
+    [ "${GST_GL_WINDOW+x}" = "x" ] && had_gst_gl_window=1
+    [ "${GST_GL_PLATFORM+x}" = "x" ] && had_gst_gl_platform=1
+    [ "${GST_GL_API+x}" = "x" ] && had_gst_gl_api=1
+
+    if [ "$sink" = "glimagesink" ]; then
+        GST_GL_WINDOW="${GST_GL_WINDOW:-x11}"
+        GST_GL_PLATFORM="${GST_GL_PLATFORM:-egl}"
+        GST_GL_API="${GST_GL_API:-gles2}"
+        export GST_GL_WINDOW GST_GL_PLATFORM GST_GL_API
+
+        log_info "glimagesink environment: GST_GL_WINDOW=$GST_GL_WINDOW GST_GL_PLATFORM=$GST_GL_PLATFORM GST_GL_API=$GST_GL_API"
+    fi
+
+    if [ "$FULLSCREEN_WATCH_AVAILABLE" -eq 1 ]; then
+        display_x11_fullscreen_watch_start \
+            "$DURATION_SECONDS" \
+            "gst-launch-1.0" \
+            "$OUTDIR/${sink}-fullscreen.status" ||
+            true
+    fi
+
+    sink_start="$(date +%s 2>/dev/null || echo 0)"
+
+    gstreamer_run_gstlaunch_timeout \
+        "$DURATION_SECONDS" \
+        "$pipeline" \
+        >"$sink_log" 2>&1
+
+    sink_rc=$?
+    sink_end="$(date +%s 2>/dev/null || echo 0)"
+    sink_elapsed=$((sink_end - sink_start))
+
+    if [ "$FULLSCREEN_WATCH_AVAILABLE" -eq 1 ]; then
+        display_x11_fullscreen_watch_finish ||
+            true
+    fi
+
+    if [ "$had_gst_gl_window" -eq 1 ]; then
+        GST_GL_WINDOW="$old_gst_gl_window"
+        export GST_GL_WINDOW
+    else
+        unset GST_GL_WINDOW
+    fi
+
+    if [ "$had_gst_gl_platform" -eq 1 ]; then
+        GST_GL_PLATFORM="$old_gst_gl_platform"
+        export GST_GL_PLATFORM
+    else
+        unset GST_GL_PLATFORM
+    fi
+
+    if [ "$had_gst_gl_api" -eq 1 ]; then
+        GST_GL_API="$old_gst_gl_api"
+        export GST_GL_API
+    else
+        unset GST_GL_API
+    fi
+
+    cat "$sink_log"
+
+    if grep -q 'ERROR:' "$sink_log" 2>/dev/null; then
+        log_fail "$sink FAIL - GStreamer reported an error, rc=$sink_rc"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        continue
+    fi
+
+    if ! grep -Eq \
+        'Pipeline is PLAYING|Setting pipeline to PLAYING' \
+        "$sink_log" 2>/dev/null; then
+        log_fail "$sink FAIL - pipeline never reached PLAYING, rc=$sink_rc"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        continue
+    fi
+
+    case "$sink_rc" in
+        0|124|130|137|143)
+            if [ "$sink_elapsed" -lt $((DURATION_SECONDS - 1)) ] 2>/dev/null; then
+                log_fail "$sink FAIL - pipeline exited too early: elapsed=${sink_elapsed}s requested=${DURATION_SECONDS}s rc=$sink_rc"
+                FAIL_COUNT=$((FAIL_COUNT + 1))
+            else
+                log_pass "$sink PASS - reached PLAYING for ${sink_elapsed}s rc=$sink_rc"
+                PASS_COUNT=$((PASS_COUNT + 1))
+            fi
+            ;;
+        *)
+            log_fail "$sink FAIL - unexpected gst-launch return code: $sink_rc"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            ;;
+    esac
+done
+
+if [ "$SELECTED_COUNT" -eq 0 ]; then
+    log_skip "$TESTNAME SKIP - no GStreamer sink was selected"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    log_fail "$TESTNAME FAIL - $FAIL_COUNT sink(s) failed; $PASS_COUNT passed; $SKIP_COUNT skipped"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if [ "$PASS_COUNT" -eq 0 ]; then
+    log_skip "$TESTNAME SKIP - no GStreamer sink completed; $SKIP_COUNT skipped"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_pass "$TESTNAME PASS - $PASS_COUNT sink(s) passed; $SKIP_COUNT skipped"
+echo "$TESTNAME PASS" >"$RES_FILE"
+exit 0

--- a/Runner/suites/Multimedia/Graphics/X11_Glmark2/README.md
+++ b/Runner/suites/Multimedia/Graphics/X11_Glmark2/README.md
@@ -1,0 +1,38 @@
+# X11 Glmark2
+
+Runs available X11 glmark2 desktop OpenGL and OpenGL ES variants with bounded, configurable scenes and rejects software rendering.
+
+## Coverage
+
+- Dynamically discovers the usable X11 runtime.
+- Runs `glmark2` and `glmark2-es2` when available.
+- Uses a short bounded benchmark list by default.
+- Requires a successful command return, hardware renderer classification, and numeric `glmark2 Score`.
+- Uses glmark2's native `--fullscreen` option; no external window watcher is needed.
+- Returns `SKIP` on KGSL/proprietary Adreno boot mode.
+
+## Options
+
+```sh
+./run.sh --help
+./run.sh
+./run.sh --fullscreen --duration 5
+./run.sh --windowed --duration 5
+./run.sh --timeout 45
+./run.sh --binaries glmark2,glmark2-es2
+./run.sh --benchmarks ':duration=5.0,build:use-vbo=true'
+./run.sh --require-xfce
+```
+
+The default benchmark configuration is:
+
+```text
+:duration=<duration>.0,build:use-vbo=true
+```
+
+The timeout is calculated dynamically from the scene count when `--timeout auto` is used.
+
+## Evidence
+
+- `X11_Glmark2.res`
+- Per-binary logs under `logs/X11_Glmark2/`

--- a/Runner/suites/Multimedia/Graphics/X11_Glmark2/X11_Glmark2.yaml
+++ b/Runner/suites/Multimedia/Graphics/X11_Glmark2/X11_Glmark2.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: X11_Glmark2
+  format: "Lava-Test Test Definition 1.0"
+  description: "Runs bounded hardware glmark2 X11 variants using native fullscreen mode and validates numeric scores."
+  os:
+    - linux
+  scope:
+    - functional
+
+run:
+  steps:
+    - REPO_PATH=$PWD
+    - cd Runner/suites/Multimedia/Graphics/X11_Glmark2
+    - ./run.sh --fullscreen || true
+    - $REPO_PATH/Runner/utils/send-to-lava.sh X11_Glmark2.res || true

--- a/Runner/suites/Multimedia/Graphics/X11_Glmark2/run.sh
+++ b/Runner/suites/Multimedia/Graphics/X11_Glmark2/run.sh
@@ -1,0 +1,439 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+# Validate desktop OpenGL and OpenGL ES rendering with bounded glmark2 scenes.
+
+SCRIPT_DIR="$(
+    cd "$(dirname "$0")" || exit 1
+    pwd
+)"
+
+TESTNAME="X11_Glmark2"
+RES_FILE="$SCRIPT_DIR/${TESTNAME}.res"
+
+INIT_ENV=""
+SEARCH="$SCRIPT_DIR"
+
+while [ "$SEARCH" != "/" ]; do
+    if [ -f "$SEARCH/init_env" ]; then
+        INIT_ENV="$SEARCH/init_env"
+        break
+    fi
+
+    SEARCH=$(dirname "$SEARCH")
+done
+
+if [ -z "$INIT_ENV" ]; then
+    echo "[ERROR] Could not find init_env (starting at $SCRIPT_DIR)" >&2
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if [ -z "${__INIT_ENV_LOADED:-}" ]; then
+    # shellcheck disable=SC1090
+    . "$INIT_ENV"
+    __INIT_ENV_LOADED=1
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/functestlib.sh"
+# shellcheck disable=SC1090,SC1091
+. "$TOOLS/lib_display.sh"
+
+if [ -r "$TOOLS/lib_pkg_provider.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_pkg_provider.sh"
+fi
+
+if [ -r "$TOOLS/lib_module_reload.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$TOOLS/lib_module_reload.sh"
+fi
+
+LC_ALL=C
+export LC_ALL
+
+test_path="$(find_test_case_by_name "$TESTNAME" 2>/dev/null || true)"
+
+if [ -z "$test_path" ] || [ ! -d "$test_path" ]; then
+    log_skip "$TESTNAME SKIP - test path not found"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if ! cd "$test_path"; then
+    log_skip "$TESTNAME SKIP - cannot cd into $test_path"
+    echo "$TESTNAME SKIP" >"$RES_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+RES_FILE="./${TESTNAME}.res"
+LOG_DIR="./logs"
+OUTDIR="$LOG_DIR/$TESTNAME"
+
+DURATION_SECONDS="${DURATION_SECONDS:-5}"
+GLMARK_TIMEOUT_SECONDS="${GLMARK_TIMEOUT_SECONDS:-auto}"
+GLMARK_BENCHMARKS="${GLMARK_BENCHMARKS:-auto}"
+GLMARK_BINARIES="${GLMARK_BINARIES:-auto}"
+REQUIRE_XFCE="${REQUIRE_XFCE:-0}"
+X11_FULLSCREEN="${X11_FULLSCREEN:-1}"
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --duration <seconds>     Default glmark2 scene duration
+  --timeout <seconds>      Per-binary timeout, or auto
+  --benchmarks <list>      Comma-separated benchmark specifications
+  --binaries <list>       auto or comma-separated glmark2 commands
+  --fullscreen             Run glmark2 fullscreen; default
+  --windowed               Keep the native glmark2 window size
+  --require-xfce           Require a real XFCE session
+  -h, --help              Show this help
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --duration)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --duration"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            DURATION_SECONDS="$2"
+            shift 2
+            ;;
+        --duration=*)
+            DURATION_SECONDS=${1#*=}
+            shift
+            ;;
+        --timeout|--glmark-timeout)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --timeout"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            GLMARK_TIMEOUT_SECONDS="$2"
+            shift 2
+            ;;
+        --timeout=*|--glmark-timeout=*)
+            GLMARK_TIMEOUT_SECONDS=${1#*=}
+            shift
+            ;;
+        --benchmarks|--glmark-benchmarks)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --benchmarks"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            GLMARK_BENCHMARKS="$2"
+            shift 2
+            ;;
+        --benchmarks=*|--glmark-benchmarks=*)
+            GLMARK_BENCHMARKS=${1#*=}
+            shift
+            ;;
+        --binaries|--glmark-binaries)
+            if [ "$#" -lt 2 ]; then
+                log_skip "$TESTNAME SKIP - missing value for --binaries"
+                echo "$TESTNAME SKIP" >"$RES_FILE"
+                exit 0
+            fi
+
+            GLMARK_BINARIES="$2"
+            shift 2
+            ;;
+        --binaries=*|--glmark-binaries=*)
+            GLMARK_BINARIES=${1#*=}
+            shift
+            ;;
+        --fullscreen)
+            X11_FULLSCREEN=1
+            shift
+            ;;
+        --windowed)
+            X11_FULLSCREEN=0
+            shift
+            ;;
+        --require-xfce)
+            REQUIRE_XFCE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            log_skip "$TESTNAME SKIP - unknown option: $1"
+            usage
+            echo "$TESTNAME SKIP" >"$RES_FILE"
+            exit 0
+            ;;
+    esac
+done
+
+case "$DURATION_SECONDS" in
+    ''|*[!0-9]*|0)
+        log_skip "$TESTNAME SKIP - duration must be a positive integer"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+if [ "$GLMARK_BENCHMARKS" = "auto" ]; then
+    GLMARK_BENCHMARKS=":duration=${DURATION_SECONDS}.0,build:use-vbo=true"
+fi
+
+benchmarks="$(printf '%s\n' "$GLMARK_BENCHMARKS" | tr ',' ' ')"
+benchmark_count=0
+
+for benchmark in $benchmarks; do
+    [ -n "$benchmark" ] || continue
+
+    case "$benchmark" in
+        :*)
+            ;;
+        *)
+            benchmark_count=$((benchmark_count + 1))
+            ;;
+    esac
+done
+
+if [ "$benchmark_count" -eq 0 ]; then
+    benchmark_count=1
+fi
+
+if [ "$GLMARK_TIMEOUT_SECONDS" = "auto" ]; then
+    GLMARK_TIMEOUT_SECONDS=$((DURATION_SECONDS * benchmark_count + 30))
+else
+    case "$GLMARK_TIMEOUT_SECONDS" in
+        ''|*[!0-9]*|0)
+            log_skip "$TESTNAME SKIP - timeout must be auto or a positive integer"
+            echo "$TESTNAME SKIP" >"$RES_FILE"
+            exit 0
+            ;;
+    esac
+fi
+
+case "$REQUIRE_XFCE" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - REQUIRE_XFCE must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+case "$X11_FULLSCREEN" in
+    0|1)
+        ;;
+    *)
+        log_skip "$TESTNAME SKIP - X11_FULLSCREEN must be 0 or 1"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+        ;;
+esac
+
+rm -f "$RES_FILE"
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+log_info "-------------------------------------------------------------------"
+log_info "---------------- Starting $TESTNAME testcase ----------------"
+log_info "DURATION_SECONDS=$DURATION_SECONDS"
+log_info "GLMARK_TIMEOUT_SECONDS=$GLMARK_TIMEOUT_SECONDS"
+log_info "GLMARK_BENCHMARKS=$GLMARK_BENCHMARKS"
+log_info "GLMARK_BINARIES=$GLMARK_BINARIES"
+log_info "X11_FULLSCREEN=$X11_FULLSCREEN"
+
+GPU_BOOT_MODE="unknown"
+
+if command -v mrv_qcom_gpu_boot_mode >/dev/null 2>&1; then
+    GPU_BOOT_MODE="$(mrv_qcom_gpu_boot_mode 2>/dev/null || true)"
+    [ -n "$GPU_BOOT_MODE" ] || GPU_BOOT_MODE="unknown"
+fi
+
+log_info "Detected Qualcomm GPU boot mode: $GPU_BOOT_MODE"
+
+if [ "$GPU_BOOT_MODE" = "kgsl" ]; then
+    log_skip "$TESTNAME SKIP - KGSL/proprietary Adreno boot mode requires the Weston/Wayland validation path"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+if command -v pkg_ensure_required_package_set_present >/dev/null 2>&1; then
+    if ! pkg_ensure_required_package_set_present graphics-x11-display ||
+       ! pkg_ensure_required_package_set_present graphics-x11-glmark2; then
+        log_skip "$TESTNAME SKIP - failed to ensure the glmark2 X11 package sets"
+        echo "$TESTNAME SKIP" >"$RES_FILE"
+        exit 0
+    fi
+fi
+
+hash -r 2>/dev/null || true
+
+deps="xdpyinfo xrandr awk sed grep tr"
+check_dependencies "$deps"
+
+if ! command -v display_x11_resolve_env >/dev/null 2>&1; then
+    log_fail "$TESTNAME FAIL - display_x11_resolve_env helper is unavailable"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if ! display_x11_resolve_env \
+    "${DISPLAY:-}" \
+    "${XAUTHORITY:-}"; then
+    log_skip "$TESTNAME SKIP - no usable X11 display and Xauthority pair could be discovered"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_info "Resolved X11 runtime:"
+log_info " DISPLAY=$DISPLAY"
+log_info " XAUTHORITY=${XAUTHORITY:-<unset>}"
+log_info " server_pid=${DISPLAY_X11_SERVER_PID:-unknown}"
+log_info " session=${DISPLAY_X11_SESSION_KIND:-unknown}"
+
+if [ "$REQUIRE_XFCE" -eq 1 ] &&
+   [ "${DISPLAY_X11_SESSION_KIND:-unknown}" != "xfce" ]; then
+    log_skip "$TESTNAME SKIP - real XFCE session required; detected ${DISPLAY_X11_SESSION_KIND:-unknown}"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+requested_bins="$(printf '%s\n' "$GLMARK_BINARIES" | tr ',' ' ')"
+
+if [ "$requested_bins" = "auto" ]; then
+    requested_bins="glmark2 glmark2-es2"
+fi
+
+for bin in $requested_bins; do
+    [ -n "$bin" ] || continue
+
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        if command -v pkg_ensure_command >/dev/null 2>&1; then
+            pkg_ensure_command "$bin" >/dev/null 2>&1 || true
+            hash -r 2>/dev/null || true
+        fi
+    fi
+
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        log_skip "$bin SKIP - benchmark binary is unavailable"
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        continue
+    fi
+
+    bin_name="$(basename "$bin")"
+    log_file="$OUTDIR/${bin_name}.log"
+    set -- \
+        "$bin"
+
+    if [ "$X11_FULLSCREEN" -eq 1 ]; then
+        set -- \
+            "$@" \
+            --fullscreen
+    fi
+
+    for benchmark in $benchmarks; do
+        [ -n "$benchmark" ] || continue
+
+        set -- \
+            "$@" \
+            --benchmark \
+            "$benchmark"
+    done
+
+    run_with_timeout \
+        "${GLMARK_TIMEOUT_SECONDS}s" \
+        "$@" \
+        >"$log_file" 2>&1
+
+    glmark_rc=$?
+
+    cat "$log_file"
+
+    if [ "$glmark_rc" -ne 0 ]; then
+        log_fail "$bin FAIL - benchmark did not complete, rc=$glmark_rc"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        continue
+    fi
+
+    vendor="$(
+        sed -n \
+            's/^[[:space:]]*GL_VENDOR:[[:space:]]*//p' \
+            "$log_file" |
+            head -n 1
+    )"
+    renderer="$(
+        sed -n \
+            's/^[[:space:]]*GL_RENDERER:[[:space:]]*//p' \
+            "$log_file" |
+            head -n 1
+    )"
+    version="$(
+        sed -n \
+            's/^[[:space:]]*GL_VERSION:[[:space:]]*//p' \
+            "$log_file" |
+            head -n 1
+    )"
+    score="$(
+        awk '
+            /glmark2 Score:/ {
+                sub(/^.*glmark2 Score:[[:space:]]*/, "")
+                print $1
+                exit
+            }
+        ' "$log_file"
+    )"
+    pipeline_kind="$(
+        egli_classify_pipeline \
+            "" \
+            "$vendor" \
+            "$renderer"
+    )"
+
+    case "$pipeline_kind" in
+        CPU*)
+            log_fail "$bin FAIL - software renderer detected: ${renderer:-unknown}"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            continue
+            ;;
+    esac
+
+    case "$score" in
+        ''|*[!0-9.]*)
+            log_fail "$bin FAIL - numeric glmark2 score was not produced"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            continue
+            ;;
+    esac
+
+    log_pass "$bin PASS - score=$score; vendor=${vendor:-unknown}; renderer=${renderer:-unknown}; version=${version:-unknown}"
+    PASS_COUNT=$((PASS_COUNT + 1))
+done
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    log_fail "$TESTNAME FAIL - $FAIL_COUNT benchmark(s) failed; $PASS_COUNT passed; $SKIP_COUNT skipped"
+    echo "$TESTNAME FAIL" >"$RES_FILE"
+    exit 0
+fi
+
+if [ "$PASS_COUNT" -eq 0 ]; then
+    log_skip "$TESTNAME SKIP - no benchmark completed; $SKIP_COUNT skipped"
+    echo "$TESTNAME SKIP" >"$RES_FILE"
+    exit 0
+fi
+
+log_pass "$TESTNAME PASS - $PASS_COUNT benchmark binary/binaries passed; $SKIP_COUNT skipped"
+echo "$TESTNAME PASS" >"$RES_FILE"
+exit 0

--- a/Runner/utils/lib_display.sh
+++ b/Runner/utils/lib_display.sh
@@ -1439,175 +1439,392 @@ egli_print_legacy() {
   log_info "EGLINFO: GL_RENDERER: $gl_renderer"
 }
 
+# Extract one platform section from multi-platform Mesa eglinfo output.
+#
+# Args:
+#   $1 - platform name: x11, wayland, gbm, device, or surfaceless
+#
+# Input:
+#   eglinfo output on stdin
+#
+# Output:
+#   Only the requested platform section
+egli_extract_platform_section() {
+    eps_platform="$1"
+
+    awk \
+        -v wanted="$eps_platform" '
+        function platform_name(line) {
+            if (line ~ /^GBM platform:[[:space:]]*$/) {
+                return "gbm"
+            }
+
+            if (line ~ /^Wayland platform:[[:space:]]*$/) {
+                return "wayland"
+            }
+
+            if (line ~ /^X11 platform:[[:space:]]*$/) {
+                return "x11"
+            }
+
+            if (line ~ /^Surfaceless platform:[[:space:]]*$/) {
+                return "surfaceless"
+            }
+
+            if (line ~ /^Device platform:[[:space:]]*$/) {
+                return "device"
+            }
+
+            return ""
+        }
+
+        {
+            detected = platform_name($0)
+
+            if (detected != "") {
+                if (selected && detected != wanted) {
+                    exit
+                }
+
+                selected = detected == wanted
+            }
+
+            if (selected) {
+                print
+            }
+        }
+        '
+}
+
 egli_try_one_platform() {
-  plat="$1"
-  plat_flag="$2"
-
-  EGLINFO="${EGLINFO:-eglinfo}"
-
-  if [ -n "$plat_flag" ]; then
-    out="$("$EGLINFO" "$plat_flag" "$plat" 2>&1)"
-    rc=$?
-  else
-    out="$(EGL_PLATFORM="$plat" "$EGLINFO" 2>&1)"
-    rc=$?
-  fi
-
-  # “Initialized?” heuristic: at least one of these should exist
-  egl_vendor="$(printf '%s\n' "$out" | egli_get_field "EGL vendor string")"
-  egl_version="$(printf '%s\n' "$out" | egli_get_field "EGL version string")"
-  egl_api_ver="$(printf '%s\n' "$out" | egli_get_field "EGL API version")"
-
-  ok=0
-  [ -n "$egl_vendor" ] && ok=1
-  [ -n "$egl_version" ] && ok=1
-  [ -n "$egl_api_ver" ] && ok=1
-
-  if [ "$rc" -ne 0 ] || [ "$ok" -eq 0 ]; then
-    log_warn "eglinfo platform '$plat' did not initialize cleanly (rc=$rc)."
-    if [ "${EGLINFO_DEBUG:-0}" = "1" ]; then
-      log_info "---- eglinfo output (platform '$plat') ----"
-      printf '%s\n' "$out"
-      log_info "---- end eglinfo output ----"
+    plat="$1"
+    plat_flag="$2"
+ 
+    EGLINFO="${EGLINFO:-eglinfo}"
+ 
+    out=""
+    parse_out=""
+    platform_out=""
+    rc=0
+ 
+    if [ -n "$plat_flag" ]; then
+        out="$(
+            "$EGLINFO" \
+                "$plat_flag" \
+                "$plat" \
+                2>&1
+        )"
+ 
+        rc=$?
+    else
+        out="$(
+            EGL_PLATFORM="$plat" \
+                "$EGLINFO" \
+                2>&1
+        )"
+ 
+        rc=$?
     fi
-    return 1
-  fi
-
-  # Driver name
-  driver="$(egli_get_first "$out" \
-    "EGL driver name" \
-    "EGL driver" \
-    "Driver name" \
-    "Driver")"
-
-  # GL vendor
-  gl_vendor="$(egli_get_first "$out" \
-    "GL_VENDOR" \
-    "OpenGL ES profile vendor string" \
-    "OpenGL vendor string" \
-    "OpenGL ES vendor string")"
-
-  # GL renderer
-  gl_renderer="$(egli_get_first "$out" \
-    "GL_RENDERER" \
-    "OpenGL ES profile renderer string" \
-    "OpenGL renderer string" \
-    "OpenGL ES renderer string")"
-
-  # Avoid classification on empty strings
-  [ -n "$driver" ] || driver="unknown"
-  [ -n "$gl_vendor" ] || gl_vendor="unknown"
-  [ -n "$gl_renderer" ] || gl_renderer="unknown"
-
-  # If eglinfo didn't expose a driver name, derive one from GLVND JSON + strings
-  if [ "$driver" = "unknown" ]; then
-    driver="$(egli_derive_driver_name "$gl_vendor" "$gl_renderer")"
-  fi
-
-  # Print GPU/CPU pipeline type
-  pipe_kind="$(egli_classify_pipeline "$driver" "$gl_vendor" "$gl_renderer")"
-  log_info "EGLINFO: Pipeline type: $pipe_kind"
-
-  # ---- Cache what we used, so decision uses the same data ----
-  EGLI_LAST_PLATFORM="$plat"
-  EGLI_LAST_DRIVER="$driver"
-  EGLI_LAST_GL_VENDOR="$gl_vendor"
-  EGLI_LAST_GL_RENDERER="$gl_renderer"
-  EGLI_LAST_PIPE_KIND="$pipe_kind"
-  if [ "${EGLINFO_CACHE_OUTPUT:-0}" = "1" ]; then
-    EGLI_LAST_OUT="$out"
-  else
-    EGLI_LAST_OUT=""
-  fi
-  # -----------------------------------------------------------
-
-  egli_print_legacy "$plat" "$driver" "$gl_vendor" "$gl_renderer"
-  return 0
+ 
+    platform_out="$(
+        printf '%s\n' "$out" |
+            egli_extract_platform_section \
+                "$plat"
+    )"
+ 
+    if [ -n "$platform_out" ]; then
+        parse_out="$platform_out"
+    else
+        parse_out="$out"
+    fi
+ 
+    egl_vendor="$(
+        printf '%s\n' "$parse_out" |
+            egli_get_field \
+                "EGL vendor string"
+    )"
+ 
+    egl_version="$(
+        printf '%s\n' "$parse_out" |
+            egli_get_field \
+                "EGL version string"
+    )"
+ 
+    egl_api_ver="$(
+        printf '%s\n' "$parse_out" |
+            egli_get_field \
+                "EGL API version"
+    )"
+ 
+    ok=0
+ 
+    [ -n "$egl_vendor" ] && ok=1
+    [ -n "$egl_version" ] && ok=1
+    [ -n "$egl_api_ver" ] && ok=1
+ 
+    if [ "$ok" -eq 0 ] ||
+       printf '%s\n' "$parse_out" |
+           grep -q \
+               '^eglinfo: eglInitialize failed'; then
+        log_warn "eglinfo platform '$plat' did not initialize cleanly, rc=$rc"
+ 
+        if [ "${EGLINFO_DEBUG:-0}" = "1" ]; then
+            log_info "---- eglinfo output, platform '$plat' ----"
+ 
+            printf '%s\n' "$parse_out"
+ 
+            log_info "---- end eglinfo output ----"
+        fi
+ 
+        return 1
+    fi
+ 
+    if [ "$rc" -ne 0 ] &&
+       [ -n "$platform_out" ]; then
+        log_warn "eglinfo returned rc=$rc because another platform probe failed; selected platform '$plat' initialized successfully"
+    fi
+ 
+    driver="$(
+        egli_get_first \
+            "$parse_out" \
+            "EGL driver name" \
+            "EGL driver" \
+            "Driver name" \
+            "Driver"
+    )"
+ 
+    gl_vendor="$(
+        egli_get_first \
+            "$parse_out" \
+            "GL_VENDOR" \
+            "OpenGL ES profile vendor" \
+            "OpenGL core profile vendor" \
+            "OpenGL compatibility profile vendor" \
+            "OpenGL ES profile vendor string" \
+            "OpenGL vendor string" \
+            "OpenGL ES vendor string"
+    )"
+ 
+    gl_renderer="$(
+        egli_get_first \
+            "$parse_out" \
+            "GL_RENDERER" \
+            "OpenGL ES profile renderer" \
+            "OpenGL core profile renderer" \
+            "OpenGL compatibility profile renderer" \
+            "OpenGL ES profile renderer string" \
+            "OpenGL renderer string" \
+            "OpenGL ES renderer string"
+    )"
+ 
+    [ -n "$egl_vendor" ] || egl_vendor="unknown"
+    [ -n "$egl_version" ] || egl_version="unknown"
+    [ -n "$egl_api_ver" ] || egl_api_ver="unknown"
+    [ -n "$driver" ] || driver="unknown"
+    [ -n "$gl_vendor" ] || gl_vendor="unknown"
+    [ -n "$gl_renderer" ] || gl_renderer="unknown"
+ 
+    if [ "$driver" = "unknown" ]; then
+        driver="$(
+            egli_derive_driver_name \
+                "$gl_vendor" \
+                "$gl_renderer"
+        )"
+    fi
+ 
+    pipe_kind="$(
+        egli_classify_pipeline \
+            "$driver" \
+            "$gl_vendor" \
+            "$gl_renderer"
+    )"
+ 
+    log_info "EGLINFO: Pipeline type: $pipe_kind"
+ 
+    EGLI_LAST_PLATFORM="$plat"
+    EGLI_LAST_EGL_VENDOR="$egl_vendor"
+    EGLI_LAST_EGL_VERSION="$egl_version"
+    EGLI_LAST_EGL_API_VERSION="$egl_api_ver"
+    EGLI_LAST_DRIVER="$driver"
+    EGLI_LAST_GL_VENDOR="$gl_vendor"
+    EGLI_LAST_GL_RENDERER="$gl_renderer"
+    EGLI_LAST_PIPE_KIND="$pipe_kind"
+ 
+    if [ "${EGLINFO_CACHE_OUTPUT:-0}" = "1" ]; then
+        EGLI_LAST_OUT="$parse_out"
+    else
+        EGLI_LAST_OUT=""
+    fi
+ 
+    egli_print_legacy \
+        "$plat" \
+        "$driver" \
+        "$gl_vendor" \
+        "$gl_renderer"
+ 
+    return 0
 }
 
 display_print_eglinfo_pipeline() {
-  # Usage: display_print_eglinfo_pipeline auto|wayland|gbm|device|surfaceless
-  mode="${1:-auto}"
-
-  # Clear cached result on every call (prevents stale decisions)
-  EGLI_LAST_PLATFORM=""
-  EGLI_LAST_DRIVER=""
-  EGLI_LAST_GL_VENDOR=""
-  EGLI_LAST_GL_RENDERER=""
-  EGLI_LAST_PIPE_KIND=""
-  EGLI_LAST_OUT=""
-
-  EGLINFO="${EGLINFO:-eglinfo}"
-  if ! command -v "$EGLINFO" >/dev/null 2>&1; then
-    log_error "eglinfo not found (EGLINFO='$EGLINFO')"
-    return 1
-  fi
-
-  # egli_pick_platform_flag may return non-zero; treat empty as "use EGL_PLATFORM="
-  plat_flag="$(egli_pick_platform_flag 2>/dev/null)" || plat_flag=""
-
-  log_info "---------------- EGLINFO pipeline detection (select one) ----------------"
-
-  if [ "$mode" = "auto" ]; then
-    # Prefer wayland only if the socket really exists (base/prop handled)
-    if egli_wayland_socket_ok; then
-      if egli_try_one_platform "wayland" "$plat_flag"; then
-        log_info "---------------- End EGLINFO pipeline detection --------------------------"
-        return 0
-      fi
+    # Usage:
+    #   display_print_eglinfo_pipeline \
+    #       auto|x11|wayland|gbm|device|surfaceless
+    #
+    # Cache populated by egli_try_one_platform():
+    #   EGLI_LAST_PLATFORM
+    #   EGLI_LAST_EGL_VENDOR
+    #   EGLI_LAST_EGL_VERSION
+    #   EGLI_LAST_EGL_API_VERSION
+    #   EGLI_LAST_DRIVER
+    #   EGLI_LAST_GL_VENDOR
+    #   EGLI_LAST_GL_RENDERER
+    #   EGLI_LAST_PIPE_KIND
+    #   EGLI_LAST_OUT
+ 
+    mode="${1:-auto}"
+ 
+    # Clear every cached field before probing so callers never consume stale
+    # data from an earlier platform attempt.
+    EGLI_LAST_PLATFORM=""
+    EGLI_LAST_EGL_VENDOR=""
+    EGLI_LAST_EGL_VERSION=""
+    EGLI_LAST_EGL_API_VERSION=""
+    EGLI_LAST_DRIVER=""
+    EGLI_LAST_GL_VENDOR=""
+    EGLI_LAST_GL_RENDERER=""
+    EGLI_LAST_PIPE_KIND=""
+    EGLI_LAST_OUT=""
+ 
+    EGLINFO="${EGLINFO:-eglinfo}"
+ 
+    if ! command -v "$EGLINFO" >/dev/null 2>&1; then
+        log_error "eglinfo not found, EGLINFO=$EGLINFO"
+        return 1
     fi
-
-    if egli_try_one_platform "gbm" "$plat_flag"; then
-      log_info "---------------- End EGLINFO pipeline detection --------------------------"
-      return 0
-    fi
-
-    if egli_try_one_platform "device" "$plat_flag"; then
-      log_info "---------------- End EGLINFO pipeline detection --------------------------"
-      return 0
-    fi
-
-    if egli_try_one_platform "surfaceless" "$plat_flag"; then
-      log_info "---------------- End EGLINFO pipeline detection --------------------------"
-      return 0
-    fi
-
-    log_warn "No working eglinfo platform found (tried wayland/gbm/device/surfaceless)."
-    log_info "---------------- End EGLINFO pipeline detection --------------------------"
-    return 1
-  fi
-
-  case "$mode" in
-    wayland|gbm|device|surfaceless)
-      # If user explicitly requested wayland but socket is not present, warn and fallback
-      if [ "$mode" = "wayland" ] && ! egli_wayland_socket_ok; then
-        log_warn "Requested 'wayland' but WAYLAND_DISPLAY socket is not present; trying fallbacks..."
-      else
-        if egli_try_one_platform "$mode" "$plat_flag"; then
-          log_info "---------------- End EGLINFO pipeline detection --------------------------"
-          return 0
-        fi
-        log_warn "Requested '$mode' did not work. Trying fallbacks..."
-      fi
-
-      # Fallback order: gbm -> device -> surfaceless -> wayland (last)
-      if egli_try_one_platform "gbm" "$plat_flag"; then :;
-      elif egli_try_one_platform "device" "$plat_flag"; then :;
-      elif egli_try_one_platform "surfaceless" "$plat_flag"; then :;
-      elif egli_wayland_socket_ok && egli_try_one_platform "wayland" "$plat_flag"; then :;
-      else
-        log_warn "No fallback platforms worked either."
-      fi
-
-      log_info "---------------- End EGLINFO pipeline detection --------------------------"
-      return 0
-      ;;
-    *)
-      log_warn "Unknown mode '$mode' (use: auto|wayland|gbm|device|surfaceless). Defaulting to auto."
-      display_print_eglinfo_pipeline auto
-      return $?
-      ;;
-  esac
+ 
+    plat_flag="$(
+        egli_pick_platform_flag \
+            2>/dev/null
+    )" || plat_flag=""
+ 
+    log_info "---------------- EGLINFO pipeline detection (select one) ----------------"
+ 
+    case "$mode" in
+        auto)
+            # Preserve the existing compositor/direct-rendering selection
+            # order. X11 tests must request x11 explicitly so auto mode cannot
+            # accidentally validate a different display stack.
+            if egli_wayland_socket_ok &&
+               egli_try_one_platform \
+                   wayland \
+                   "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            if egli_try_one_platform \
+                gbm \
+                "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            if egli_try_one_platform \
+                device \
+                "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            if egli_try_one_platform \
+                surfaceless \
+                "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            log_warn "No working eglinfo platform found, tried wayland/gbm/device/surfaceless"
+            log_info "---------------- End EGLINFO pipeline detection --------------------------"
+            return 1
+            ;;
+ 
+        x11)
+            # X11 is intentionally strict. Do not fall back to GBM, device,
+            # surfaceless, or Wayland because that would make an X11 testcase
+            # pass without validating X11 EGL.
+            if egli_try_one_platform \
+                x11 \
+                "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            log_warn "Requested X11 EGL platform did not initialize"
+            log_info "---------------- End EGLINFO pipeline detection --------------------------"
+            return 1
+            ;;
+ 
+        wayland|gbm|device|surfaceless)
+            if [ "$mode" = "wayland" ] &&
+               ! egli_wayland_socket_ok; then
+                log_warn "Requested wayland platform, but the WAYLAND_DISPLAY socket is unavailable; trying fallbacks"
+            elif egli_try_one_platform \
+                "$mode" \
+                "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            else
+                log_warn "Requested $mode platform did not initialize; trying fallbacks"
+            fi
+ 
+            # Preserve the existing fallback policy for non-X11 callers.
+            if [ "$mode" != "gbm" ] &&
+               egli_try_one_platform \
+                   gbm \
+                   "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            if [ "$mode" != "device" ] &&
+               egli_try_one_platform \
+                   device \
+                   "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            if [ "$mode" != "surfaceless" ] &&
+               egli_try_one_platform \
+                   surfaceless \
+                   "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            if [ "$mode" != "wayland" ] &&
+               egli_wayland_socket_ok &&
+               egli_try_one_platform \
+                   wayland \
+                   "$plat_flag"; then
+                log_info "---------------- End EGLINFO pipeline detection --------------------------"
+                return 0
+            fi
+ 
+            log_warn "No working eglinfo platform found for requested mode $mode or its fallbacks"
+            log_info "---------------- End EGLINFO pipeline detection --------------------------"
+            return 1
+            ;;
+ 
+        *)
+            log_warn "Unknown mode '$mode', use auto|x11|wayland|gbm|device|surfaceless; defaulting to auto"
+ 
+            display_print_eglinfo_pipeline \
+                auto
+ 
+            return $?
+            ;;
+    esac
 }
 
 ###############################################################################
@@ -1826,6 +2043,7 @@ display_resolve_fps_policy() {
     fps_default="${EXPECT_FPS_DEFAULT:-60}"
     fps_tol="${FPS_TOL_PCT:-10}"
     fps_min_pct="${MIN_FPS_PCT:-85}"
+    fps_backend="${DISPLAY_FPS_BACKEND:-auto}"
 
     case "$fps_mode" in
         auto)
@@ -1849,7 +2067,9 @@ display_resolve_fps_policy() {
     esac
 
     if [ "$DISPLAY_FPS_MODE" = "detected" ]; then
-        if command -v weston_get_primary_refresh_hz >/dev/null 2>&1; then
+        if command -v display_get_primary_refresh_hz >/dev/null 2>&1; then
+            DISPLAY_FPS_DETECTED_HZ="$(display_get_primary_refresh_hz "$fps_backend" 2>/dev/null || true)"
+        elif command -v weston_get_primary_refresh_hz >/dev/null 2>&1; then
             DISPLAY_FPS_DETECTED_HZ="$(weston_get_primary_refresh_hz 2>/dev/null || true)"
         fi
 
@@ -1867,7 +2087,7 @@ display_resolve_fps_policy() {
             *)
                 DISPLAY_FPS_EXPECTED="$(printf '%s\n' "$DISPLAY_FPS_DETECTED_HZ" | awk '{printf "%.0f\n", $1 + 0.0}')"
                 DISPLAY_FPS_MIN_OK="$(awk -v f="$DISPLAY_FPS_EXPECTED" -v p="$fps_min_pct" 'BEGIN { printf "%.0f\n", f * p / 100.0 }')"
-                log_info "FPS policy: mode=detected refresh=${DISPLAY_FPS_DETECTED_HZ}Hz expected=${DISPLAY_FPS_EXPECTED} min_ok=${DISPLAY_FPS_MIN_OK}"
+                log_info "FPS policy: mode=detected backend=$fps_backend refresh=${DISPLAY_FPS_DETECTED_HZ}Hz expected=${DISPLAY_FPS_EXPECTED} min_ok=${DISPLAY_FPS_MIN_OK}"
                 return 0
                 ;;
         esac
@@ -1898,6 +2118,11 @@ display_apply_fps_refresh_policy() {
 
     if [ "$DISPLAY_FPS_MODE" = "detected" ]; then
         log_info "Detected FPS mode selected; keeping native refresh"
+        return 0
+    fi
+
+    if [ "${DISPLAY_FPS_BACKEND:-auto}" = "x11" ]; then
+        log_info "X11 FPS backend selected; keeping the active XRandR mode unchanged"
         return 0
     fi
 
@@ -1984,53 +2209,51 @@ display_parse_fps_log() {
     [ -n "$logf" ] || return 1
     [ -r "$logf" ] || return 1
 
-    fps_stats=$(
+    fps_stats="$({
         awk '
-            /[0-9]+[[:space:]]+frames in[[:space:]]+[0-9]+[[:space:]]+seconds/ {
-                val = $(NF-1) + 0.0
-                all_n++
-                all_vals[all_n] = val
+            $1 ~ /^[0-9]+$/ &&
+            $2 == "frames" &&
+            $3 == "in" &&
+            $4 ~ /^[0-9]+([.][0-9]+)?$/ &&
+            $5 == "seconds" &&
+            $6 == "=" &&
+            $7 ~ /^[0-9]+([.][0-9]+)?$/ {
+                value = $7 + 0.0
+                count++
+                sum += value
+
+                if (count == 1 || value < min) {
+                    min = value
+                }
+
+                if (count == 1 || value > max) {
+                    max = value
+                }
             }
+
             END {
-                if (all_n == 0) exit
-
-                if (all_n == 1) {
-                    n = 1
-                    sum = all_vals[1]
-                    min = all_vals[1]
-                    max = all_vals[1]
-                } else {
-                    n = 0
-                    sum = 0.0
-                    for (i = 2; i <= all_n; i++) {
-                        v = all_vals[i]
-                        n++
-                        sum += v
-                        if (n == 1 || v < min) min = v
-                        if (n == 1 || v > max) max = v
-                    }
-                }
-
-                if (n > 0) {
-                    avg = sum / n
-                    printf "n=%d avg=%f min=%f max=%f\n", n, avg, min, max
+                if (count > 0) {
+                    printf "n=%d avg=%.6f min=%.6f max=%.6f\n", count, sum / count, min, max
                 }
             }
-        ' "$logf" 2>/dev/null || true
-    )
+        ' "$logf" 2>/dev/null ||
+        true
+    } | head -n 1)"
 
     [ -n "$fps_stats" ] || return 1
 
-    DISPLAY_FPS_COUNT=$(printf '%s\n' "$fps_stats" | awk '{print $1}' | sed 's/^n=//')
-    DISPLAY_FPS_AVG=$(printf '%s\n' "$fps_stats" | awk '{print $2}' | sed 's/^avg=//')
-    DISPLAY_FPS_MIN=$(printf '%s\n' "$fps_stats" | awk '{print $3}' | sed 's/^min=//')
-    DISPLAY_FPS_MAX=$(printf '%s\n' "$fps_stats" | awk '{print $4}' | sed 's/^max=//')
+    DISPLAY_FPS_COUNT="$(printf '%s\n' "$fps_stats" | awk '{print $1}' | sed 's/^n=//')"
+    DISPLAY_FPS_AVG="$(printf '%s\n' "$fps_stats" | awk '{print $2}' | sed 's/^avg=//')"
+    DISPLAY_FPS_MIN="$(printf '%s\n' "$fps_stats" | awk '{print $3}' | sed 's/^min=//')"
+    DISPLAY_FPS_MAX="$(printf '%s\n' "$fps_stats" | awk '{print $4}' | sed 's/^max=//')"
 
-    case "$DISPLAY_FPS_COUNT" in ''|*[!0-9]*) DISPLAY_FPS_COUNT=0 ;; esac
-    [ -n "$DISPLAY_FPS_AVG" ] || DISPLAY_FPS_AVG="-"
-    [ -n "$DISPLAY_FPS_MIN" ] || DISPLAY_FPS_MIN="-"
-    [ -n "$DISPLAY_FPS_MAX" ] || DISPLAY_FPS_MAX="-"
+    case "$DISPLAY_FPS_COUNT" in
+        ''|*[!0-9]*)
+            DISPLAY_FPS_COUNT=0
+            ;;
+    esac
 
+    [ "$DISPLAY_FPS_COUNT" -gt 0 ] 2>/dev/null || return 1
     return 0
 }
 
@@ -2936,5 +3159,1235 @@ display_restore_service_from_state() {
     rm -f "$drsfs_state_file"
     log_pass "Display manager restored: $drsfs_service"
     return 0
+}
+
+###############################################################################
+# X11 runtime, output, GLX, and XVideo helpers
+###############################################################################
+# These helpers extend lib_display.sh. They discover the currently usable X11
+# runtime from live server processes and sockets instead of assuming :0, a
+# LightDM path, a user ID, a connector name, a mode, or a refresh rate.
+
+DISPLAY_X11_DISPLAY=""
+DISPLAY_X11_XAUTHORITY=""
+DISPLAY_X11_SERVER_PID=""
+DISPLAY_X11_SERVER_COMMAND=""
+DISPLAY_X11_SESSION_KIND="unknown"
+DISPLAY_X11_OUTPUT=""
+DISPLAY_X11_MODE=""
+DISPLAY_X11_REFRESH_HZ=""
+DISPLAY_X11_ROOT_WIDTH=""
+DISPLAY_X11_ROOT_HEIGHT=""
+DISPLAY_X11_ROOT_DEPTH=""
+DISPLAY_X11_ROOT_MAP_STATE=""
+
+DISPLAY_GLX_DIRECT=""
+DISPLAY_GLX_ACCELERATED=""
+DISPLAY_GLX_VENDOR=""
+DISPLAY_GLX_RENDERER=""
+DISPLAY_GLX_VERSION=""
+DISPLAY_GLX_PIPE_KIND=""
+DISPLAY_GLX_OUT=""
+
+# display_x11_connection_ok [display] [xauthority]
+# Verify that xdpyinfo can connect to the supplied or currently exported X11
+# display. When an authority file is supplied, it must be readable and is used
+# only for this probe.
+# Returns: 0 when the connection succeeds; 1 otherwise.
+display_x11_connection_ok() {
+    dxco_display="${1:-${DISPLAY:-}}"
+    dxco_authority="${2:-${XAUTHORITY:-}}"
+
+    [ -n "$dxco_display" ] || return 1
+    command -v xdpyinfo >/dev/null 2>&1 || return 1
+
+    if [ -n "$dxco_authority" ]; then
+        [ -r "$dxco_authority" ] || return 1
+        DISPLAY="$dxco_display" \
+        XAUTHORITY="$dxco_authority" \
+        LC_ALL=C \
+            xdpyinfo -display "$dxco_display" >/dev/null 2>&1
+        return $?
+    fi
+
+    (
+        unset XAUTHORITY
+        DISPLAY="$dxco_display" \
+        LC_ALL=C \
+            xdpyinfo -display "$dxco_display" >/dev/null 2>&1
+    )
+}
+
+# display_x11_server_pids
+# Print unique PIDs for live Xorg, X, and Xwayland server processes. pgrep is
+# used when available and ps provides a portable fallback.
+# Returns: 0 after emitting zero or more PIDs.
+display_x11_server_pids() {
+    {
+        if command -v pgrep >/dev/null 2>&1; then
+            for dxsp_name in Xorg X Xwayland; do
+                pgrep -x "$dxsp_name" 2>/dev/null || true
+            done
+        fi
+
+        ps -eo pid=,comm= 2>/dev/null |
+            awk '$2 == "Xorg" || $2 == "X" || $2 == "Xwayland" { print $1 }'
+    } | awk 'NF && !seen[$1]++ { print $1 }'
+
+    return 0
+}
+
+# display_x11_process_display <pid>
+# Extract the first command-line argument that looks like an X11 display name
+# such as :0 or :0.0 from one server process.
+# Returns: 0 when a display is printed; 1 when it cannot be determined.
+display_x11_process_display() {
+    dxpd_pid="${1:-}"
+
+    [ -n "$dxpd_pid" ] || return 1
+    [ -r "/proc/$dxpd_pid/cmdline" ] || return 1
+
+    tr '\000' '\n' <"/proc/$dxpd_pid/cmdline" 2>/dev/null |
+        awk '/^:[0-9]+([.][0-9]+)?$/ { print; exit }'
+}
+
+# display_x11_process_env_value <pid> <name>
+# Read one environment variable from /proc/<pid>/environ and print its first
+# value without modifying the caller's environment.
+# Returns: 0 when a value is printed; 1 when the process environment is not
+# readable or the variable is absent.
+display_x11_process_env_value() {
+    dxpev_pid="${1:-}"
+    dxpev_name="${2:-}"
+
+    [ -n "$dxpev_pid" ] || return 1
+    [ -n "$dxpev_name" ] || return 1
+    [ -r "/proc/$dxpev_pid/environ" ] || return 1
+
+    tr '\000' '\n' <"/proc/$dxpev_pid/environ" 2>/dev/null |
+        sed -n "s/^${dxpev_name}=//p" |
+        head -n 1
+}
+
+# display_x11_process_authority <pid>
+# Discover an Xauthority path from an X server's -auth command-line argument,
+# falling back to the process XAUTHORITY environment variable.
+# Returns: 0 and prints a non-empty path when found; 1 otherwise.
+display_x11_process_authority() {
+    dxpa_pid="${1:-}"
+
+    [ -n "$dxpa_pid" ] || return 1
+
+    dxpa_authority=""
+
+    if [ -r "/proc/$dxpa_pid/cmdline" ]; then
+        dxpa_authority="$(
+            tr '\000' '\n' <"/proc/$dxpa_pid/cmdline" 2>/dev/null |
+                awk '
+                    take_next { print; exit }
+                    $0 == "-auth" { take_next=1 }
+                '
+        )"
+    fi
+
+    if [ -z "$dxpa_authority" ]; then
+        dxpa_authority="$(
+            display_x11_process_env_value "$dxpa_pid" XAUTHORITY 2>/dev/null || true
+        )"
+    fi
+
+    [ -n "$dxpa_authority" ] || return 1
+    printf '%s\n' "$dxpa_authority"
+}
+
+# display_x11_find_authority_for_display <display>
+# Search readable process environments for a process using the requested
+# DISPLAY and print the first readable XAUTHORITY path associated with it.
+# Returns: 0 when a readable authority file is printed; 1 otherwise.
+display_x11_find_authority_for_display() {
+    dxfafd_display="${1:-}"
+
+    [ -n "$dxfafd_display" ] || return 1
+
+    for dxfafd_env in /proc/[0-9]*/environ; do
+        [ -r "$dxfafd_env" ] || continue
+
+        dxfafd_pid=${dxfafd_env#/proc/}
+        dxfafd_pid=${dxfafd_pid%/environ}
+        dxfafd_proc_display="$(
+            display_x11_process_env_value "$dxfafd_pid" DISPLAY 2>/dev/null || true
+        )"
+
+        [ "$dxfafd_proc_display" = "$dxfafd_display" ] || continue
+
+        dxfafd_authority="$(
+            display_x11_process_env_value "$dxfafd_pid" XAUTHORITY 2>/dev/null || true
+        )"
+
+        if [ -n "$dxfafd_authority" ] && [ -r "$dxfafd_authority" ]; then
+            printf '%s\n' "$dxfafd_authority"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# display_x11_process_on_display <process-name> <display>
+# Return success when an exact process name has at least one process whose
+# DISPLAY environment matches the requested X11 display.
+# Returns: 0 on a match; 1 when no matching process is found.
+display_x11_process_on_display() {
+    dxpod_name="${1:-}"
+    dxpod_display="${2:-}"
+
+    [ -n "$dxpod_name" ] || return 1
+    [ -n "$dxpod_display" ] || return 1
+    command -v pgrep >/dev/null 2>&1 || return 1
+
+    for dxpod_pid in $(pgrep -x "$dxpod_name" 2>/dev/null || true); do
+        dxpod_process_display="$(
+            display_x11_process_env_value "$dxpod_pid" DISPLAY 2>/dev/null || true
+        )"
+
+        if [ "$dxpod_process_display" = "$dxpod_display" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# display_x11_detect_session_kind
+# Classify the adopted X11 session as generic x11, xfce, or lightdm-greeter by
+# inspecting the active window manager and session processes.
+# Sets and exports DISPLAY_X11_SESSION_KIND and prints the detected value.
+# Returns: 0 after classification.
+display_x11_detect_session_kind() {
+    DISPLAY_X11_SESSION_KIND="x11"
+
+    if command -v xprop >/dev/null 2>&1; then
+        dxsk_wm_id="$({
+            LC_ALL=C xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null || true
+        } |
+            sed -n 's/.*#[[:space:]]*\(0x[0-9a-fA-F][0-9a-fA-F]*\).*/\1/p' |
+            head -n 1)"
+
+        if [ -n "$dxsk_wm_id" ]; then
+            dxsk_wm_name="$({
+                LC_ALL=C xprop -id "$dxsk_wm_id" _NET_WM_NAME WM_NAME 2>/dev/null || true
+            } |
+                sed -n 's/.*=[[:space:]]*"\(.*\)".*/\1/p' |
+                head -n 1)"
+
+            case "$(printf '%s\n' "$dxsk_wm_name" | tr '[:upper:]' '[:lower:]')" in
+                *xfwm*) DISPLAY_X11_SESSION_KIND="xfce" ;;
+            esac
+        fi
+    fi
+
+    if [ "$DISPLAY_X11_SESSION_KIND" != "xfce" ]; then
+        dxsk_display="${DISPLAY:-${DISPLAY_X11_DISPLAY:-}}"
+
+        if display_x11_process_on_display xfce4-session "$dxsk_display" ||
+           display_x11_process_on_display xfwm4 "$dxsk_display"; then
+            DISPLAY_X11_SESSION_KIND="xfce"
+        elif display_x11_process_on_display lightdm-gtk-greeter "$dxsk_display"; then
+            DISPLAY_X11_SESSION_KIND="lightdm-greeter"
+        fi
+    fi
+
+    export DISPLAY_X11_SESSION_KIND
+    printf '%s\n' "$DISPLAY_X11_SESSION_KIND"
+    return 0
+}
+
+# display_x11_adopt_candidate <display> [xauthority] [server-pid]
+# Validate one DISPLAY/XAUTHORITY candidate, export it for subsequent helpers,
+# capture optional server metadata, and classify the session.
+# Returns: 0 when the candidate is usable and adopted; 1 otherwise.
+display_x11_adopt_candidate() {
+    dxac_display="${1:-}"
+    dxac_authority="${2:-}"
+    dxac_pid="${3:-}"
+
+    [ -n "$dxac_display" ] || return 1
+
+    if [ -n "$dxac_authority" ] &&
+       display_x11_connection_ok "$dxac_display" "$dxac_authority"; then
+        DISPLAY="$dxac_display"
+        XAUTHORITY="$dxac_authority"
+        export DISPLAY XAUTHORITY
+    elif display_x11_connection_ok "$dxac_display" ""; then
+        DISPLAY="$dxac_display"
+        export DISPLAY
+        unset XAUTHORITY
+        dxac_authority=""
+    else
+        return 1
+    fi
+
+    DISPLAY_X11_DISPLAY="$dxac_display"
+    DISPLAY_X11_XAUTHORITY="$dxac_authority"
+    DISPLAY_X11_SERVER_PID="$dxac_pid"
+    DISPLAY_X11_SERVER_COMMAND=""
+
+    if [ -n "$dxac_pid" ] && [ -r "/proc/$dxac_pid/cmdline" ]; then
+        DISPLAY_X11_SERVER_COMMAND="$(
+            tr '\000' ' ' <"/proc/$dxac_pid/cmdline" 2>/dev/null
+        )"
+    fi
+
+    export DISPLAY_X11_DISPLAY
+    export DISPLAY_X11_XAUTHORITY
+    export DISPLAY_X11_SERVER_PID
+    export DISPLAY_X11_SERVER_COMMAND
+
+    display_x11_detect_session_kind >/dev/null 2>&1 || true
+
+    log_info "Adopted X11 runtime: DISPLAY=$DISPLAY XAUTHORITY=${XAUTHORITY:-<unset>} server_pid=${DISPLAY_X11_SERVER_PID:-unknown} session=${DISPLAY_X11_SESSION_KIND:-unknown}"
+    return 0
+}
+
+# display_x11_resolve_env [display-override] [xauthority-override]
+# Resolve and adopt a usable X11 runtime in this order: explicit override,
+# current environment, discovered X server processes, then live X11 sockets.
+# Returns: 0 after exporting a usable runtime; 1 when none can be discovered.
+display_x11_resolve_env() {
+    dxre_display_override="${1:-}"
+    dxre_authority_override="${2:-}"
+
+    if [ -n "$dxre_display_override" ]; then
+        if display_x11_adopt_candidate \
+            "$dxre_display_override" \
+            "$dxre_authority_override" \
+            ""; then
+            return 0
+        fi
+
+        if [ -n "${XAUTHORITY:-}" ] &&
+           [ "$dxre_authority_override" != "$XAUTHORITY" ] &&
+           display_x11_adopt_candidate \
+               "$dxre_display_override" \
+               "$XAUTHORITY" \
+               ""; then
+            return 0
+        fi
+    fi
+
+    if [ -n "${DISPLAY:-}" ]; then
+        if display_x11_adopt_candidate \
+            "$DISPLAY" \
+            "${XAUTHORITY:-}" \
+            ""; then
+            return 0
+        fi
+    fi
+
+    dxre_pids="$(display_x11_server_pids 2>/dev/null)"
+
+    for dxre_pid in $dxre_pids; do
+        dxre_display="$(display_x11_process_display "$dxre_pid" 2>/dev/null || true)"
+        dxre_authority="$(display_x11_process_authority "$dxre_pid" 2>/dev/null || true)"
+
+        [ -n "$dxre_display" ] || continue
+
+        if [ -z "$dxre_authority" ]; then
+            dxre_authority="$(
+                display_x11_find_authority_for_display "$dxre_display" 2>/dev/null || true
+            )"
+        fi
+
+        if [ -n "$dxre_display_override" ] &&
+           [ "$dxre_display" != "$dxre_display_override" ]; then
+            continue
+        fi
+
+        if [ -n "$dxre_authority_override" ]; then
+            dxre_authority="$dxre_authority_override"
+        fi
+
+        if display_x11_adopt_candidate \
+            "$dxre_display" \
+            "$dxre_authority" \
+            "$dxre_pid"; then
+            return 0
+        fi
+    done
+
+    for dxre_socket in /tmp/.X11-unix/X*; do
+        [ -S "$dxre_socket" ] || continue
+
+        dxre_index=${dxre_socket##*/X}
+        case "$dxre_index" in
+            ''|*[!0-9]*) continue ;;
+        esac
+
+        dxre_display=":$dxre_index"
+
+        if [ -n "$dxre_display_override" ] &&
+           [ "$dxre_display" != "$dxre_display_override" ]; then
+            continue
+        fi
+
+        dxre_socket_authority="$dxre_authority_override"
+        if [ -z "$dxre_socket_authority" ]; then
+            dxre_socket_authority="$(
+                display_x11_find_authority_for_display "$dxre_display" 2>/dev/null || true
+            )"
+        fi
+
+        if display_x11_adopt_candidate \
+            "$dxre_display" \
+            "$dxre_socket_authority" \
+            ""; then
+            return 0
+        fi
+    done
+
+    log_warn "No usable X11 display and Xauthority pair was discovered"
+    return 1
+}
+
+# display_x11_get_active_output
+# Discover the active XRandR output, current mode, and refresh rate. A primary
+# output is preferred; otherwise the first connected output with an active mode
+# is selected.
+# Sets and exports DISPLAY_X11_OUTPUT, DISPLAY_X11_MODE, and
+# DISPLAY_X11_REFRESH_HZ.
+# Returns: 0 when a valid active output is found; 1 otherwise.
+display_x11_get_active_output() {
+    command -v xrandr >/dev/null 2>&1 || return 1
+    display_x11_connection_ok || return 1
+
+    dxao_record="$(LC_ALL=C xrandr --current 2>/dev/null |
+        awk '
+            function clean_hz(value) {
+                gsub(/[+*i]/, "", value)
+                return value
+            }
+
+            $2 == "connected" {
+                in_output=1
+                output_name=$1
+                output_primary=0
+
+                for (i=3; i<=NF; i++) {
+                    if ($i == "primary") {
+                        output_primary=1
+                    }
+                }
+                next
+            }
+
+            $2 == "disconnected" {
+                in_output=0
+                next
+            }
+
+            in_output && $1 ~ /^[0-9]+x[0-9]+$/ {
+                for (i=2; i<=NF; i++) {
+                    if (index($i, "*") > 0) {
+                        hz=clean_hz($i)
+                        record=output_name "|" $1 "|" hz
+
+                        if (output_primary) {
+                            print record
+                            emitted=1
+                            exit
+                        }
+
+                        if (first_record == "") {
+                            first_record=record
+                        }
+                    }
+                }
+            }
+
+            END {
+                if (!emitted && first_record != "") {
+                    print first_record
+                }
+            }
+        ' | head -n 1)"
+
+    [ -n "$dxao_record" ] || return 1
+
+    DISPLAY_X11_OUTPUT="$(printf '%s\n' "$dxao_record" | awk -F'|' '{print $1}')"
+    DISPLAY_X11_MODE="$(printf '%s\n' "$dxao_record" | awk -F'|' '{print $2}')"
+    DISPLAY_X11_REFRESH_HZ="$(printf '%s\n' "$dxao_record" | awk -F'|' '{print $3}')"
+
+    case "$DISPLAY_X11_MODE" in
+        *x*) ;;
+        *) return 1 ;;
+    esac
+
+    case "$DISPLAY_X11_REFRESH_HZ" in
+        ''|*[!0-9.]*) return 1 ;;
+    esac
+
+    export DISPLAY_X11_OUTPUT
+    export DISPLAY_X11_MODE
+    export DISPLAY_X11_REFRESH_HZ
+    return 0
+}
+
+# display_x11_get_primary_refresh_hz
+# Print the refresh rate selected by display_x11_get_active_output.
+# Returns: 0 when a refresh rate is printed; 1 when no active output is found.
+display_x11_get_primary_refresh_hz() {
+    if ! display_x11_get_active_output; then
+        return 1
+    fi
+
+    printf '%s\n' "$DISPLAY_X11_REFRESH_HZ"
+}
+
+# display_x11_get_root_geometry
+# Query the X11 root window and capture its width, height, depth, and map state.
+# Sets and exports DISPLAY_X11_ROOT_WIDTH, DISPLAY_X11_ROOT_HEIGHT,
+# DISPLAY_X11_ROOT_DEPTH, and DISPLAY_X11_ROOT_MAP_STATE.
+# Returns: 0 when numeric root geometry is available; 1 otherwise.
+display_x11_get_root_geometry() {
+    command -v xwininfo >/dev/null 2>&1 || return 1
+    display_x11_connection_ok || return 1
+
+    dxrg_out="$(LC_ALL=C xwininfo -root 2>/dev/null)" || return 1
+
+    DISPLAY_X11_ROOT_WIDTH="$(printf '%s\n' "$dxrg_out" |
+        sed -n 's/^[[:space:]]*Width:[[:space:]]*//p' |
+        head -n 1)"
+    DISPLAY_X11_ROOT_HEIGHT="$(printf '%s\n' "$dxrg_out" |
+        sed -n 's/^[[:space:]]*Height:[[:space:]]*//p' |
+        head -n 1)"
+    DISPLAY_X11_ROOT_DEPTH="$(printf '%s\n' "$dxrg_out" |
+        sed -n 's/^[[:space:]]*Depth:[[:space:]]*//p' |
+        head -n 1)"
+    DISPLAY_X11_ROOT_MAP_STATE="$(printf '%s\n' "$dxrg_out" |
+        sed -n 's/^[[:space:]]*Map State:[[:space:]]*//p' |
+        head -n 1)"
+
+    case "$DISPLAY_X11_ROOT_WIDTH:$DISPLAY_X11_ROOT_HEIGHT" in
+        *[!0-9:]*|:*|*:) return 1 ;;
+    esac
+
+    export DISPLAY_X11_ROOT_WIDTH
+    export DISPLAY_X11_ROOT_HEIGHT
+    export DISPLAY_X11_ROOT_DEPTH
+    export DISPLAY_X11_ROOT_MAP_STATE
+    return 0
+}
+
+# display_x11_print_glx_pipeline
+# Run glxinfo -B, parse the direct-rendering and renderer details, classify the
+# pipeline as hardware or software, export the parsed fields, and print the raw
+# glxinfo output.
+# Returns: 0 when a renderer is reported; 1 when glxinfo or the X11 connection
+# is unavailable or glxinfo fails.
+display_x11_print_glx_pipeline() {
+    DISPLAY_GLX_DIRECT=""
+    DISPLAY_GLX_ACCELERATED=""
+    DISPLAY_GLX_VENDOR=""
+    DISPLAY_GLX_RENDERER=""
+    DISPLAY_GLX_VERSION=""
+    DISPLAY_GLX_PIPE_KIND=""
+    DISPLAY_GLX_OUT=""
+
+    command -v glxinfo >/dev/null 2>&1 || return 1
+    display_x11_connection_ok || return 1
+
+    dxpg_out="$(LC_ALL=C glxinfo -B 2>&1)"
+    dxpg_rc=$?
+
+    if [ "$dxpg_rc" -ne 0 ]; then
+        printf '%s\n' "$dxpg_out"
+        return 1
+    fi
+
+    DISPLAY_GLX_DIRECT="$(printf '%s\n' "$dxpg_out" |
+        sed -n 's/^direct rendering:[[:space:]]*//p' |
+        head -n 1)"
+    DISPLAY_GLX_ACCELERATED="$(printf '%s\n' "$dxpg_out" |
+        sed -n 's/^[[:space:]]*Accelerated:[[:space:]]*//p' |
+        head -n 1)"
+    DISPLAY_GLX_VENDOR="$(printf '%s\n' "$dxpg_out" |
+        sed -n 's/^OpenGL vendor string:[[:space:]]*//p' |
+        head -n 1)"
+    DISPLAY_GLX_RENDERER="$(printf '%s\n' "$dxpg_out" |
+        sed -n 's/^OpenGL renderer string:[[:space:]]*//p' |
+        head -n 1)"
+    DISPLAY_GLX_VERSION="$(printf '%s\n' "$dxpg_out" |
+        sed -n \
+            -e 's/^OpenGL core profile version string:[[:space:]]*//p' \
+            -e 's/^OpenGL version string:[[:space:]]*//p' |
+        head -n 1)"
+
+    [ -n "$DISPLAY_GLX_VENDOR" ] || DISPLAY_GLX_VENDOR="unknown"
+    [ -n "$DISPLAY_GLX_RENDERER" ] || DISPLAY_GLX_RENDERER="unknown"
+    [ -n "$DISPLAY_GLX_VERSION" ] || DISPLAY_GLX_VERSION="unknown"
+
+    if command -v egli_classify_pipeline >/dev/null 2>&1; then
+        DISPLAY_GLX_PIPE_KIND="$(egli_classify_pipeline \
+            "" \
+            "$DISPLAY_GLX_VENDOR" \
+            "$DISPLAY_GLX_RENDERER")"
+    else
+        case "$(printf '%s\n' "$DISPLAY_GLX_RENDERER" | tr '[:upper:]' '[:lower:]')" in
+            *llvmpipe*|*softpipe*|*swrast*|*software*)
+                DISPLAY_GLX_PIPE_KIND="CPU (software)"
+                ;;
+            unknown|"")
+                DISPLAY_GLX_PIPE_KIND="unknown"
+                ;;
+            *)
+                DISPLAY_GLX_PIPE_KIND="GPU (hardware)"
+                ;;
+        esac
+    fi
+
+    [ -n "$DISPLAY_GLX_PIPE_KIND" ] || DISPLAY_GLX_PIPE_KIND="unknown"
+    DISPLAY_GLX_OUT="$dxpg_out"
+
+    export DISPLAY_GLX_DIRECT
+    export DISPLAY_GLX_ACCELERATED
+    export DISPLAY_GLX_VENDOR
+    export DISPLAY_GLX_RENDERER
+    export DISPLAY_GLX_VERSION
+    export DISPLAY_GLX_PIPE_KIND
+    export DISPLAY_GLX_OUT
+
+    printf '%s\n' "$dxpg_out"
+    log_info "GLXINFO: direct=${DISPLAY_GLX_DIRECT:-unknown} accelerated=${DISPLAY_GLX_ACCELERATED:-unknown}"
+    log_info "GLXINFO: vendor=$DISPLAY_GLX_VENDOR"
+    log_info "GLXINFO: renderer=$DISPLAY_GLX_RENDERER"
+    log_info "GLXINFO: version=$DISPLAY_GLX_VERSION"
+    log_info "GLXINFO: pipeline type=$DISPLAY_GLX_PIPE_KIND"
+
+    [ "$DISPLAY_GLX_RENDERER" != "unknown" ]
+}
+
+###############################################################################
+# X11 fullscreen helpers
+###############################################################################
+# These helpers are shared by X11 clients that do not provide a reliable native
+# fullscreen option. Window discovery compares exact before/after snapshots so
+# an existing root, greeter, panel, or desktop window is not selected.
+
+DISPLAY_X11_FULLSCREEN_WATCH_PID=""
+DISPLAY_X11_FULLSCREEN_STATUS_FILE=""
+DISPLAY_X11_FULLSCREEN_STOP_FILE=""
+DISPLAY_X11_FULLSCREEN_RESULT=""
+DISPLAY_X11_FULLSCREEN_WINDOW_ID=""
+DISPLAY_X11_FULLSCREEN_DETAIL=""
+DISPLAY_X11_FULLSCREEN_AVAILABLE=0
+DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL=0
+
+# display_x11__snapshot_visible_windows <output-file>
+# Save the unique IDs of all currently visible X11 windows to the supplied file.
+# Returns: 0 when the snapshot file is created; 1 when it cannot be created.
+display_x11__snapshot_visible_windows() {
+    dxsvw_file="${1:-}"
+
+    [ -n "$dxsvw_file" ] || return 1
+    : >"$dxsvw_file" || return 1
+
+    xdotool search \
+        --onlyvisible \
+        --name '.*' \
+        2>/dev/null |
+        awk '/^[0-9]+$/ && !seen[$1]++ { print $1 }' \
+        >"$dxsvw_file" ||
+        true
+
+    return 0
+}
+
+# display_x11__snapshot_command_pids <command> <output-file>
+# Save the PIDs whose process comm exactly matches the requested command. A path
+# is normalized to its basename before matching.
+# Returns: 0 when the snapshot file is created; 1 when it cannot be created.
+display_x11__snapshot_command_pids() {
+    dxscp_command="${1:-}"
+    dxscp_file="${2:-}"
+
+    [ -n "$dxscp_file" ] || return 1
+    : >"$dxscp_file" || return 1
+
+    [ -n "$dxscp_command" ] || return 0
+    dxscp_command=${dxscp_command##*/}
+
+    ps -eo pid=,comm= 2>/dev/null |
+        awk -v command="$dxscp_command" '
+            $2 == command {
+                print $1
+            }
+        ' >"$dxscp_file" ||
+        true
+
+    return 0
+}
+
+# display_x11__window_is_viewable <window-id>
+# Return success when xwininfo reports that the requested X11 window is mapped
+# and viewable.
+# Returns: 0 for a viewable window; 1 otherwise.
+display_x11__window_is_viewable() {
+    dxwiv_id="${1:-}"
+
+    [ -n "$dxwiv_id" ] || return 1
+
+    LC_ALL=C xwininfo \
+        -id "$dxwiv_id" \
+        2>/dev/null |
+        grep -q 'Map State:[[:space:]]*IsViewable'
+}
+
+# display_x11__find_new_window <command> <before-windows> <before-pids>
+#                              <after-windows> <after-pids>
+# Find a newly created viewable window. New PIDs matching the client command are
+# preferred; a before/after visible-window comparison is used as fallback.
+# Sets and exports DISPLAY_X11_FULLSCREEN_WINDOW_ID.
+# Returns: 0 when a new viewable window is found; 1 otherwise.
+display_x11__find_new_window() {
+    dxfnw_command="${1:-}"
+    dxfnw_before_windows="${2:-}"
+    dxfnw_before_pids="${3:-}"
+    dxfnw_after_windows="${4:-}"
+    dxfnw_after_pids="${5:-}"
+
+    DISPLAY_X11_FULLSCREEN_WINDOW_ID=""
+
+    display_x11__snapshot_command_pids \
+        "$dxfnw_command" \
+        "$dxfnw_after_pids"
+
+    if [ -n "$dxfnw_command" ]; then
+        while IFS= read -r dxfnw_pid; do
+            [ -n "$dxfnw_pid" ] || continue
+
+            if grep -Fqx \
+                "$dxfnw_pid" \
+                "$dxfnw_before_pids" \
+                2>/dev/null; then
+                continue
+            fi
+
+            dxfnw_id="$({
+                xdotool search \
+                    --onlyvisible \
+                    --pid "$dxfnw_pid" \
+                    2>/dev/null ||
+                    true
+            } | head -n 1)"
+
+            if display_x11__window_is_viewable "$dxfnw_id"; then
+                DISPLAY_X11_FULLSCREEN_WINDOW_ID="$dxfnw_id"
+                export DISPLAY_X11_FULLSCREEN_WINDOW_ID
+                return 0
+            fi
+        done <"$dxfnw_after_pids"
+    fi
+
+    display_x11__snapshot_visible_windows "$dxfnw_after_windows"
+
+    while IFS= read -r dxfnw_id; do
+        [ -n "$dxfnw_id" ] || continue
+
+        if grep -Fqx \
+            "$dxfnw_id" \
+            "$dxfnw_before_windows" \
+            2>/dev/null; then
+            continue
+        fi
+
+        if display_x11__window_is_viewable "$dxfnw_id"; then
+            DISPLAY_X11_FULLSCREEN_WINDOW_ID="$dxfnw_id"
+            export DISPLAY_X11_FULLSCREEN_WINDOW_ID
+            return 0
+        fi
+    done <"$dxfnw_after_windows"
+
+    return 1
+}
+
+# display_x11__recover_command <command>
+# Recover one missing X11 command through the common command-to-package map.
+# The package-provider library is sourced lazily when needed, and the configured
+# dependency-recovery policy is respected.
+# Returns: 0 when the command is available before or after recovery; 1 otherwise.
+display_x11__recover_command() {
+    dxrc_command="${1:-}"
+
+    [ -n "$dxrc_command" ] || return 1
+
+    if command -v "$dxrc_command" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if ! command -v pkg_ensure_command >/dev/null 2>&1; then
+        if [ -n "${TOOLS:-}" ] && [ -r "$TOOLS/lib_pkg_provider.sh" ]; then
+            # shellcheck disable=SC1091
+            . "$TOOLS/lib_pkg_provider.sh"
+        fi
+    fi
+
+    if ! command -v pkg_ensure_command >/dev/null 2>&1; then
+        return 1
+    fi
+
+    if command -v pkg_check_dependencies_recover_enabled >/dev/null 2>&1 &&
+       ! pkg_check_dependencies_recover_enabled; then
+        return 1
+    fi
+
+    if ! pkg_ensure_command "$dxrc_command"; then
+        return 1
+    fi
+
+    hash -r 2>/dev/null || true
+    command -v "$dxrc_command" >/dev/null 2>&1
+}
+
+# display_x11_prepare_fullscreen_support
+# Prepare the optional shared fullscreen watcher when X11_FULLSCREEN=1.
+# xdotool and xwininfo are required and are recovered individually through the
+# command map. wmctrl is recovered best-effort and enables an EWMH fullscreen
+# request in addition to the geometry fallback.
+# Sets and exports DISPLAY_X11_FULLSCREEN_AVAILABLE and
+# DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL.
+# Returns: 0 when fullscreen is disabled or support is ready; 1 when enabled but
+# required commands remain unavailable.
+display_x11_prepare_fullscreen_support() {
+    DISPLAY_X11_FULLSCREEN_AVAILABLE=0
+    DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL=0
+
+    export DISPLAY_X11_FULLSCREEN_AVAILABLE
+    export DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL
+
+    [ "${X11_FULLSCREEN:-0}" = "1" ] || return 0
+
+    display_x11__recover_command xdotool || true
+    display_x11__recover_command xwininfo || true
+
+    # Optional EWMH support. Failure does not disable geometry-based fullscreen.
+    display_x11__recover_command wmctrl || true
+
+    if command -v wmctrl >/dev/null 2>&1; then
+        DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL=1
+    fi
+
+    if command -v xdotool >/dev/null 2>&1 &&
+       command -v xwininfo >/dev/null 2>&1; then
+        DISPLAY_X11_FULLSCREEN_AVAILABLE=1
+        export DISPLAY_X11_FULLSCREEN_AVAILABLE
+        export DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL
+
+        log_info "X11 fullscreen support ready: xdotool=$(command -v xdotool) xwininfo=$(command -v xwininfo) wmctrl=${DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL}"
+        return 0
+    fi
+
+    if ! command -v xdotool >/dev/null 2>&1; then
+        log_warn "X11 fullscreen support unavailable: xdotool not installed"
+    fi
+
+    if ! command -v xwininfo >/dev/null 2>&1; then
+        log_warn "X11 fullscreen support unavailable: xwininfo not installed"
+    fi
+
+    export DISPLAY_X11_FULLSCREEN_AVAILABLE
+    export DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL
+    return 1
+}
+
+# display_x11__apply_fullscreen_window <window-id> <width> <height>
+# Map the selected window, request EWMH fullscreen when wmctrl is available,
+# force it to root-window geometry with xdotool, and verify the resulting size.
+# Sets and exports DISPLAY_X11_FULLSCREEN_DETAIL.
+# Returns: 0 when the measured size matches; 1 otherwise.
+display_x11__apply_fullscreen_window() {
+    dxafw_id="${1:-}"
+    dxafw_width="${2:-}"
+    dxafw_height="${3:-}"
+
+    [ -n "$dxafw_id" ] || return 1
+    [ -n "$dxafw_width" ] || return 1
+    [ -n "$dxafw_height" ] || return 1
+
+    xdotool windowmap \
+        "$dxafw_id" \
+        >/dev/null 2>&1 ||
+        true
+
+    if [ "${DISPLAY_X11_FULLSCREEN_HAVE_WMCTRL:-0}" = "1" ] &&
+       command -v wmctrl >/dev/null 2>&1; then
+        dxafw_hex="$({
+            printf '0x%x\n' "$dxafw_id" 2>/dev/null ||
+            true
+        } | head -n 1)"
+
+        if [ -n "$dxafw_hex" ]; then
+            wmctrl \
+                -i \
+                -r "$dxafw_hex" \
+                -b add,fullscreen \
+                >/dev/null 2>&1 ||
+                true
+        fi
+    fi
+
+    xdotool windowmove \
+        "$dxafw_id" \
+        0 \
+        0 \
+        >/dev/null 2>&1 ||
+        true
+
+    xdotool windowsize \
+        "$dxafw_id" \
+        "$dxafw_width" \
+        "$dxafw_height" \
+        >/dev/null 2>&1 ||
+        true
+
+    xdotool windowraise \
+        "$dxafw_id" \
+        >/dev/null 2>&1 ||
+        true
+
+    dxafw_actual_width="$({
+        LC_ALL=C xwininfo \
+            -id "$dxafw_id" \
+            2>/dev/null ||
+            true
+    } | awk '
+        /^[[:space:]]*Width:/ {
+            print $2
+            exit
+        }
+    ')"
+
+    dxafw_actual_height="$({
+        LC_ALL=C xwininfo \
+            -id "$dxafw_id" \
+            2>/dev/null ||
+            true
+    } | awk '
+        /^[[:space:]]*Height:/ {
+            print $2
+            exit
+        }
+    ')"
+
+    DISPLAY_X11_FULLSCREEN_DETAIL="actual=${dxafw_actual_width:-unknown}x${dxafw_actual_height:-unknown}"
+    export DISPLAY_X11_FULLSCREEN_DETAIL
+
+    [ "$dxafw_actual_width" = "$dxafw_width" ] &&
+    [ "$dxafw_actual_height" = "$dxafw_height" ]
+}
+
+# display_x11_fullscreen_watch_start [wait-seconds] [command] [status-file]
+# Start a background watcher before launching an X11 client. It snapshots the
+# current windows/processes, waits for the new client window, and repeatedly
+# applies fullscreen geometry until the client exits or the watcher is stopped.
+# Sets and exports watcher PID/status/stop-file globals.
+# Returns: 0 when the watcher starts; 1 when fullscreen is disabled, preparation
+# fails, the timeout is invalid, or root geometry cannot be resolved.
+display_x11_fullscreen_watch_start() {
+    dxfw_wait_seconds="${1:-10}"
+    dxfw_command="${2:-}"
+    dxfw_status_file="${3:-/tmp/display-x11-fullscreen-$$.status}"
+    dxfw_stop_file="${dxfw_status_file}.stop"
+    dxfw_before_windows="${dxfw_status_file}.before-windows"
+    dxfw_before_pids="${dxfw_status_file}.before-pids"
+    dxfw_after_windows="${dxfw_status_file}.after-windows"
+    dxfw_after_pids="${dxfw_status_file}.after-pids"
+
+    DISPLAY_X11_FULLSCREEN_WATCH_PID=""
+    DISPLAY_X11_FULLSCREEN_STATUS_FILE="$dxfw_status_file"
+    DISPLAY_X11_FULLSCREEN_STOP_FILE="$dxfw_stop_file"
+
+    export DISPLAY_X11_FULLSCREEN_WATCH_PID
+    export DISPLAY_X11_FULLSCREEN_STATUS_FILE
+    export DISPLAY_X11_FULLSCREEN_STOP_FILE
+
+    case "$dxfw_wait_seconds" in
+        ''|*[!0-9]*|0)
+            printf '%s\n' \
+                "SKIP|invalid-timeout|$dxfw_wait_seconds" \
+                >"$dxfw_status_file"
+            return 1
+            ;;
+    esac
+
+    if [ "${X11_FULLSCREEN:-0}" != "1" ]; then
+        printf '%s\n' \
+            "SKIP|fullscreen-disabled|" \
+            >"$dxfw_status_file"
+        return 1
+    fi
+
+    if ! display_x11_prepare_fullscreen_support; then
+        if ! command -v xdotool >/dev/null 2>&1; then
+            dxfw_prepare_reason="xdotool-unavailable"
+        elif ! command -v xwininfo >/dev/null 2>&1; then
+            dxfw_prepare_reason="xwininfo-unavailable"
+        else
+            dxfw_prepare_reason="fullscreen-support-unavailable"
+        fi
+
+        printf '%s\n' \
+            "SKIP|$dxfw_prepare_reason|" \
+            >"$dxfw_status_file"
+        return 1
+    fi
+
+    if ! display_x11_get_root_geometry; then
+        printf '%s\n' \
+            "SKIP|root-geometry-unavailable|" \
+            >"$dxfw_status_file"
+        return 1
+    fi
+
+    dxfw_root_width="$DISPLAY_X11_ROOT_WIDTH"
+    dxfw_root_height="$DISPLAY_X11_ROOT_HEIGHT"
+
+    case "$dxfw_root_width:$dxfw_root_height" in
+        *[!0-9:]*|:*|*:)
+            printf '%s\n' \
+                "SKIP|invalid-root-geometry|${dxfw_root_width}x${dxfw_root_height}" \
+                >"$dxfw_status_file"
+            return 1
+            ;;
+    esac
+
+    rm -f \
+        "$dxfw_status_file" \
+        "$dxfw_stop_file" \
+        "$dxfw_before_windows" \
+        "$dxfw_before_pids" \
+        "$dxfw_after_windows" \
+        "$dxfw_after_pids"
+
+    if ! display_x11__snapshot_visible_windows "$dxfw_before_windows"; then
+        printf '%s\n' \
+            "SKIP|window-snapshot-failed|" \
+            >"$dxfw_status_file"
+        return 1
+    fi
+
+    if ! display_x11__snapshot_command_pids \
+        "$dxfw_command" \
+        "$dxfw_before_pids"; then
+        printf '%s\n' \
+            "SKIP|process-snapshot-failed|command=$dxfw_command" \
+            >"$dxfw_status_file"
+        return 1
+    fi
+
+    (
+        dxfw_elapsed=0
+        dxfw_window_id=""
+        dxfw_first_apply_elapsed=""
+        dxfw_verified=0
+
+        while [ "$dxfw_elapsed" -lt "$dxfw_wait_seconds" ] &&
+              [ ! -e "$dxfw_stop_file" ]; do
+            if display_x11__find_new_window \
+                "$dxfw_command" \
+                "$dxfw_before_windows" \
+                "$dxfw_before_pids" \
+                "$dxfw_after_windows" \
+                "$dxfw_after_pids"; then
+                dxfw_window_id="$DISPLAY_X11_FULLSCREEN_WINDOW_ID"
+                break
+            fi
+
+            sleep 1
+            dxfw_elapsed=$((dxfw_elapsed + 1))
+        done
+
+        if [ -z "$dxfw_window_id" ]; then
+            printf '%s\n' \
+                "SKIP|window-not-found|command=$dxfw_command" \
+                >"$dxfw_status_file"
+            exit 0
+        fi
+
+        while [ ! -e "$dxfw_stop_file" ]; do
+            if ! display_x11__window_is_viewable "$dxfw_window_id"; then
+                break
+            fi
+
+            if display_x11__apply_fullscreen_window \
+                "$dxfw_window_id" \
+                "$dxfw_root_width" \
+                "$dxfw_root_height"; then
+                dxfw_verified=1
+
+                if [ -z "$dxfw_first_apply_elapsed" ]; then
+                    dxfw_first_apply_elapsed="$dxfw_elapsed"
+                    printf '%s\n' \
+                        "PASS|$dxfw_window_id|geometry=${dxfw_root_width}x${dxfw_root_height};detected_after=${dxfw_first_apply_elapsed}s" \
+                        >"$dxfw_status_file"
+                fi
+            fi
+
+            sleep 1
+        done
+
+        if [ "$dxfw_verified" -eq 0 ]; then
+            printf '%s\n' \
+                "WARN|$dxfw_window_id|${DISPLAY_X11_FULLSCREEN_DETAIL:-geometry-not-verified}" \
+                >"$dxfw_status_file"
+        fi
+    ) &
+
+    DISPLAY_X11_FULLSCREEN_WATCH_PID=$!
+
+    export DISPLAY_X11_FULLSCREEN_WATCH_PID
+    export DISPLAY_X11_FULLSCREEN_STATUS_FILE
+    export DISPLAY_X11_FULLSCREEN_STOP_FILE
+
+    return 0
+}
+
+# display_x11_fullscreen_watch_finish
+# Stop and join the active watcher, parse its status file into exported globals,
+# remove transient snapshot files, and log the final fullscreen result.
+# Returns: 0 for PASS, 1 for WARN, and 2 for SKIP/not applied.
+display_x11_fullscreen_watch_finish() {
+    dxfwf_status_file="${DISPLAY_X11_FULLSCREEN_STATUS_FILE:-}"
+    dxfwf_stop_file="${DISPLAY_X11_FULLSCREEN_STOP_FILE:-}"
+
+    DISPLAY_X11_FULLSCREEN_RESULT="SKIP"
+    DISPLAY_X11_FULLSCREEN_WINDOW_ID=""
+    DISPLAY_X11_FULLSCREEN_DETAIL="watcher-not-started"
+
+    if [ -n "$dxfwf_stop_file" ]; then
+        : >"$dxfwf_stop_file" 2>/dev/null ||
+            true
+    fi
+
+    if [ -n "${DISPLAY_X11_FULLSCREEN_WATCH_PID:-}" ]; then
+        wait \
+            "$DISPLAY_X11_FULLSCREEN_WATCH_PID" \
+            2>/dev/null ||
+            true
+    fi
+
+    if [ -n "$dxfwf_status_file" ] && [ -r "$dxfwf_status_file" ]; then
+        IFS='|' read -r \
+            DISPLAY_X11_FULLSCREEN_RESULT \
+            DISPLAY_X11_FULLSCREEN_WINDOW_ID \
+            DISPLAY_X11_FULLSCREEN_DETAIL \
+            <"$dxfwf_status_file"
+    fi
+
+    if [ -n "$dxfwf_status_file" ]; then
+        rm -f \
+            "$dxfwf_stop_file" \
+            "${dxfwf_status_file}.before-windows" \
+            "${dxfwf_status_file}.before-pids" \
+            "${dxfwf_status_file}.after-windows" \
+            "${dxfwf_status_file}.after-pids" \
+            2>/dev/null ||
+            true
+    elif [ -n "$dxfwf_stop_file" ]; then
+        rm -f "$dxfwf_stop_file" 2>/dev/null || true
+    fi
+
+    DISPLAY_X11_FULLSCREEN_WATCH_PID=""
+    DISPLAY_X11_FULLSCREEN_STOP_FILE=""
+
+    export DISPLAY_X11_FULLSCREEN_RESULT
+    export DISPLAY_X11_FULLSCREEN_WINDOW_ID
+    export DISPLAY_X11_FULLSCREEN_DETAIL
+    export DISPLAY_X11_FULLSCREEN_WATCH_PID
+    export DISPLAY_X11_FULLSCREEN_STOP_FILE
+
+    case "$DISPLAY_X11_FULLSCREEN_RESULT" in
+        PASS)
+            log_info "X11 fullscreen applied: window=$DISPLAY_X11_FULLSCREEN_WINDOW_ID $DISPLAY_X11_FULLSCREEN_DETAIL"
+            return 0
+            ;;
+        WARN)
+            log_warn "X11 fullscreen could not be fully verified: window=$DISPLAY_X11_FULLSCREEN_WINDOW_ID detail=$DISPLAY_X11_FULLSCREEN_DETAIL"
+            return 1
+            ;;
+        *)
+            log_warn "X11 fullscreen was not applied: reason=$DISPLAY_X11_FULLSCREEN_WINDOW_ID detail=$DISPLAY_X11_FULLSCREEN_DETAIL"
+            return 2
+            ;;
+    esac
+}
+
+# display_x11_xvideo_available
+# Probe xvinfo on the adopted X11 display and return success only when at least
+# one XVideo adaptor is reported.
+# Returns: 0 when XVideo is usable; 1 otherwise.
+display_x11_xvideo_available() {
+    command -v xvinfo >/dev/null 2>&1 || return 1
+    display_x11_connection_ok || return 1
+
+    dxxv_out="$(LC_ALL=C xvinfo 2>&1)"
+    dxxv_rc=$?
+
+    [ "$dxxv_rc" -eq 0 ] || return 1
+
+    if printf '%s\n' "$dxxv_out" |
+       grep -Eq 'number of adaptors:[[:space:]]*[1-9][0-9]*|Adaptor #[0-9]+'; then
+        return 0
+    fi
+
+    return 1
+}
+
+# display_get_primary_refresh_hz [auto|x11|wayland|weston]
+# Print the primary display refresh rate using the requested backend. Auto mode
+# prefers a usable Wayland/Weston runtime, then X11, and finally a direct Weston
+# fallback when the helper exists.
+# Returns: 0 when a refresh rate is printed; 1 when no backend can provide one.
+display_get_primary_refresh_hz() {
+    dgpr_backend="${1:-auto}"
+
+    case "$dgpr_backend" in
+        x11)
+            display_x11_get_primary_refresh_hz
+            return $?
+            ;;
+        wayland|weston)
+            if command -v weston_get_primary_refresh_hz >/dev/null 2>&1; then
+                weston_get_primary_refresh_hz
+                return $?
+            fi
+            return 1
+            ;;
+        auto)
+            if command -v egli_wayland_socket_ok >/dev/null 2>&1 &&
+               egli_wayland_socket_ok >/dev/null 2>&1 &&
+               command -v weston_get_primary_refresh_hz >/dev/null 2>&1; then
+                if weston_get_primary_refresh_hz; then
+                    return 0
+                fi
+            fi
+
+            if display_x11_connection_ok >/dev/null 2>&1 &&
+               command -v xrandr >/dev/null 2>&1; then
+                if display_x11_get_primary_refresh_hz; then
+                    return 0
+                fi
+            fi
+
+            if command -v weston_get_primary_refresh_hz >/dev/null 2>&1; then
+                weston_get_primary_refresh_hz
+                return $?
+            fi
+            ;;
+        *)
+            log_warn "Unsupported display refresh backend: $dgpr_backend"
+            ;;
+    esac
+
+    return 1
 }
 


### PR DESCRIPTION
- Add modular X11 graphics validation coverage for Debian and other apt-based X11 environments.
- This change introduces dedicated tests for X11 display discovery, GLX, EGL/OpenGL ES, Glmark2, and GStreamer display pipelines. It also extends the shared display library with reusable X11 runtime, output, rendering, and fullscreen helpers.
- The implementation dynamically discovers the active X11 environment instead of assuming a fixed display number, Xauthority path, user ID, output name, resolution, or refresh rate.