### PR TITLE
audio: enable Ubuntu package preparation

### DIFF
--- a/Runner/config/pkg_command_map.conf
+++ b/Runner/config/pkg_command_map.conf
@@ -216,35 +216,91 @@ ubuntu:package-set:graphics=kgsl-dkms adreno-common adreno-gles1 adreno-gles2 ad
 # ---------------------------------------------------------------------------
 # Audio validation package recovery.
 #
-# Debian Audio tests use the upstream base Audio stack by default.
+# Debian and Ubuntu Audio tests use their distro-provided base Audio stack.
+#
 # Qualcomm AudioReach packages are installed only when --overlay is explicitly
 # requested.
 #
+# Ubuntu uses the apt sources already configured by the distro image. Audio
+# package preparation must not add, replace, or rewrite Ubuntu apt sources.
+#
 # No rpm, opkg, qcom-distro, or generic provider package-set mapping is
-# provided. Yocto and other embedded images therefore continue using their
-# image-provided Audio stack without package recovery.
+# provided. Yocto and other embedded images continue using their image-provided
+# Audio stack without package recovery.
 # ---------------------------------------------------------------------------
  
-# Base Debian Audio stack.
-debian:package-set:audio-base=alsa-utils pipewire-bin wireplumber pulseaudio-utils
+# ---------------------------------------------------------------------------
+# Debian base Audio stack.
+# ---------------------------------------------------------------------------
  
+debian:package-set:audio-base=alsa-utils pipewire-bin wireplumber pulseaudio-utils curl wget ca-certificates tar gzip
+ 
+# ---------------------------------------------------------------------------
+# Ubuntu base Audio stack.
+#
+# pipewire:
+#   PipeWire daemon and service files.
+#
+# pipewire-bin:
+#   pw-play, pw-record, pw-cli and other PipeWire command-line tools.
+#
+# pipewire-audio:
+#   Recommended Ubuntu PipeWire audio integration, including ALSA and
+#   PulseAudio compatibility components.
+#
+# wireplumber:
+#   PipeWire session and policy manager providing wpctl.
+#
+# pulseaudio-utils:
+#   pactl, paplay and parecord compatibility commands.
+#
+# curl, wget, ca-certificates, tar and gzip:
+#   Required by AudioPlayback to download and extract AudioClips.tar.gz.
+# ---------------------------------------------------------------------------
+ 
+ubuntu:package-set:audio-base=alsa-utils alsa-ucm-conf curl ca-certificates tar gzip
+ 
+# ---------------------------------------------------------------------------
 # Debian Qualcomm AudioReach overlay stack.
 #
-# This package set is complete by itself because overlay mode checks only
-# "audio"; it does not check "audio-base" first.
-debian:package-set:audio=alsa-utils pipewire-bin wireplumber pulseaudio-utils audioreach-pipewire-plugin audioreach-kernel-dkms audioreach-config
+# The overlay package set must be complete by itself because --overlay checks
+# the "audio" package set directly; it does not install "audio-base" first.
+# ---------------------------------------------------------------------------
  
+debian:package-set:audio=alsa-utils pipewire-bin wireplumber pulseaudio-utils curl ca-certificates tar gzip audioreach-pipewire-plugin audioreach-kernel-dkms audioreach-config
+ 
+# ---------------------------------------------------------------------------
+# Ubuntu Qualcomm AudioReach overlay stack.
+#
+# Ubuntu uses the existing distro-configured apt sources. Do not configure a
+# Debian, qli, or qli-staging source from the Audio test.
+#
+# This package set includes the complete Ubuntu base Audio stack because
+# --overlay checks only the "audio" package set.
+# ---------------------------------------------------------------------------
+ 
+ubuntu:package-set:audio=alsa-utils pipewire pipewire-bin pipewire-audio wireplumber pulseaudio-utils curl wget ca-certificates tar gzip audioreach-pipewire-plugin audioreach-kernel-dkms audioreach-config
+ 
+# ---------------------------------------------------------------------------
 # Command recovery used by check_dependencies()/pkg_ensure_command().
+#
+# These apt-provider mappings apply to Debian and Ubuntu.
+# ---------------------------------------------------------------------------
+ 
 apt:aplay=alsa-utils
 apt:arecord=alsa-utils
 apt:amixer=alsa-utils
 apt:alsaucm=alsa-utils
 apt:wpctl=wireplumber
+apt:pipewire=pipewire
 apt:pw-play=pipewire-bin
 apt:pw-record=pipewire-bin
 apt:pactl=pulseaudio-utils
 apt:paplay=pulseaudio-utils
 apt:parecord=pulseaudio-utils
+apt:curl=curl
+apt:wget=wget
+apt:tar=tar
 
 # ---------------------------------------------------------------------------
 # Qualcomm Sensors runtime and test packages.

--- a/Runner/utils/audio_common.sh
+++ b/Runner/utils/audio_common.sh
@@ -4204,8 +4204,10 @@ audio_prepare_test_packages() {
       ;;
   esac
  
-  # Resolve the operating-system ID without making the package-provider
-  # library mandatory on native embedded images.
+  ###########################################################################
+  # Platform detection
+  ###########################################################################
+ 
   if command -v pkg_detect_os_id >/dev/null 2>&1; then
     atp_os_id="$(
       pkg_detect_os_id 2>/dev/null ||
@@ -4227,7 +4229,7 @@ audio_prepare_test_packages() {
       log_info "Native image detected; Audio package preparation is not required"
       return 0
       ;;
-    debian)
+    debian|ubuntu)
       ;;
     *)
       log_info "Audio package preparation is not enabled for os=$atp_os_id"
@@ -4235,15 +4237,47 @@ audio_prepare_test_packages() {
       ;;
   esac
  
-  # Debian package preparation must run before the test is re-executed as the
-  # unprivileged Audio user.
+  ###########################################################################
+  # Root requirement
+  ###########################################################################
+ 
   if [ "$(id -u 2>/dev/null || echo 1)" -ne 0 ]; then
-    log_fail "Debian Audio package preparation must run as root"
+    log_fail "Audio package preparation must run as root for os=$atp_os_id"
     return 1
   fi
  
   ###########################################################################
-  # Debian base mode
+  # Ubuntu package preparation
+  ###########################################################################
+ 
+  if [ "$atp_os_id" = "ubuntu" ]; then
+    if [ "$atp_overlay_requested" -eq 1 ]; then
+      log_fail "Ubuntu AudioReach overlay support is still in progress"
+      log_info "Use the Ubuntu native ALSA/UCM path without --overlay"
+      log_info "No AudioReach packages were installed"
+      log_info "No Ubuntu apt source files were added or modified"
+      return 1
+    fi
+ 
+    if ! command -v pkg_ensure_required_package_set_present \
+        >/dev/null 2>&1; then
+      log_fail "Required package-set helper is unavailable"
+      return 1
+    fi
+ 
+    log_info "Preparing native Ubuntu ALSA/UCM Audio packages"
+ 
+    if ! pkg_ensure_required_package_set_present audio-base; then
+      log_fail "Failed to ensure Ubuntu native Audio package set"
+      return 1
+    fi
+ 
+    log_pass "Ubuntu native ALSA/UCM Audio package set is ready"
+    return 0
+  fi
+ 
+  ###########################################################################
+  # Debian base package preparation
   ###########################################################################
  
   if [ "$atp_overlay_requested" -eq 0 ]; then
@@ -4252,6 +4286,8 @@ audio_prepare_test_packages() {
       log_fail "Required package-set helper is unavailable"
       return 1
     fi
+ 
+    log_info "Preparing Debian base Audio packages"
  
     if ! pkg_ensure_required_package_set_present audio-base; then
       log_fail "Failed to ensure Debian base Audio package set"
@@ -4263,7 +4299,7 @@ audio_prepare_test_packages() {
   fi
  
   ###########################################################################
-  # Debian AudioReach overlay mode
+  # Debian Qualcomm AudioReach overlay package preparation
   ###########################################################################
  
   if ! command -v pkg_ensure_optional_package_set_present \
@@ -4278,9 +4314,12 @@ audio_prepare_test_packages() {
     return 1
   fi
  
-  # Capture AudioReach package versions before package preparation. These
-  # values let us distinguish an already-ready target from an install or
-  # upgrade performed during this invocation.
+  log_info "Preparing Debian Qualcomm AudioReach overlay packages"
+ 
+  ###########################################################################
+  # Capture AudioReach package state before preparation
+  ###########################################################################
+ 
   atp_before_plugin="$(
     pkg_installed_package_version \
       audioreach-pipewire-plugin 2>/dev/null ||
@@ -4299,18 +4338,25 @@ audio_prepare_test_packages() {
       true
   )"
  
-  # The optional package provider intentionally requires the literal
-  # --overlay argument. Passing only the internal value "1" makes the provider
-  # treat the request as base mode.
+  ###########################################################################
+  # Ensure the Debian AudioReach package set
+  ###########################################################################
+ 
+  # The optional package provider determines overlay mode from the arguments.
+  # Keep --overlay last so it cannot be overridden by an earlier base option.
   if ! pkg_ensure_optional_package_set_present \
       audio \
       qli-staging \
       auto \
-      --overlay \
-      "$@"; then
+      "$@" \
+      --overlay; then
     log_fail "Failed to ensure Debian AudioReach package set"
     return 1
   fi
+ 
+  ###########################################################################
+  # Capture AudioReach package state after preparation
+  ###########################################################################
  
   atp_after_plugin="$(
     pkg_installed_package_version \
@@ -4329,6 +4375,10 @@ audio_prepare_test_packages() {
       audioreach-config 2>/dev/null ||
       true
   )"
+ 
+  ###########################################################################
+  # Detect AudioReach package changes
+  ###########################################################################
  
   if [ "$atp_before_plugin" != "$atp_after_plugin" ] ||
      [ "$atp_before_dkms" != "$atp_after_dkms" ] ||
@@ -4353,8 +4403,10 @@ audio_prepare_test_packages() {
     log_info "AudioReach packages were already installed; runtime package state is unchanged"
   fi
  
-  # Do not continue into Audio testing after installing or upgrading the DKMS
-  # package. The active kernel must boot with the newly prepared module.
+  ###########################################################################
+  # Debian AudioReach DKMS reboot requirement
+  ###########################################################################
+ 
   if [ "$atp_before_dkms" != "$atp_after_dkms" ]; then
     AUDIO_OVERLAY_REBOOT_REQUIRED=1
     export AUDIO_OVERLAY_REBOOT_REQUIRED
@@ -4363,9 +4415,11 @@ audio_prepare_test_packages() {
     log_warn "A reboot is required before running AudioReach validation"
     return 2
   fi
-  
-  # Refresh module metadata when package state changed, then install and
-  # activate the repository-owned AudioReach udev rule.
+ 
+  ###########################################################################
+  # Refresh Debian AudioReach device policy
+  ###########################################################################
+ 
   if ! command -v audio_refresh_overlay_devices \
       >/dev/null 2>&1; then
     log_fail "AudioReach device-refresh helper is unavailable"
@@ -4375,7 +4429,7 @@ audio_prepare_test_packages() {
   if ! audio_refresh_overlay_devices \
       "$atp_overlay_requested" \
       "$AUDIO_OVERLAY_PACKAGES_CHANGED"; then
-    log_fail "Failed to refresh AudioReach devices"
+    log_fail "Failed to refresh Debian AudioReach devices"
     return 1
   fi
  


### PR DESCRIPTION
## Why
 
Audio package preparation was enabled only for Debian, causing Ubuntu Audio tests to skip dependency recovery even when required playback, recording, or download tools were missing.
 
Ubuntu already provides the required packages through its existing apt sources, so the test should use those sources directly without adding or rewriting repository configuration.