### PR TITLE
fix: scope pages and id-token permissions to deploy job only

### DIFF
--- a/.github/workflows/test-inventory-pages.yml
+++ b/.github/workflows/test-inventory-pages.yml
@@ -14,8 +14,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -61,6 +59,8 @@ jobs:
           path: _site
 
   deploy:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The test-inventory-pages.yml workflow granted pages: write and id-token: write at the workflow level, causing both the build and deploy jobs to inherit these elevated permissions. The build job only generates HTML and uploads an artifact, so it does not need either permission.

Scope pages: write and id-token: write exclusively to the deploy job that requires them, and reduce the workflow-level permissions to contents: read only.

This resolves the excessive-permissions findings reported by the zizmor GitHub Actions security scan.