### PR TITLE
fix: prevent template injection in zstd archive workflow

### DIFF
--- a/.github/workflows/zstd.yml
+++ b/.github/workflows/zstd.yml
@@ -31,11 +31,13 @@ jobs:
           echo "tag_name=$TAG" >> $GITHUB_OUTPUT
 
       - name: Create .tar.zst archive
+        env:
+          TAG_NAME: ${{ steps.version.outputs.tag_name }}  # ✅ safe: env var, not inline expansion
         run: |
           git archive --format=tar \
             --prefix=qcom-linux-testkit/ \
-            "${{ steps.version.outputs.tag_name }}" \
-          | zstd -o "${GITHUB_WORKSPACE}/${{ steps.version.outputs.tag_name }}.tar.zst"
+            "$TAG_NAME" \
+            | zstd -o "${GITHUB_WORKSPACE}/${TAG_NAME}.tar.zst"
 
       - name: Create GitHub Release
         id: create_release


### PR DESCRIPTION
The Create .tar.zst archive step in zstd.yml used
${{ steps.version.outputs.tag_name }} directly inside a run: shell block. This allows template injection since the value is derived from GITHUB_REF which is attacker-controllable via a crafted git tag.

Pass the value through an env: variable instead and reference it as $TAG_NAME in the shell script to prevent direct template expansion into the run context.

This resolves the template-injection findings reported by the zizmor GitHub Actions security scan.