### PR TITLE
Add distro package support for Sensors validation

### DIFF
--- a/Runner/config/pkg_command_map.conf
+++ b/Runner/config/pkg_command_map.conf
@@ -245,3 +245,45 @@ apt:pw-record=pipewire-bin
 apt:pactl=pulseaudio-utils
 apt:paplay=pulseaudio-utils
 apt:parecord=pulseaudio-utils
+
+# ---------------------------------------------------------------------------
+# Qualcomm Sensors runtime and test packages.
+#
+# Important:
+# - Never use wildcard package names.
+# - Never install dbgsym packages.
+# - The six qcom-sensors-*-dev packages are temporarily required because
+#   ssc_sensor_info fails to load its sensor libraries without the unversioned
+#   library links currently shipped by those development packages.
+# - qcom-sensing-hub-dev remains required for the sensing-hub development
+#   library links.
+# - libqcsi1 is a required runtime library.
+# ---------------------------------------------------------------------------
+
+debian:package-set:sensors=qcom-sensing-hub qcom-sensing-hub-dev libqcsi1 qcom-sensors-api qcom-sensors-api-dev qcom-sensors-core qcom-sensors-core-dev qcom-sensors-registry qcom-sensors-registry-dev qcom-sensors-services qcom-sensors-services-dev qcom-sensors-test-core qcom-sensors-test-core-dev qcom-sensors-test-apps qcom-sensors-test-apps-dev
+
+ubuntu:package-set:sensors=qcom-sensing-hub qcom-sensing-hub-dev libqcsi1 qcom-sensors-api qcom-sensors-api-dev qcom-sensors-core qcom-sensors-core-dev qcom-sensors-registry qcom-sensors-registry-dev qcom-sensors-services qcom-sensors-services-dev qcom-sensors-test-core qcom-sensors-test-core-dev qcom-sensors-test-apps qcom-sensors-test-apps-dev
+
+# Keep CentOS limited to confirmed RPM package names.
+# Debian -dev names must not be copied to RPM systems. Add RPM -devel packages
+# only after confirming their exact names in the enabled CentOS repository.
+centos:package-set:sensors=qcom-sensing-hub qcom-sensors-api qcom-sensors-core qcom-sensors-registry qcom-sensors-services qcom-sensors-test-core qcom-sensors-test-apps
+
+# ---------------------------------------------------------------------------
+# Sensors command recovery.
+#
+# ssc_sensor_info currently requires the runtime packages plus all confirmed
+# development packages that provide its load-time library links.
+# ---------------------------------------------------------------------------
+
+debian:Sensors:ssc_sensor_info=qcom-sensing-hub qcom-sensing-hub-dev libqcsi1 qcom-sensors-api qcom-sensors-api-dev qcom-sensors-core qcom-sensors-core-dev qcom-sensors-registry qcom-sensors-registry-dev qcom-sensors-services qcom-sensors-services-dev qcom-sensors-test-core qcom-sensors-test-core-dev qcom-sensors-test-apps qcom-sensors-test-apps-dev
+debian:Sensors:see_workhorse=qcom-sensors-test-core qcom-sensors-test-apps
+debian:Sensors:ssc_drva_test=qcom-sensors-test-core qcom-sensors-test-apps
+
+ubuntu:Sensors:ssc_sensor_info=qcom-sensing-hub qcom-sensing-hub-dev libqcsi1 qcom-sensors-api qcom-sensors-api-dev qcom-sensors-core qcom-sensors-core-dev qcom-sensors-registry qcom-sensors-registry-dev qcom-sensors-services qcom-sensors-services-dev qcom-sensors-test-core qcom-sensors-test-core-dev qcom-sensors-test-apps qcom-sensors-test-apps-dev
+ubuntu:Sensors:see_workhorse=qcom-sensors-test-core qcom-sensors-test-apps
+ubuntu:Sensors:ssc_drva_test=qcom-sensors-test-core qcom-sensors-test-apps
+
+centos:Sensors:ssc_sensor_info=qcom-sensing-hub
+centos:Sensors:see_workhorse=qcom-sensors-test-core qcom-sensors-test-apps
+centos:Sensors:ssc_drva_test=qcom-sensors-test-core qcom-sensors-test-apps

--- a/Runner/suites/Multimedia/Sensors/run.sh
+++ b/Runner/suites/Multimedia/Sensors/run.sh
@@ -17,6 +17,11 @@ usage() {
   cat <<EOF
 Usage: $0 [options]
 
+Package handling:
+  --overlay Install the Qualcomm Sensors runtime/test package set from
+            qli-staging on Debian, Ubuntu, or CentOS.
+            No package removal or base-mode transition is performed.
+
 Discovery:
   --list List discovered sensor TYPEs (from ssc_sensor_info) and exit 0
   --sensors <csv> Comma-separated list of sensor TYPEs to test
@@ -39,24 +44,27 @@ Other:
   --help Show this help
 
 Examples:
-  $0 --list
-  $0 --profile basic
+  $0 --overlay --list
+  $0 --overlay --profile basic
   $0 --profile vision
   $0 --sensors accel,gyro,tilt --strict 0
   $0 --profile all --strict 0
 
 Environment overrides:
   OUT_DIR, SEE_DURATION, DRVA_DURATION, HB_SECS, STRICT_REQUIRED,
-  SENSORS_TIMEOUT_PAD_SECS, SENSORS_DISPLAY_EVENTS, SENSORS_DRVA_NUM_SAMPLES
+  SENSORS_TIMEOUT_PAD_SECS, SENSORS_DISPLAY_EVENTS, SENSORS_DRVA_NUM_SAMPLES,
+  SENSORS_SERVICE
 EOF
 }
 
 SENSORS_CSV=""
 PROFILE="auto"
 LIST_ONLY=0
+OVERLAY_REQUESTED=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
+    --overlay) OVERLAY_REQUESTED=1; shift 1 ;;
     --out) OUT_DIR="$2"; shift 2 ;;
     --see-duration) SEE_DURATION="$2"; shift 2 ;;
     --drva-duration) DRVA_DURATION="$2"; shift 2 ;;
@@ -97,6 +105,11 @@ fi
 # shellcheck disable=SC1090,SC1091
 . "$TOOLS/lib_sensors.sh"
 
+if [ -r "$TOOLS/lib_pkg_provider.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$TOOLS/lib_pkg_provider.sh"
+fi
+
 # Resolve test path and cd (single SKIP/exit path)
 SKIP_REASON=""
 test_path=$(find_test_case_by_name "$TESTNAME")
@@ -119,9 +132,32 @@ SEE_DURATION="${SEE_DURATION:-5}"
 DRVA_DURATION="${DRVA_DURATION:-10}"
 HB_SECS="${HB_SECS:-5}"
 STRICT_REQUIRED="${STRICT_REQUIRED:-1}"
+SENSORS_SERVICE="${SENSORS_SERVICE:-sscrpcd.service}"
 : "${SENSORS_DRVA_NUM_SAMPLES:=325}"
 
 mkdir -p "$OUT_DIR" 2>/dev/null || true
+
+OS_ID="unknown"
+DISTRO_SENSORS_HANDLING_SUPPORTED=0
+
+if command -v pkg_detect_os_id >/dev/null 2>&1; then
+  OS_ID="$(pkg_detect_os_id 2>/dev/null || true)"
+elif [ -r /etc/os-release ]; then
+  OS_ID="$(
+    sed -n 's/^ID=//p' /etc/os-release |
+      head -n 1 |
+      tr -d '"' |
+      tr '[:upper:]' '[:lower:]'
+  )"
+fi
+
+[ -n "$OS_ID" ] || OS_ID="unknown"
+
+case "$OS_ID" in
+  debian|ubuntu|centos)
+    DISTRO_SENSORS_HANDLING_SUPPORTED=1
+    ;;
+esac
 
 # ---- clock sanity (fix 1970 timestamps) ----
 # If system time is too old, many logs become confusing. We don't FAIL for this.
@@ -132,8 +168,69 @@ if [ "$now_epoch" -lt 1640995200 ] 2>/dev/null; then
 fi
 
 log_info "------------------- Starting $TESTNAME testcase -------------------"
+log_info "OS_ID=$OS_ID OVERLAY_REQUESTED=$OVERLAY_REQUESTED"
 log_info "OUT_DIR=$OUT_DIR SEE_DURATION=$SEE_DURATION DRVA_DURATION=$DRVA_DURATION HB_SECS=$HB_SECS STRICT_REQUIRED=$STRICT_REQUIRED PROFILE=$PROFILE"
 [ -n "$SENSORS_CSV" ] && log_info "Requested sensors (override): $SENSORS_CSV"
+
+# Install only the explicitly mapped Qualcomm Sensors runtime/test packages.
+# No wildcard, development, debug-symbol, package-removal, or base-transition
+# operation is permitted here.
+if [ "$OVERLAY_REQUESTED" -eq 1 ]; then
+  if [ "$DISTRO_SENSORS_HANDLING_SUPPORTED" -eq 1 ]; then
+    for required_helper in \
+      pkg_provider_init \
+      pkg_ensure_optional_package_set_present \
+      pkg_verify_package_set_installed; do
+      if ! command -v "$required_helper" >/dev/null 2>&1; then
+        log_fail "$TESTNAME FAIL - required package helper is unavailable: $required_helper"
+        echo "$TESTNAME FAIL" >"$RES_FILE"
+        exit 0
+      fi
+    done
+
+    pkg_provider_init
+
+    old_package_set_upgrade="${PKG_PACKAGE_SET_UPGRADE-__unset__}"
+    PKG_PACKAGE_SET_UPGRADE=0
+    export PKG_PACKAGE_SET_UPGRADE
+
+    if ! pkg_ensure_optional_package_set_present \
+      sensors \
+      qli-staging \
+      auto \
+      --overlay; then
+      case "$old_package_set_upgrade" in
+        __unset__)
+          unset PKG_PACKAGE_SET_UPGRADE
+          ;;
+        *)
+          PKG_PACKAGE_SET_UPGRADE="$old_package_set_upgrade"
+          export PKG_PACKAGE_SET_UPGRADE
+          ;;
+      esac
+
+      log_fail "$TESTNAME FAIL - failed to ensure Qualcomm Sensors package set"
+      echo "$TESTNAME FAIL" >"$RES_FILE"
+      exit 0
+    fi
+
+    case "$old_package_set_upgrade" in
+      __unset__)
+        unset PKG_PACKAGE_SET_UPGRADE
+        ;;
+      *)
+        PKG_PACKAGE_SET_UPGRADE="$old_package_set_upgrade"
+        export PKG_PACKAGE_SET_UPGRADE
+        ;;
+    esac
+
+    log_pass "Qualcomm Sensors runtime/test package set is ready"
+  else
+    log_info "Package installation skipped for os=$OS_ID; using image-provided Sensors runtime"
+  fi
+else
+  log_info "Overlay package installation not requested; validating installed Sensors runtime"
+fi
 
 deps="ssc_sensor_info see_workhorse awk sed grep sort wc tr"
 if ! check_dependencies "$deps"; then
@@ -146,6 +243,28 @@ if [ ! -d /etc/sensors/config ]; then
   log_skip "$TESTNAME SKIP - /etc/sensors/config not present (likely non-prop build)"
   echo "$TESTNAME SKIP" >"$RES_FILE"
   exit 0
+fi
+
+# The qcom-sensors-services package installs sscrpcd.service. On supported
+# desktop distributions, ensure an already-installed unit is running.
+if [ "$DISTRO_SENSORS_HANDLING_SUPPORTED" -eq 1 ] &&
+   command -v systemctl >/dev/null 2>&1; then
+  if systemctl cat "$SENSORS_SERVICE" >/dev/null 2>&1; then
+    if ! systemctl is-active --quiet "$SENSORS_SERVICE"; then
+      log_info "Starting Sensors service, $SENSORS_SERVICE"
+
+      if ! systemctl start "$SENSORS_SERVICE"; then
+        log_fail "$TESTNAME FAIL - failed to start $SENSORS_SERVICE"
+        systemctl status "$SENSORS_SERVICE" --no-pager --full 2>/dev/null || true
+        echo "$TESTNAME FAIL" >"$RES_FILE"
+        exit 0
+      fi
+    fi
+
+    log_pass "Sensors service is active, $SENSORS_SERVICE"
+  else
+    log_warn "Sensors service unit is not installed: $SENSORS_SERVICE"
+  fi
 fi
 
 # ADSP remoteproc gating
@@ -338,3 +457,4 @@ else
 fi
 
 exit 0
+

--- a/Runner/suites/Multimedia/Sensors/sensors.yaml
+++ b/Runner/suites/Multimedia/Sensors/sensors.yaml
@@ -1,16 +1,20 @@
 metadata:
   name: Sensors
   format: "Lava-Test Test Definition 1.0"
-  description: "Dynamic Sensors validation (DT-free): auto-detect sensors via ssc_sensor_info and validate using see_workhorse/ssc_drva_test."
+  description: "Dynamic Sensors validation with optional Qualcomm Sensors overlay package recovery."
   os:
     - linux
   scope:
     - functional
     - multimedia
 
+params:
+  OVERLAY: "0"
+
 run:
   steps:
     - REPO_PATH=$PWD
     - cd Runner/suites/Multimedia/Sensors
-    - ./run.sh || true
+    - if [ "${OVERLAY}" = "1" ]; then ./run.sh --overlay || true; else ./run.sh || true; fi
     - $REPO_PATH/Runner/utils/send-to-lava.sh Sensors.res || true
+


### PR DESCRIPTION
Extend the Sensors testcase to support dependency discovery and package recovery on distro-based Linux images.

The testcase previously depended on the required Qualcomm sensor utilities already being present in the target image. This change adds package-provider mappings and updates the runner so the required sensor packages can be resolved consistently on supported distributions.